### PR TITLE
:bug: only release the head append prototype overwrite while all the apps are unmounted

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,6 @@ module.exports = {
     // see https://github.com/prettier/prettier/issues/3847
     'space-before-function-paren': ['error', { anonymous: 'never', named: 'never', asyncArrow: 'always' }],
     'no-underscore-dangle': 0,
+    'no-plusplus': 0,
   },
 };


### PR DESCRIPTION
多实例场景下由于不会确保后一个应用会在前一个 unmount 之后再 mount https://github.com/umijs/qiankun/blob/3bb406465d2d38417911e4bc47922a1c0fd0934a/src/loader.ts#L202

所以存在一种场景是 A 应用 mount 期间由于 B 应用 unmount 了，会将 A 应用对原型链的复写给移除掉，从而导致 A 应用后续的动态添加标签的行为失效。

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/qiankun/512)
<!-- Reviewable:end -->
