### PR TITLE
feat: add runtime css transformer

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -133,16 +133,35 @@ By linking the micro-application to some url rules, the function of automaticall
 
       If configured as `function`, the timing of all subapplication static resources will be controlled by yourself.
 
-    - sandbox - `boolean` | `{ strictStyleIsolation?: boolean }` - optional, whether to open the js sandbox, default is `true`.
-      
+    - sandbox - `boolean` | `{ strictStyleIsolation?: boolean, experimentalStyleIsolation?: boolean }` - optional, whether to open the js sandbox, default is `true`.
+
       When configured as `{strictStyleIsolation: true}`, qiankun will convert the container dom of each application to a [shadow dom](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM), to ensure that the style of the application will not leak to the global.
+
+      And qiankun offered an experimental way to support css isolation, when experimentalStyleIsolation is set to true, qiankun will limit their scope of influence by add selector constraint, thereforce styles of sub-app will like following case:
+
+      ```
+      // if app name is react16
+      .app-main {
+        font-size: 14px;
+      }
+
+      div[data-qiankun-react16] .app-main {
+        font-size: 14px;
+      }
+      ```
+
+      notice:
+      @keyframes, @font-face, @import, @page are not supported (i.e. will not be rewritten)
+
+      and in current stage, we're not support the case: add external styles by `<link>` yet, we're consider add this part in the future.
+
 
     - singular - `boolean | ((app: RegistrableApp<any>) => Promise<boolean>);` - optional，whether is a singular mode，default is `true`.
 
     - fetch - `Function` - optional
-    
+
     - getPublicPath - `(url: string) => string` - optional
-    
+
     - getTemplate - `(tpl: string) => string` - optional
 
 - Usage
@@ -247,7 +266,7 @@ A criterion for judging whether the business is closely related: <strong>Look at
   * bootstrapPromise: Promise&lt;null&gt;;
   * mountPromise: Promise&lt;null&gt;;
   * unmountPromise: Promise&lt;null&gt;;
-  
+
 * Usage
 
   Load a micro application manually.
@@ -258,7 +277,7 @@ A criterion for judging whether the business is closely related: <strong>Look at
   export function mount(props) {
     renderApp(props);
   }
