### PR TITLE
fix: selector patch when using :root with :not

### DIFF
--- a/src/sandbox/patchers/__tests__/css.test.ts
+++ b/src/sandbox/patchers/__tests__/css.test.ts
@@ -72,9 +72,19 @@ test('should replace body correctly', () => {
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
-test('should replace :root correctly', () => {
+test('should replace :root correctly [1]', () => {
   const actualValue = ':root {--gray: #eee}';
   const expectValue = 'div[data-qiankun=react15] {--gray: #eee;}';
+
+  const styleNode = fakeStyleNode(actualValue);
+  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+
+  expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
+});
+
+test('should replace :root correctly [2]', () => {
+  const actualValue = `svg:not(:root) {overflow: hidden;}`;
+  const expectValue = `svg:not(div[data-qiankun=react15]){overflow:hidden;}`;
 
   const styleNode = fakeStyleNode(actualValue);
   CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');

--- a/src/sandbox/patchers/css.ts
+++ b/src/sandbox/patchers/css.ts
@@ -137,8 +137,11 @@ class ScopedCSS {
     if (rootSelectorRE.test(rule.selectorText)) {
       // handle div,body,span { ... }
       return cssText.replace(rootSelectorRE, m => {
-        if (m && m[0] === ',') {
-          return `,${prefix}`;
+        // do not discard valid previous character, such as body,html or *:not(:root)
+        const whitePrevChars = [',', '('];
+
+        if (m && whitePrevChars.includes(m[0])) {
+          return `${m[0]}${prefix}`;
         }
         return prefix;
       });


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

For `experimentalStyleIsolation` ability, to fix root selector replace bug, for example `selector:not(:root)` will be replaced with `selector:notdiv[data-qiankun=xxx])` rather than the correct reuslt `selector:not(div[data-qiankun=xxx])`.