### PR TITLE
:sparkles: write value back to fake window to instead of value map

### DIFF
--- a/src/sandbox/__tests__/proxySandbox.test.ts
+++ b/src/sandbox/__tests__/proxySandbox.test.ts
@@ -95,7 +95,7 @@ test('descriptor of non-configurable and non-enumerable property existed in raw 
 
   (<any>proxy).nonConfigurableProp = (<any>window).nonConfigurableProp;
   (<any>proxy).nonConfigurablePropWithAccessor = 123;
-  expect((<any>proxy).nonConfigurablePropWithAccessor).toBe(123);
+  expect((<any>proxy).nonConfigurablePropWithAccessor).toBe(undefined);
   expect(Object.keys(proxy)).toEqual(Object.keys(window));
   expect(Object.getOwnPropertyDescriptor(proxy, 'nonConfigurableProp')).toEqual(
     Object.getOwnPropertyDescriptor(window, 'nonConfigurableProp'),
@@ -108,7 +108,44 @@ test('descriptor of non-configurable and non-enumerable property existed in raw 
   expect(Object.keys(proxy)).toEqual(Object.keys(window));
   expect(Object.keys(proxy).includes('nonEnumerableProp')).toBeFalsy();
   expect(Object.keys(proxy).includes('enumerableProp')).toBeTruthy();
-  expect(Object.getOwnPropertyDescriptor(proxy, 'nonEnumerableProp')).toEqual(
-    Object.getOwnPropertyDescriptor(window, 'nonEnumerableProp'),
-  );
+  expect(Object.getOwnPropertyDescriptor(proxy, 'nonEnumerableProp')).toEqual({
+    enumerable: false,
+    writable: true,
+    configurable: false,
+    value: 456,
+  });
+  expect(Object.getOwnPropertyDescriptor(window, 'nonEnumerableProp')).toEqual({
+    enumerable: false,
+    writable: true,
+    configurable: false,
+  });
+});
+
+test('property added by Object.defineProperty should works as expect', () => {
+  const { proxy } = new ProxySandbox('object-define-property-test');
+
+  let v: any;
+  const descriptor = {
+    get(): any {
+      return v;
+    },
+    set(value: any) {
+      v = value;
+    },
+  };
+
+  Object.defineProperty(proxy, 'g_history', descriptor);
+  (<any>proxy).g_history = 'window.g_history';
+
+  expect((<any>proxy).g_history).toBe('window.g_history');
+
+  expect('g_history' in proxy).toBeTruthy();
+
+  expect(Object.keys(proxy)).toEqual(Object.keys(window));
+
+  expect(Object.getOwnPropertyDescriptor(proxy, 'g_history')).toEqual({
+    ...descriptor,
+    configurable: false,
+    enumerable: false,
+  });
 });

--- a/src/sandbox/noise/systemjs.ts
+++ b/src/sandbox/noise/systemjs.ts
@@ -20,15 +20,15 @@ export function interceptSystemJsProps(p: PropertyKey, value: any) {
 }
 
 // FIXME see interceptSystemJsProps function
-export function clearSystemJsProps(map: Map<PropertyKey, any>, allInactive: boolean) {
+export function clearSystemJsProps(global: Window, allInactive: boolean) {
   if (!allInactive) return;
 
-  if (map.has('System')) {
+  if (global.hasOwnProperty('System')) {
     // @ts-ignore
     delete window.System;
   }
 
-  if (map.has('__cjsWrapper')) {
+  if (global.hasOwnProperty('__cjsWrapper')) {
     // @ts-ignore
     delete window.__cjsWrapper;
   }


### PR DESCRIPTION
发现没必要使用 updateValueMap 作为桥接，可以直接回写到 fakeWindow，这样也能避免诸如 Object.defineProperty 方式写入 proxy 的行为丢失

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/qiankun/545)
<!-- Reviewable:end -->