-  
+
   // Added update hook to allow the main application to manually update the micro application
   export function update(props) {
     renderPatch(props);
@@ -270,26 +289,26 @@ A criterion for judging whether the business is closely related: <strong>Look at
   ```jsx
   import { loadMicroApp } from 'qiankun';
   import React from 'react';
-  
+
   class App extends React.Component {
-    
+
     containerRef = React.createRef();
     microApp = null;
-    
+
     componentDidMount() {
       this.microApp = loadMicroApp(
         { name: 'app1', entry: '//localhost:1234', container: this.containerRef.current, props: { name: 'qiankun' } },
       );
     }
-  
+
     componentWillUnmount() {
       this.microApp.unmount();
     }
-  
+
     componentDidUpdate() {
       this.microApp.update({ name: 'kuitos' });
     }
-    
+
     render() {
       return <div ref={this.containerRef}></div>;
     }
@@ -301,21 +320,21 @@ A criterion for judging whether the business is closely related: <strong>Look at
 - Parameters
   - apps - `AppMetadata[]` - Required - list of preloaded apps
   - importEntryOpts - Optional - Load configuration
-  
+
 - Type
   - `AppMetadata`
     - name - `string` - Required - Application name
     - entry - `string | { scripts?: string[]; styles?: string[]; html?: string }` - Required,The entry address of the microapp
 
 - Usage
-  
+
   Manually preload the specified micro application static resources. Only needed to manually load micro-application scenarios, you can directly configure the `prefetch` attribute based on the route automatic activation scenario.
-  
+
 - Sample
 
   ```ts
   import { prefetchApps } from 'qiankun';
-  
+
   prefetchApps([ { name: 'app1', entry: '//locahost:7001' }, { name: 'app2', entry: '//locahost:7002' } ])
   ```
 
@@ -335,7 +354,7 @@ A criterion for judging whether the business is closely related: <strong>Look at
 
   ```ts
   import { addGlobalUncaughtErrorHandler } from 'qiankun';
-  
+
   addGlobalUncaughtErrorHandler(event => console.log(event));
   ```
 
@@ -353,7 +372,7 @@ A criterion for judging whether the business is closely related: <strong>Look at
 
   ```ts
   import { removeGlobalUncaughtErrorHandler } from 'qiankun';
-  
+
   removeGlobalUncaughtErrorHandler(handler);
   ```
 
@@ -407,7 +426,7 @@ A criterion for judging whether the business is closely related: <strong>Look at
 
     // It will trigger when slave umount,  not necessary to use in non special cases.
     props.offGlobalStateChange();
-    
+
     // ...
   }
   ```

--- a/docs/api/README.zh.md
+++ b/docs/api/README.zh.md
@@ -18,7 +18,7 @@ toc: menu
 
   - apps - `Array<RegistrableApp>` - 必选，微应用的一些注册信息
   - lifeCycles - `LifeCycles` - 可选，全局的微应用生命周期钩子
-  
+
 - 类型
 
   - `RegistrableApp`
@@ -192,7 +192,7 @@ toc: menu
 
   runAfterFirstMounted(() => startMonitor());
   ```
-  
+
 ## 手动加载微应用
 
 适用于需要手动 加载/卸载 一个微应用的场景。
@@ -211,25 +211,43 @@ toc: menu
     * entry - `string | { scripts?: string[]; styles?: string[]; html?: string }` - 必选，微应用的 entry 地址。
     * container - `string | HTMLElement` - 必选，微应用的容器节点的选择器或者 Element 实例。如`container: '#root'` 或 `container: document.querySelector('#root')`。
     * props - `object` - 可选，初始化时需要传递给微应用的数据。
-    
+
   * configuration - `Configuration` - 可选，微应用的配置信息
 
-    * sandbox - `boolean` | `{ strictStyleIsolation?: boolean }` - 可选，是否开启沙箱，默认为 `true`。
+    * sandbox - `boolean` | `{ strictStyleIsolation?: boolean, experimentalStyleIsolation?: boolean }` - 可选，是否开启沙箱，默认为 `true`。
 
       默认情况下沙箱可以确保单实例场景子应用之间的样式隔离，但是无法确保主应用跟子应用、或者多实例场景的子应用样式隔离。当配置为 `{ strictStyleIsolation: true }` 时表示开启严格的样式隔离模式。这种模式下 qiankun 会为每个微应用的容器包裹上一个 [shadow dom](https://developer.mozilla.org/zh-CN/docs/Web/Web_Components/Using_shadow_DOM) 节点，从而确保微应用的样式不会对全局造成影响。
+
+      除此以外，qiankun 还提供了一个实验性的样式隔离特性，当 experimentalStyleIsolation 被设置为 true 时，qiankun 会改写子应用所添加的样式为所有样式规则增加一个特殊的选择器规则来限定其影响范围，因此改写后的代码会表达类似为如下结构：
+
+      ```
+      // 假设加载的应用名为 react16
+      .app-main {
+        font-size: 14px;
+      }
+
+      div[data-qiankun-react16] .app-main {
+        font-size: 14px;
+      }
+      ```
+
+      注意事项:
+      目前 @keyframes, @font-face, @import, @page 等规则不会支持 (i.e. 不会被改写)
+
+      在目前阶段, 我们还不支持以动态的外联形式 (`<link />`) 形式加入的样式，但我们考虑将来支持这一部分。
 
       <Alert>
       基于 ShadowDOM 的严格样式隔离并不是一个可以无脑使用的方案，大部分情况下都需要接入应用做一些适配后才能正常在 ShadowDOM 中运行起来（比如 react 场景下需要解决这些 <a target="_blank" href="https://github.com/facebook/react/issues/10422">问题</a>，使用者需要清楚开启了 <code>strictStyleIsolation</code> 意味着什么。后续 qiankun 会提供更多官方实践文档帮助用户能快速的将应用改造成可以运行在 ShadowDOM 环境的微应用。
       </Alert>
 
     * singular - `boolean | ((app: RegistrableApp<any>) => Promise<boolean>);` - 可选，是否为单实例场景，默认为 `false`。
-  
+
     * fetch - `Function` - 可选，自定义的 fetch 方法。
-    
+
     * getPublicPath - `(url: string) => string` - 可选
-    
+
     * getTemplate - `(tpl: string) => string` - 可选
-  
+
 * 返回值 - `MicroApp` - 微应用实例
   * mount(): Promise&lt;null&gt;;
   * unmount(): Promise&lt;null&gt;;
@@ -251,7 +269,7 @@ toc: menu
   * bootstrapPromise: Promise&lt;null&gt;;
   * mountPromise: Promise&lt;null&gt;;
   * unmountPromise: Promise&lt;null&gt;;
-  
+
 * 用法
 
   手动加载一个微应用。
@@ -262,7 +280,7 @@ toc: menu
   export function mount(props) {
     renderApp(props);
   }
-  
+
   // 增加 update 钩子以便主应用手动更新微应用
   export function update(props) {
     renderPatch(props);
@@ -274,26 +292,26 @@ toc: menu
   ```jsx
   import { loadMicroApp } from 'qiankun';
   import React from 'react';
-  
+
   class App extends React.Component {
-    
+
     containerRef = React.createRef();
     microApp = null;
-    
+
     componentDidMount() {
       this.microApp = loadMicroApp(
         { name: 'app1', entry: '//localhost:1234', container: this.containerRef.current, props: { name: 'qiankun' } },
       );
     }
-  
+
     componentWillUnmount() {
       this.microApp.unmount();
     }
-  
+
     componentDidUpdate() {
       this.microApp.update({ name: 'kuitos' });
     }
-    
+
     render() {
       return <div ref={this.containerRef}></div>;
     }
@@ -305,21 +323,21 @@ toc: menu
 - 参数
   - apps - `AppMetadata[]` - 必选 - 预加载的应用列表
   - importEntryOpts - 可选 - 加载配置
-  
+
 - 类型
   - `AppMetadata`
     - name - `string` - 必选 - 应用名
     - entry - `string | { scripts?: string[]; styles?: string[]; html?: string }` - 必选，微应用的 entry 地址
 
 - 用法
-  
+
   手动预加载指定的微应用静态资源。仅手动加载微应用场景需要，基于路由自动激活场景直接配置 `prefetch` 属性即可。
-  
+
 - 示例
 
   ```ts
   import { prefetchApps } from 'qiankun';
-  
+
   prefetchApps([ { name: 'app1', entry: '//locahost:7001' }, { name: 'app2', entry: '//locahost:7002' } ])
   ```
 
@@ -339,7 +357,7 @@ toc: menu
 
   ```ts
   import { addGlobalUncaughtErrorHandler } from 'qiankun';
-  
+
   addGlobalUncaughtErrorHandler(event => console.log(event));
   ```
 
@@ -357,7 +375,7 @@ toc: menu
 
   ```ts
   import { removeGlobalUncaughtErrorHandler } from 'qiankun';
-  
+
   removeGlobalUncaughtErrorHandler(handler);
   ```
 
@@ -407,7 +425,7 @@ toc: menu
       // state: 变更后的状态; prev 变更前的状态
       console.log(state, prev);
     });
