### PR TITLE
🐛 insertBefore will report an error

### DIFF
--- a/src/sandbox/patchers/dynamicHeadAppend.ts
+++ b/src/sandbox/patchers/dynamicHeadAppend.ts
@@ -207,8 +207,10 @@ function getNewInsertBefore(...args: any[]) {
 
           if (activated) {
             dynamicStyleSheetElements.push(stylesheetElement);
+            const wrapper = appWrapperGetter();
+            const referenceNode = wrapper.contains(refChild) ? refChild : null;
 
-            return rawHeadInsertBefore.call(appWrapperGetter(), stylesheetElement, refChild) as T;
+            return rawHeadInsertBefore.call(wrapper, stylesheetElement, referenceNode) as T;
           }
 
           return rawHeadInsertBefore.call(this, element, refChild) as T;


### PR DESCRIPTION
bug fix - insertBefore will report an error when refChild is not a child node.
As shown below.

![qiankun](http://shadows-mall.oss-cn-shenzhen.aliyuncs.com/images/blogs/qiankun_practice/4.png)

![qiankun](http://shadows-mall.oss-cn-shenzhen.aliyuncs.com/images/blogs/qiankun_practice/5.png)

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


