### PR TITLE
:bug: insertBefore will report an error

### DIFF
--- a/src/sandbox/patchers/dynamicHeadAppend.ts
+++ b/src/sandbox/patchers/dynamicHeadAppend.ts
@@ -207,8 +207,10 @@ function getNewInsertBefore(...args: any[]) {
 
           if (activated) {
             dynamicStyleSheetElements.push(stylesheetElement);
+            const wrapper = appWrapperGetter();
+            const referenceNode = wrapper.contains(refChild) ? refChild : null;
 
-            return rawHeadInsertBefore.call(appWrapperGetter(), stylesheetElement, refChild) as T;
+            return rawHeadInsertBefore.call(wrapper, stylesheetElement, referenceNode) as T;
           }
 
           return rawHeadInsertBefore.call(this, element, refChild) as T;


### PR DESCRIPTION
bug fix - insertBefore will report an error when refChild is not a child node.
As shown below.

![qiankun](https://camo.githubusercontent.com/11ff98a411cbbab19a0eeff04b3a1dd8c1867908/687474703a2f2f736861646f77732d6d616c6c2e6f73732d636e2d7368656e7a68656e2e616c6979756e63732e636f6d2f696d616765732f626c6f67732f7169616e6b756e5f70726163746963652f342e706e67)

![qiankun](https://camo.githubusercontent.com/3ec98a267ec4249ef49be6aa29aac6cb3349cc2a/687474703a2f2f736861646f77732d6d616c6c2e6f73732d636e2d7368656e7a68656e2e616c6979756e63732e636f6d2f696d616765732f626c6f67732f7169616e6b756e5f70726163746963652f352e706e67)

* [x]   `npm test` passes
* [x]   tests are included
* [ ]   documentation is changed or added
* [x]   commit message follows commit guidelines

resolve https://github.com/umijs/qiankun/issues/554