### PR TITLE
:bug: make sure the sub app execute after framework started

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ class Deferred<T> {
  */
 let singularMode: StartOpts['singular'] = false;
 let useJsSandbox = false;
+const frameworkStartedDefer = new Deferred<void>();
 
 export function registerMicroApps<T extends object = {}>(
   apps: Array<RegistrableApp<T>>,
@@ -94,6 +95,8 @@ export function registerMicroApps<T extends object = {}>(
       name,
 
       async ({ name: appName }) => {
+        await frameworkStartedDefer.promise;
+
         // 获取入口 html 模板及脚本加载器
         const { template: appContent, execScripts } = await importEntry(entry, { fetch });
         // as single-spa load and bootstrap new app parallel with other apps unmounting
@@ -188,4 +191,6 @@ export function start(opts: StartOpts = {}) {
   }
 
   startSpa();
+
+  frameworkStartedDefer.resolve();
 }


### PR DESCRIPTION
1. 保证子应用脚本执行在 qiankun 框架启动之后
2. 移除 registerMicroApps 里的 fetch 配置

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/qiankun/113)
<!-- Reviewable:end -->
