### PR TITLE
:sparkles: inject qiankun engine flag to micro app rather than set it to native window

### DIFF
--- a/src/addons/engineFlag.ts
+++ b/src/addons/engineFlag.ts
@@ -1,0 +1,22 @@
+/**
+ * @author Kuitos
+ * @since 2020-05-15
+ */
+
+import { FrameworkLifeCycles } from '../interfaces';
+
+export default function getAddOn(global: Window): FrameworkLifeCycles<any> {
+  return {
+    async beforeLoad() {
+      global.__POWERED_BY_QIANKUN__ = true;
+    },
+
+    async beforeMount() {
+      global.__POWERED_BY_QIANKUN__ = true;
+    },
+
+    async beforeUnmount() {
+      delete global.__POWERED_BY_QIANKUN__;
+    },
+  };
+}

--- a/src/addons/index.ts
+++ b/src/addons/index.ts
@@ -7,7 +7,10 @@ import { concat, mergeWith } from 'lodash';
 import { FrameworkLifeCycles } from '../interfaces';
 
 import getRuntimePublicPathAddOn from './runtimePublicPath';
+import getEngineFlagAddon from './engineFlag';
 
 export default function getAddOns<T extends object>(global: Window, publicPath: string): FrameworkLifeCycles<T> {
-  return mergeWith({}, getRuntimePublicPathAddOn(global, publicPath), (v1, v2) => concat(v1 ?? [], v2 ?? []));
+  return mergeWith({}, getEngineFlagAddon(global), getRuntimePublicPathAddOn(global, publicPath), (v1, v2) =>
+    concat(v1 ?? [], v2 ?? []),
+  );
 }

--- a/src/apis.ts
+++ b/src/apis.ts
@@ -5,8 +5,6 @@ import { loadApp } from './loader';
 import { doPrefetchStrategy } from './prefetch';
 import { Deferred, toArray } from './utils';
 
-window.__POWERED_BY_QIANKUN__ = true;
-
 let microApps: RegistrableApp[] = [];
 
 // eslint-disable-next-line import/no-mutable-exports


### PR DESCRIPTION
子应用若自己也 import 了 qiankun 则无法通过 `__POWERED_BY_QIANKUN__` 判断自己是否是嵌入模式了，兼容有的应用又是子应用又是主应用的场景

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/qiankun/595)
<!-- Reviewable:end -->
