### PR TITLE
:bug: write document setting back to avoid illegal invocation

### DIFF
--- a/src/sandbox/patchers/dynamicHeadAppend.ts
+++ b/src/sandbox/patchers/dynamicHeadAppend.ts
@@ -257,6 +257,12 @@ export default function patch(
 
           return getTargetValue(document, (<any>target)[property]);
         },
+
+        set(target: Document, p: PropertyKey, value: any): boolean {
+          // eslint-disable-next-line no-param-reassign
+          (<any>target)[p] = value;
+          return true;
+        },
       });
     });
   }


### PR DESCRIPTION
Not write the document setting back to native document back will cause `Uncaught TypeError: Illegal invocation` exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/qiankun/526)
<!-- Reviewable:end -->