-  
+
     props.setGlobalState(state);
   }
   ```

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -59,6 +59,7 @@ type QiankunSpecialOpts = {
     | boolean
     | {
         strictStyleIsolation?: boolean;
+        experimentalStyleIsolation?: boolean;
         patchers?: Patcher[];
       };
   /*

--- a/src/sandbox/__tests__/utils.test.ts
+++ b/src/sandbox/__tests__/utils.test.ts
@@ -1,0 +1,87 @@
+import { getWrapperId, getDefaultTplWrapper, validateExportLifecycle, sleep, Deferred } from '../../utils';
+
+test('should wrap the id [1]', () => {
+  const id = 'REACT16';
+
+  expect(getWrapperId(id)).toBe(`__qiankun_microapp_wrapper_for_${'react_16'}__`);
+});
+
+test('should wrap the id [2]', () => {
+  const id = 'react16';
+
+  expect(getWrapperId(id)).toBe('__qiankun_microapp_wrapper_for_react_16__');
+});
+
+test('should wrap string with div', () => {
+  const tpl = '<span>qiankun</span>';
+  const factory = getDefaultTplWrapper('react16');
+
+  const ret = factory(tpl);
+
+  expect(ret).toBe(`<div id="__qiankun_microapp_wrapper_for_react_16__">${tpl}</div>`);
+});
+
+test('should be able to validate lifecycle', () => {
+  const noop = () => undefined;
+
+  const export1 = {
+    bootstrap: noop,
+    mount: noop,
+    unmount: noop,
+  };
+  expect(validateExportLifecycle(export1)).toBeTruthy();
+
+  const export2 = {
+    bootstrap: noop,
+  };
+  expect(validateExportLifecycle(export2)).toBeFalsy();
+
+  const export3 = {};
+  expect(validateExportLifecycle(export3)).toBeFalsy();
+
+  const export4 = {
+    bootstrap: true,
+    mount: 1,
+    unmount: 'noop',
+  };
+  expect(validateExportLifecycle(export4)).toBeFalsy();
+});
+
+test('should be able to suspend', async () => {
+  const start = new Date().getTime();
+  await sleep(10);
+
+  const end = new Date().getTime();
+
+  const diff = end - start;
+  expect(diff >= 10 && diff < 100).toBeTruthy();
+});
+
+test('Deferred should worked [1]', async () => {
+  const inst = new Deferred();
+
+  setTimeout(() => {
+    inst.resolve(1);
+  });
+  const ret = await inst.promise;
+
+  expect(ret).toBe(1);
+});
+
+test('Deferred should worked [2]', async () => {
+  const inst = new Deferred();
+
+  setTimeout(() => {
+    inst.reject(new Error());
+  });
+
+  let err = null;
+
+  try {
+    await inst.promise;
+  } catch (e) {
+    err = e;
+  }
+
+  expect(err).toBeInstanceOf(Error);
+});

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -8,7 +8,7 @@ import { patchAtBootstrapping, patchAtMounting } from './patchers';
 import ProxySandbox from './proxySandbox';
 import SnapshotSandbox from './snapshotSandbox';
 
-export { QiankunCSSRewriteAttr } from './patchers';
+export { css } from './patchers';
 
 /**
  * 生成应用运行时沙箱
@@ -26,7 +26,12 @@ export { QiankunCSSRewriteAttr } from './patchers';
  * @param elementGetter
  * @param singular
  */
-export function createSandbox(appName: string, elementGetter: () => HTMLElement | ShadowRoot, singular: boolean) {
+export function createSandbox(
+  appName: string,
+  elementGetter: () => HTMLElement | ShadowRoot,
+  singular: boolean,
+  scopedCSS: boolean,
+) {
   let sandbox: SandBox;
   if (window.Proxy) {
     sandbox = singular ? new LegacySandbox(appName) : new ProxySandbox(appName);
@@ -35,7 +40,7 @@ export function createSandbox(appName: string, elementGetter: () => HTMLElement 
   }
 
   // some side effect could be be invoked while bootstrapping, such as dynamic stylesheet injection with style-loader, especially during the development phase
-  const bootstrappingFreers = patchAtBootstrapping(appName, elementGetter, sandbox, singular);
+  const bootstrappingFreers = patchAtBootstrapping(appName, elementGetter, sandbox, singular, scopedCSS);
   // mounting freers are one-off and should be re-init at every mounting time
   let mountingFreers: Freer[] = [];
 
@@ -65,7 +70,7 @@ export function createSandbox(appName: string, elementGetter: () => HTMLElement 
 
       /* ------------------------------------------ 2. 开启全局变量补丁 ------------------------------------------*/
       // render 沙箱启动时开始劫持各类全局监听，尽量不要在应用初始化阶段有 事件监听/定时器 等副作用
-      mountingFreers = patchAtMounting(appName, elementGetter, sandbox, singular);
+      mountingFreers = patchAtMounting(appName, elementGetter, sandbox, singular, scopedCSS);
 
       /* ------------------------------------------ 3. 重置一些初始化时的副作用 ------------------------------------------*/
       // 存在 rebuilder 则表明有些副作用需要重建

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -8,6 +8,8 @@ import { patchAtBootstrapping, patchAtMounting } from './patchers';
 import ProxySandbox from './proxySandbox';
 import SnapshotSandbox from './snapshotSandbox';
 
+export { QiankunCSSRewriteAttr } from './patchers';
+
 /**
  * 生成应用运行时沙箱
  *

--- a/src/sandbox/patchers/__tests__/css.test.ts
+++ b/src/sandbox/patchers/__tests__/css.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @author Saviio
+ * @since 2020-04-19
+ */
+
+import { processor as CSSProcessor } from '../css';
+import { sleep } from '../../../utils';
+
+const fakeStyleNode = (css: string) => {
+  const styleNode = document.createElement('style');
+  const textNode = document.createTextNode(css);
+
+  styleNode.appendChild(textNode);
+  document.body.append(styleNode);
+
+  return styleNode;
+};
+
+const removeWs = (s: string | null) => {
+  if (s == null) {
+    return s;
+  }
+
+  const re = /\s/g;
+  return s.replace(re, '');
+};
+
+test('should add attribute selector correctly', () => {
+  const actualValue = '.react15-main {display: flex; flex-direction: column; align-items: center;}';
+  const expectValue =
+    'div[data-qiankun=react15] .react15-main {display: flex; flex-direction: column; align-items: center;}';
+
+  const styleNode = fakeStyleNode(actualValue);
+  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+
+  expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
+});
+
+test('should add attribute selector correctly [2]', async () => {
+  const actualValue = '.react15-main {display: flex; flex-direction: column; align-items: center;}';
+  const expectValue =
+    'div[data-qiankun=react15] .react15-main {display: flex; flex-direction: column; align-items: center;}';
+
+  const styleNode = fakeStyleNode('');
+  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+
+  const textNode = document.createTextNode(actualValue);
+  styleNode.appendChild(textNode);
+
+  await sleep(10);
+
+  expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
+});
+
+test('should replace html correctly', () => {
+  const actualValue = 'html {font-size: 14px;}';
+  const expectValue = 'div[data-qiankun=react15] {font-size: 14px;}';
+
+  const styleNode = fakeStyleNode(actualValue);
+  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+
+  expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
+});
+
+test('should replace body correctly', () => {
+  const actualValue = 'body {font-size: 14px;}';
+  const expectValue = 'div[data-qiankun=react15] {font-size: 14px;}';
+
+  const styleNode = fakeStyleNode(actualValue);
+  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+
+  expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
+});
+
+test('should transform @supports', () => {
+  const actualValue = '@supports (display: grid) {div{margin: 1cm;}}';
+  const expectValue = '@supports (display: grid) {div[data-qiankun=react15] div {margin: 1cm;}}';
+
+  const styleNode = fakeStyleNode(actualValue);
+  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+
+  expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
+});
+
+test('should not transform @keyframes', () => {
+  const actualValue = '@keyframes move {from {top: 0px;}to {top: 200px;}}';
+  const expectValue = '@keyframes move {from {top: 0px;}to {top: 200px;}}';
+
+  const styleNode = fakeStyleNode(actualValue);
+  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+
+  expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
+});
+
+test('should not transform @font-face', () => {
+  const actualValue = '@font-face {font-family: "Open Sans";}';
+  const expectValue = '@font-face {font-family: "Open Sans";}';
+
+  const styleNode = fakeStyleNode(actualValue);
+  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+
+  expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
+});
+
+// jest cannot handle @page directive correctly
+test.skip('should not transform @page', () => {
+  const actualValue = '@page {margin: 1cm;}';
+  const expectValue = '@page {margin: 1cm;}';
+
+  const styleNode = fakeStyleNode(actualValue);
+  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+
+  expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
+});
+
+// jest cannot handle @import directive correctly
+test.skip('should not transform @import', () => {
+  const actualValue = "@import 'custom.css'";
+  const expectValue = "@import 'custom.css'";
+
+  const styleNode = fakeStyleNode(actualValue);
+  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+
+  expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
+});
+
+// jest cannot handle @media directive correctly
+test.skip('should transform @media', () => {
+  const actualValue = '@media screen and (max-width: 300px) {div{margin: 1cm;}}';
+  const expectValue = '@media screen and (max-width: 300px) {div[data-qiankun=react15] div {margin: 1cm;}}';
+
+  const styleNode = fakeStyleNode(actualValue);
+  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+
+  expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
+});

--- a/src/sandbox/patchers/css.ts
+++ b/src/sandbox/patchers/css.ts
@@ -1,0 +1,161 @@
+/**
+ * @author Saviio
+ * @since 2020-4-19
+ */
+
+// https://developer.mozilla.org/en-US/docs/Web/API/CSSRule
+enum RuleType {
+  // type: rule will be rewrote
+  STYLE = 1,
+  MEDIA = 4,
+  SUPPORTS = 12,
+
+  // type: value will be keeped
+  IMPORT = 3,
+  FONT_FACE = 5,
+  PAGE = 6,
+  KEYFRAMES = 7,
+  KEYFRAME = 8,
+}
+
+const arrayify = <T>(list: CSSRuleList | any[]) => {
+  return [].slice.call(list, 0) as T[];
+};
+
+class ScopedCSS {
+  private static ModifiedTag = 'Symbol(style-modified-qiankun)';
+
+  private sheet: StyleSheet;
+
+  private swapNode: HTMLStyleElement;
+
+  constructor() {
+    const styleNode = document.createElement('style');
+    document.body.appendChild(styleNode);
+
+    this.swapNode = styleNode;
+    this.sheet = styleNode.sheet!;
+    this.sheet.disabled = true;
+  }
+
+  process(styleNode: HTMLStyleElement, prefix: string = '') {
+    if (styleNode.textContent !== '') {
+      const textNode = document.createTextNode(styleNode.textContent || '');
+      this.swapNode.appendChild(textNode);
+      const sheet = this.swapNode.sheet as any; // type is missing
+      const rules = arrayify<CSSRule>(sheet?.cssRules ?? []);
+      const css = this.rewrite(rules, prefix);
+      // eslint-disable-next-line no-param-reassign
+      styleNode.textContent = css;
+
+      // cleanup
+      this.swapNode.removeChild(textNode);
+      return;
+    }
+
+    const mutator = new MutationObserver(mutations => {
+      for (let i = 0; i < mutations.length; i += 1) {
+        const mutation = mutations[i];
+
+        if (ScopedCSS.ModifiedTag in styleNode) {
+          return;
+        }
+
+        if (mutation.type === 'childList') {
+          const sheet = styleNode.sheet as any;
+          const rules = arrayify<CSSRule>(sheet?.cssRules ?? []);
+          const css = this.rewrite(rules, prefix);
+
+          // eslint-disable-next-line no-param-reassign
+          styleNode.textContent = css;
+          // eslint-disable-next-line no-param-reassign
+          (styleNode as any)[ScopedCSS.ModifiedTag] = true;
+        }
+      }
+    });
+
+    // since observer will be deleted when node be removed
+    // we dont need create a cleanup function manually
+    // see https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/disconnect
+    mutator.observe(styleNode, { childList: true });
+  }
+
+  private rewrite(rules: CSSRule[], prefix: string = '') {
+    let css = '';
+
+    rules.forEach(rule => {
+      switch (rule.type) {
+        case RuleType.STYLE:
+          css += this.ruleStyle(rule as CSSStyleRule, prefix);
+          break;
+        case RuleType.MEDIA:
+          css += this.ruleMedia(rule as CSSMediaRule, prefix);
+          break;
+        case RuleType.SUPPORTS:
+          css += this.ruleSupport(rule as CSSSupportsRule, prefix);
+          break;
+        default:
+          css += `${rule.cssText}`;
+          break;
+      }
+    });
+
+    return css;
+  }
+
+  // handle case:
+  // .app-main {}
+  // html, body {}
+
+  // eslint-disable-next-line class-methods-use-this
+  private ruleStyle(rule: CSSStyleRule, prefix: string) {
+    const rootSelectorRE = /((html)|(body))/g;
+
+    if (rootSelectorRE.test(rule.selectorText)) {
+      return rule.cssText.replace(rootSelectorRE, prefix);
+    }
+
+    return `${prefix} ${rule.cssText}`;
+  }
+
+  // handle case:
+  // @media screen and (max-width: 300px) {}
+  private ruleMedia(rule: CSSMediaRule, prefix: string) {
+    const css = this.rewrite(arrayify(rule.cssRules), prefix);
+    return `@media ${rule.conditionText} {${css}}`;
+  }
+
+  // handle case:
+  // @supports (display: grid) {}
+  private ruleSupport(rule: CSSSupportsRule, prefix: string) {
+    const css = this.rewrite(arrayify(rule.cssRules), prefix);
+    return `@supports ${rule.conditionText} {${css}}`;
+  }
+}
+
+const processor = new ScopedCSS();
+
+export const QiankunCSSRewriteAttr = 'data-qiankun';
+const process = (
+  appWrapper: () => HTMLElement,
+  stylesheetElement: HTMLStyleElement | HTMLLinkElement,
+  appName: string,
+) => {
+  if (stylesheetElement.tagName === 'LINK') {
+    console.warn('Feature: sandbox.experimentalStyleIsolation is not support for link element yet.');
+  }
+
+  const mountDOM = appWrapper();
+  if (!mountDOM) {
+    return;
+  }
+
+  const tag = (mountDOM.tagName || '').toLowerCase();
+
+  if (tag && stylesheetElement.tagName === 'STYLE') {
+    const prefix = `${tag}[${QiankunCSSRewriteAttr}=${appName}]`;
+    processor.process(stylesheetElement, prefix);
+  }
+};
+
+export { process, processor };

--- a/src/sandbox/patchers/css.ts
+++ b/src/sandbox/patchers/css.ts
@@ -109,7 +109,7 @@ class ScopedCSS {
 
   // eslint-disable-next-line class-methods-use-this
   private ruleStyle(rule: CSSStyleRule, prefix: string) {
-    const rootSelectorRE = /((html)|(body))/g;
+    const rootSelectorRE = /((html)|(body)|(:root))/g;
 
     if (rootSelectorRE.test(rule.selectorText)) {
       return rule.cssText.replace(rootSelectorRE, prefix);
@@ -136,16 +136,12 @@ class ScopedCSS {
 const processor = new ScopedCSS();
 
 export const QiankunCSSRewriteAttr = 'data-qiankun';
-const process = (
-  appWrapper: () => HTMLElement,
-  stylesheetElement: HTMLStyleElement | HTMLLinkElement,
-  appName: string,
-) => {
+const process = (appWrapper: HTMLElement, stylesheetElement: HTMLStyleElement | HTMLLinkElement, appName: string) => {
   if (stylesheetElement.tagName === 'LINK') {
     console.warn('Feature: sandbox.experimentalStyleIsolation is not support for link element yet.');
   }
 
-  const mountDOM = appWrapper();
+  const mountDOM = appWrapper;
   if (!mountDOM) {
     return;
   }

--- a/src/sandbox/patchers/dynamicAppend.ts
+++ b/src/sandbox/patchers/dynamicAppend.ts
@@ -8,6 +8,8 @@ import { checkActivityFunctions } from 'single-spa';
 import { frameworkConfiguration } from '../../apis';
 import { Freer } from '../../interfaces';
 import { getTargetValue, setProxyPropertyGetter } from '../common';
+import { isEnableScopedCSS } from '../../utils';
+import * as css from './css';
 
 const styledComponentSymbol = 'Symbol(styled-component-qiankun)';
 const attachProxySymbol = 'Symbol(attach-proxy-qiankun)';
@@ -96,6 +98,10 @@ function getNewAppendChild(args: {
 
           if (!invokedByMicroApp) {
             return headOrBodyAppendChild.call(this, element) as T;
+          }
+
+          if (isEnableScopedCSS(frameworkConfiguration)) {
+            css.process(appWrapperGetter as () => HTMLElement, stylesheetElement, appName);
           }
 
           // eslint-disable-next-line no-shadow
@@ -220,6 +226,10 @@ function getNewInsertBefore(args: {
 
           if (!invokedByMicroApp) {
             return headOrBodyInsertBefore.call(this, element, refChild) as T;
+          }
+
+          if (isEnableScopedCSS(frameworkConfiguration)) {
+            css.process(appWrapperGetter as () => HTMLElement, stylesheetElement, appName);
           }
 
           dynamicStyleSheetElements.push(stylesheetElement);

--- a/src/sandbox/patchers/dynamicAppend.ts
+++ b/src/sandbox/patchers/dynamicAppend.ts
@@ -8,7 +8,6 @@ import { checkActivityFunctions } from 'single-spa';
 import { frameworkConfiguration } from '../../apis';
 import { Freer } from '../../interfaces';
 import { getTargetValue, setProxyPropertyGetter } from '../common';
-import { isEnableScopedCSS } from '../../utils';
 import * as css from './css';
 
 const styledComponentSymbol = 'Symbol(styled-component-qiankun)';
@@ -60,13 +59,14 @@ function getNewAppendChild(args: {
   dynamicStyleSheetElements: HTMLStyleElement[];
   appWrapperGetter: CallableFunction;
   headOrBodyAppendChild: typeof HTMLElement.prototype.appendChild;
+  scopedCSS: boolean;
 }) {
   return function appendChild<T extends Node>(this: HTMLHeadElement | HTMLBodyElement, newChild: T) {
     const element = newChild as any;
     const { headOrBodyAppendChild } = args;
     if (element.tagName) {
       // eslint-disable-next-line prefer-const
-      let { appWrapperGetter, proxy, singular, dynamicStyleSheetElements, appName } = args;
+      let { appWrapperGetter, proxy, singular, dynamicStyleSheetElements, appName, scopedCSS } = args;
 
       const storedContainerInfo = element[attachProxySymbol];
       if (storedContainerInfo) {
@@ -100,13 +100,15 @@ function getNewAppendChild(args: {
             return headOrBodyAppendChild.call(this, element) as T;
           }
 
-          if (isEnableScopedCSS(frameworkConfiguration)) {
-            css.process(appWrapperGetter as () => HTMLElement, stylesheetElement, appName);
+          const mountDOM = appWrapperGetter();
+
+          if (scopedCSS) {
+            css.process(mountDOM, stylesheetElement, appName);
           }
 
           // eslint-disable-next-line no-shadow
           dynamicStyleSheetElements.push(stylesheetElement);
-          return rawAppendChild.call(appWrapperGetter(), stylesheetElement) as T;
+          return rawAppendChild.call(mountDOM, stylesheetElement) as T;
         }
 
         case SCRIPT_TAG_NAME: {
@@ -117,6 +119,7 @@ function getNewAppendChild(args: {
           const { src, text } = element as HTMLScriptElement;
 
           const { fetch } = frameworkConfiguration;
+          const mountDOM = appWrapperGetter();
           if (src) {
             execScripts(null, [src], proxy, { fetch, strictGlobal: !singular }).then(
               () => {
@@ -142,7 +145,7 @@ function getNewAppendChild(args: {
             );
 
             const dynamicScriptCommentElement = document.createComment(`dynamic script ${src} replaced by qiankun`);
-            return rawAppendChild.call(appWrapperGetter(), dynamicScriptCommentElement) as T;
+            return rawAppendChild.call(mountDOM, dynamicScriptCommentElement) as T;
           }
 
           execScripts(null, [`<script>${text}</script>`], proxy, { strictGlobal: !singular }).then(
@@ -150,7 +153,7 @@ function getNewAppendChild(args: {
             element.onerror,
           );
           const dynamicInlineScriptCommentElement = document.createComment('dynamic inline script replaced by qiankun');
-          return rawAppendChild.call(appWrapperGetter(), dynamicInlineScriptCommentElement) as T;
+          return rawAppendChild.call(mountDOM, dynamicInlineScriptCommentElement) as T;
         }
 
         default:
@@ -197,13 +200,14 @@ function getNewInsertBefore(args: {
   dynamicStyleSheetElements: HTMLStyleElement[];
   appWrapperGetter: CallableFunction;
   headOrBodyInsertBefore: typeof HTMLElement.prototype.insertBefore;
+  scopedCSS: boolean;
 }) {
   return function insertBefore<T extends Node>(this: HTMLHeadElement, newChild: T, refChild: Node | null): T {
     const element = newChild as any;
     const { headOrBodyInsertBefore } = args;
     if (element.tagName) {
       // eslint-disable-next-line prefer-const
-      let { appName, appWrapperGetter, proxy, singular, dynamicStyleSheetElements } = args;
+      let { appName, appWrapperGetter, proxy, singular, dynamicStyleSheetElements, scopedCSS } = args;
 
       const storedContainerInfo = element[attachProxySymbol];
       if (storedContainerInfo) {
@@ -228,14 +232,15 @@ function getNewInsertBefore(args: {
             return headOrBodyInsertBefore.call(this, element, refChild) as T;
           }
 
-          if (isEnableScopedCSS(frameworkConfiguration)) {
-            css.process(appWrapperGetter as () => HTMLElement, stylesheetElement, appName);
+          const mountDOM = appWrapperGetter();
+
+          if (scopedCSS) {
+            css.process(mountDOM, stylesheetElement, appName);
           }
 
           dynamicStyleSheetElements.push(stylesheetElement);
-          const wrapper = appWrapperGetter();
-          const referenceNode = wrapper.contains(refChild) ? refChild : null;
-          return rawInsertBefore.call(wrapper, stylesheetElement, referenceNode) as T;
+          const referenceNode = mountDOM.contains(refChild) ? refChild : null;
+          return rawInsertBefore.call(mountDOM, stylesheetElement, referenceNode) as T;
         }
 
         case SCRIPT_TAG_NAME: {
@@ -247,8 +252,8 @@ function getNewInsertBefore(args: {
 
           const { fetch } = frameworkConfiguration;
 
-          const wrapper = appWrapperGetter();
-          const referenceNode = wrapper.contains(refChild) ? refChild : null;
+          const mountDOM = appWrapperGetter();
+          const referenceNode = mountDOM.contains(refChild) ? refChild : null;
 
           if (src) {
             execScripts(null, [src], proxy, { fetch, strictGlobal: !singular }).then(
@@ -275,7 +280,7 @@ function getNewInsertBefore(args: {
             );
 
             const dynamicScriptCommentElement = document.createComment(`dynamic script ${src} replaced by qiankun`);
-            return rawInsertBefore.call(appWrapperGetter(), dynamicScriptCommentElement, referenceNode) as T;
+            return rawInsertBefore.call(mountDOM, dynamicScriptCommentElement, referenceNode) as T;
           }
 
           execScripts(null, [`<script>${text}</script>`], proxy, { strictGlobal: !singular }).then(
@@ -283,7 +288,7 @@ function getNewInsertBefore(args: {
             element.onerror,
           );
           const dynamicInlineScriptCommentElement = document.createComment('dynamic inline script replaced by qiankun');
-          return rawInsertBefore.call(appWrapperGetter(), dynamicInlineScriptCommentElement, referenceNode) as T;
+          return rawInsertBefore.call(mountDOM, dynamicInlineScriptCommentElement, referenceNode) as T;
         }
         default:
           break;
@@ -313,6 +318,7 @@ export default function patch(
   proxy: Window,
   mounting = true,
   singular = true,
+  scopedCSS = false,
 ): Freer {
   let dynamicStyleSheetElements: Array<HTMLLinkElement | HTMLStyleElement> = [];
 
@@ -359,6 +365,7 @@ export default function patch(
       proxy,
       singular,
       dynamicStyleSheetElements,
+      scopedCSS,
     });
     HTMLBodyElement.prototype.appendChild = getNewAppendChild({
       headOrBodyAppendChild: rawBodyAppendChild,
@@ -367,6 +374,7 @@ export default function patch(
       proxy,
       singular,
       dynamicStyleSheetElements,
+      scopedCSS,
     });
   }
 
@@ -395,6 +403,7 @@ export default function patch(
       singular,
       dynamicStyleSheetElements,
       headOrBodyInsertBefore: rawHeadInsertBefore,
+      scopedCSS,
     });
   }
 

--- a/src/sandbox/patchers/index.ts
+++ b/src/sandbox/patchers/index.ts
@@ -10,19 +10,20 @@ import patchInterval from './interval';
 import patchWindowListener from './windowListener';
 import patchUIEvent from './UIEvent';
 
-export { QiankunCSSRewriteAttr } from './css';
+import * as css from './css';
 
 export function patchAtMounting(
   appName: string,
   elementGetter: () => HTMLElement | ShadowRoot,
   sandbox: SandBox,
   singular: boolean,
+  scopedCSS: boolean,
 ): Freer[] {
   const basePatchers = [
     () => patchInterval(),
     () => patchWindowListener(),
     () => patchHistoryListener(),
-    () => patchDynamicAppend(appName, elementGetter, sandbox.proxy, true, singular),
+    () => patchDynamicAppend(appName, elementGetter, sandbox.proxy, true, singular, scopedCSS),
   ];
 
   const patchersInSandbox = {
@@ -39,8 +40,9 @@ export function patchAtBootstrapping(
   elementGetter: () => HTMLElement | ShadowRoot,
   sandbox: SandBox,
   singular: boolean,
+  scopedCSS: boolean,
 ): Freer[] {
-  const basePatchers = [() => patchDynamicAppend(appName, elementGetter, sandbox.proxy, false, singular)];
+  const basePatchers = [() => patchDynamicAppend(appName, elementGetter, sandbox.proxy, false, singular, scopedCSS)];
 
   const patchersInSandbox = {
     [SandBoxType.LegacyProxy]: basePatchers,
@@ -50,3 +52,5 @@ export function patchAtBootstrapping(
 
   return patchersInSandbox[sandbox.type]?.map(patch => patch());
 }
+
+export { css };

--- a/src/sandbox/patchers/index.ts
+++ b/src/sandbox/patchers/index.ts
@@ -10,6 +10,8 @@ import patchInterval from './interval';
 import patchWindowListener from './windowListener';
 import patchUIEvent from './UIEvent';
 
+export { QiankunCSSRewriteAttr } from './css';
+
 export function patchAtMounting(
   appName: string,
   elementGetter: () => HTMLElement | ShadowRoot,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@
  */
 
 import { isFunction, snakeCase } from 'lodash';
+import { FrameworkConfiguration } from './interfaces';
 
 export function toArray<T>(array: T | T[]): T[] {
   return Array.isArray(array) ? array : [array];
@@ -104,4 +105,16 @@ export function performanceMeasure(measureName: string, markName: string) {
     performance.clearMarks(markName);
     performance.clearMeasures(measureName);
   }
+}
+
+export function isEnableScopedCSS(opt: FrameworkConfiguration) {
+  if (typeof opt.sandbox !== 'object') {
+    return false;
+  }
+
+  if (opt.sandbox.strictStyleIsolation) {
+    return false;
+  }
+
+  return !!opt.sandbox.experimentalStyleIsolation;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines
- [ ] documentation is changed or added

##### Description of change

<!-- Provide a description of the change below this comment. -->
qiankun offered `strictStyleIsolation` already, but it is implemented by shadow-dom which may casue other problems, we may need a more generic way to support `css isolation`. 

With this PR, a experimental feature is added, if you start qiankun with following args:
``` typescript
start({
  sandbox: {
    experimentalStyleIsolation: true
  }
})
```
the css style of sub app will be isolated by the runtime transformer, i.e. processor will add a specified attribute selector for every single css rule.
``` css
.app-main { ... }
↓ ↓ ↓
div[data-qiankun-react16] .app-main { ... }
↓ ↓ ↓
tag[data-qiankun-appname] sub-app-css-selector
```

### known issue:
#### These rules are not supported:
@keyframes, @font-face, @import, @page

#### Some component like Modal seems lost its style?
When option: experimentalStyleIsolation is true, all styles of sub app will be rewrite and qiankun will limit their scope of influence, therefore you have to manually add config code like this:
```typescript
// antd 
function render(props) {
  const { container } = props;
  const mountDOM = container ? container.querySelector('#root') : document.querySelector('#root')
  const rootDomGetter = () => mountDOM

  ReactDOM.render((
    <ConfigProvider getPopupContainer ={ rootDomGetter }>
      <App />
    </ConfigProvider>
  ), mountDOM);
}

``` 

#### My css is not be scoped?
currently we're not support tag: link, so if your css is be add by ```<link />```, this transformer will not process them.



