### PR TITLE
fix: incorrect behavior of `loadMicroApp` 

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,7 +3,7 @@
  * @since 2019-05-16
  */
 import { ImportEntryOpts } from 'import-html-entry';
-import { RegisterApplicationConfig, StartOpts, Parcel } from 'single-spa';
+import { RegisterApplicationConfig, StartOpts, Parcel, ParcelConfigObject } from 'single-spa';
 
 declare global {
   interface Window {
@@ -40,6 +40,11 @@ export type LoadableApp<T extends object = {}> = AppMetadata & { /* props pass t
         container: string | HTMLElement;
       }
   );
+
+export type SeparatedLoadedApp = {
+  instance: Promise<ParcelConfigObject & { reuse: Function }>;
+  name: string;
+};
 
 // for the route-based apps
 export type RegistrableApp<T extends object = {}> = LoadableApp<T> & {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

This PR fixed incorrect behavior of `loadMicroApp`.

Before this PR, the rebuilder mechanism will not working as expected if we're calling `loadMicroApp` multiple times. 

here's a minimal repro:
```javascript
async function repro() {
  var dom = document.createElement('div')
  document.body.appendChild(dom)
  
  var x1 = {
    name: 'react16',
    entry: '//localhost:7100',
    container: dom
  }
  
  var x2 = {
    name: 'react15',
    entry: '//localhost:7102',
    container: dom
  }

  var config = { sandbox: true, singular: false }
  
  var app1 = loadMicroApp(x1, config)
  await app1.unmount()

  var app2 = loadMicroApp(x2, config)
  await app2.unmount()

  // buggy here
  loadMicroApp(x1, config)
}

repro()
```

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL
