### PR TITLE
:bug: use a ref copy instead to avoid listener traverse disordered while splicing

### DIFF
--- a/src/hijackers/timer.ts
+++ b/src/hijackers/timer.ts
@@ -8,8 +8,8 @@ import { sleep } from '../utils';
 
 export default function hijack() {
 
-  const rawWindowInterval = window.setInterval.bind(window);
-  const rawWindowTimeout = window.setTimeout.bind(window);
+  const rawWindowInterval = window.setInterval;
+  const rawWindowTimeout = window.setTimeout;
   const timerIds: number[] = [];
   const intervalIds: number[] = [];
 

--- a/src/hijackers/windowListener.ts
+++ b/src/hijackers/windowListener.ts
@@ -29,9 +29,9 @@ export default function hijack() {
 
   return function free() {
 
-    listenerMap.forEach((listeners, type) => listeners.forEach(listener => window.removeEventListener(type, listener)));
-    window.addEventListener = rawAddEventListener.bind(window);
-    window.removeEventListener = rawRemoveEventListener.bind(window);
+    listenerMap.forEach((listeners, type) => [...listeners].forEach(listener => window.removeEventListener(type, listener)));
+    window.addEventListener = rawAddEventListener;
+    window.removeEventListener = rawRemoveEventListener;
 
     return noop;
   };


### PR DESCRIPTION
splice the same reference would cause the listener traverse disordered, see 
https://github.com/umijs/qiankun/blob/9bdb48ab6b5867579c8d2a474e2a3b6a7c451562/src/hijackers/windowListener.ts#L25

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/qiankun/76)
<!-- Reviewable:end -->
