### PR TITLE
fix: style isolation failed if app name contains some character

### DIFF
--- a/src/sandbox/patchers/__tests__/css.test.ts
+++ b/src/sandbox/patchers/__tests__/css.test.ts
@@ -113,8 +113,16 @@ test('should rewrite root-level correctly [2]', () => {
 });
 
 test('should rewrite root-level correctly [3]', () => {
-  const actualValue = `html button[type="reset"] {color: #fff}`;
-  const expectValue = `div[data-qiankun=react15] button[type="reset"]{color:#fff;}`;
+  const actualValue = `[type="reset"],
+[type="submit"],
+button,
+html [type="button"] {
+  -webkit-appearance: button;
+}`;
+  const expectValue = `div[data-qiankun=react15] [type="reset"],
+div[data-qiankun=react15] [type="submit"],
+div[data-qiankun=react15] button,
+div[data-qiankun=react15] [type="button"] {-webkit-appearance: button;}`;
 
   const styleNode = fakeStyleNode(actualValue);
   CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');

--- a/src/sandbox/patchers/__tests__/css.test.ts
+++ b/src/sandbox/patchers/__tests__/css.test.ts
@@ -28,10 +28,10 @@ const removeWs = (s: string | null) => {
 test('should add attribute selector correctly', () => {
   const actualValue = '.react15-main {display: flex; flex-direction: column; align-items: center;}';
   const expectValue =
-    'div[data-qiankun=react15] .react15-main {display: flex; flex-direction: column; align-items: center;}';
+    'div[data-qiankun="react15"] .react15-main {display: flex; flex-direction: column; align-items: center;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
@@ -39,10 +39,10 @@ test('should add attribute selector correctly', () => {
 test('should add attribute selector correctly [2]', async () => {
   const actualValue = '.react15-main {display: flex; flex-direction: column; align-items: center;}';
   const expectValue =
-    'div[data-qiankun=react15] .react15-main {display: flex; flex-direction: column; align-items: center;}';
+    'div[data-qiankun="react15"] .react15-main {display: flex; flex-direction: column; align-items: center;}';
 
   const styleNode = fakeStyleNode('');
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   const textNode = document.createTextNode(actualValue);
   styleNode.appendChild(textNode);
@@ -54,60 +54,60 @@ test('should add attribute selector correctly [2]', async () => {
 
 test('should replace html correctly', () => {
   const actualValue = 'html {font-size: 14px;}';
-  const expectValue = 'div[data-qiankun=react15] {font-size: 14px;}';
+  const expectValue = 'div[data-qiankun="react15"] {font-size: 14px;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should replace body correctly', () => {
   const actualValue = 'body {font-size: 14px;}';
-  const expectValue = 'div[data-qiankun=react15] {font-size: 14px;}';
+  const expectValue = 'div[data-qiankun="react15"] {font-size: 14px;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should replace :root correctly [1]', () => {
   const actualValue = ':root {--gray: #eee}';
-  const expectValue = 'div[data-qiankun=react15] {--gray: #eee;}';
+  const expectValue = 'div[data-qiankun="react15"] {--gray: #eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should replace :root correctly [2]', () => {
   const actualValue = `svg:not(:root) {overflow: hidden;}`;
-  const expectValue = `svg:not(div[data-qiankun=react15]){overflow:hidden;}`;
+  const expectValue = `svg:not(div[data-qiankun="react15"]){overflow:hidden;}`;
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should rewrite root-level correctly [1]', () => {
   const actualValue = 'html + div {font-size: 14px;}';
-  const expectValue = 'div[data-qiankun=react15] + div {font-size: 14px;}';
+  const expectValue = 'div[data-qiankun="react15"] + div {font-size: 14px;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should rewrite root-level correctly [2]', () => {
   const actualValue = 'body + div {font-size: 14px;}';
-  const expectValue = 'div[data-qiankun=react15] + div {font-size: 14px;}';
+  const expectValue = 'div[data-qiankun="react15"] + div {font-size: 14px;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
@@ -119,153 +119,154 @@ button,
 html [type="button"] {
   -webkit-appearance: button;
 }`;
-  const expectValue = `div[data-qiankun=react15] [type="reset"],
-div[data-qiankun=react15] [type="submit"],
-div[data-qiankun=react15] button,
-div[data-qiankun=react15] [type="button"] {-webkit-appearance: button;}`;
+  const expectValue = `div[data-qiankun="react15"] [type="reset"],
+div[data-qiankun="react15"] [type="submit"],
+div[data-qiankun="react15"] button,
+div[data-qiankun="react15"] [type="button"] {-webkit-appearance: button;}`;
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should not replace body/html if body is part of class [1]', () => {
   const actualValue = '.ant-card-body {color: #eee}';
-  const expectValue = 'div[data-qiankun=react15] .ant-card-body {color: #eee;}';
+  const expectValue = 'div[data-qiankun="react15"] .ant-card-body {color: #eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should not replace body/html if body is part of class [2]', () => {
   const actualValue = '.ant-card_body {color: #eee}';
-  const expectValue = 'div[data-qiankun=react15] .ant-card_body {color: #eee;}';
+  const expectValue = 'div[data-qiankun="react15"] .ant-card_body {color: #eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should not replace body/html if body is part of class [3]', () => {
   const actualValue = '.body {color: #eee}';
-  const expectValue = 'div[data-qiankun=react15] .body {color: #eee;}';
+  const expectValue = 'div[data-qiankun="react15"] .body {color: #eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should not replace body/html if body is part of id [1]', () => {
   const actualValue = '#body {color: #eee}';
-  const expectValue = 'div[data-qiankun=react15] #body {color: #eee;}';
+  const expectValue = 'div[data-qiankun="react15"] #body {color: #eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should not replace body/html if body is part of id [2]', () => {
   const actualValue = '#ant-card-body {color: #eee}';
-  const expectValue = 'div[data-qiankun=react15] #ant-card-body {color: #eee;}';
+  const expectValue = 'div[data-qiankun="react15"] #ant-card-body {color: #eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should not replace body/html if body is part of id [3]', () => {
   const actualValue = '#ant-card__body {color: #eee}';
-  const expectValue = 'div[data-qiankun=react15] #ant-card__body {color: #eee;}';
+  const expectValue = 'div[data-qiankun="react15"] #ant-card__body {color: #eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should handle root-level descendant selector [1]', () => {
   const actualValue = 'html > body {color: #eee;}';
-  const expectValue = 'div[data-qiankun=react15] {color: #eee;}';
+  const expectValue = 'div[data-qiankun="react15"] {color: #eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should handle root-level descendant selector [2]', () => {
   const actualValue = 'html body {color: #eee;}';
-  const expectValue = 'div[data-qiankun=react15] {color: #eee;}';
+  const expectValue = 'div[data-qiankun="react15"] {color: #eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should handle root-level grouping selector [1]', () => {
   const actualValue = 'html,body {color: #eee;}';
-  const expectValue = 'div[data-qiankun=react15] {color: #eee;}';
+  const expectValue = 'div[data-qiankun="react15"] {color: #eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should handle root-level grouping selector [2]', () => {
   const actualValue = 'body,html,div {color: #eee;}';
-  const expectValue = 'div[data-qiankun=react15],div[data-qiankun=react15]div{color:#eee;}';
+  const expectValue = 'div[data-qiankun="react15"],div[data-qiankun="react15"]div{color:#eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should handle root-level grouping selector [3]', () => {
   const actualValue = 'a,body,html,div {color: #eee;}';
-  const expectValue = 'div[data-qiankun=react15]a,div[data-qiankun=react15],div[data-qiankun=react15]div{color:#eee;}';
+  const expectValue =
+    'div[data-qiankun="react15"]a,div[data-qiankun="react15"],div[data-qiankun="react15"]div{color:#eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should not remove special root-level selector when rule is non-standard [1]', () => {
   const actualValue = 'html + body {color: #eee;}';
-  const expectValue = 'div[data-qiankun=react15] + div[data-qiankun=react15] {color: #eee;}';
+  const expectValue = 'div[data-qiankun="react15"] + div[data-qiankun="react15"] {color: #eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should not remove special root-level selector when rule is non-standard [1]', () => {
   const actualValue = 'html ~ body {color: #eee;}';
-  const expectValue = 'div[data-qiankun=react15] ~ div[data-qiankun=react15] {color: #eee;}';
+  const expectValue = 'div[data-qiankun="react15"] ~ div[data-qiankun="react15"] {color: #eee;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
 
 test('should transform @supports', () => {
   const actualValue = '@supports (display: grid) {div{margin: 1cm;}}';
-  const expectValue = '@supports (display: grid) {div[data-qiankun=react15] div {margin: 1cm;}}';
+  const expectValue = '@supports (display: grid) {div[data-qiankun="react15"] div {margin: 1cm;}}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
@@ -275,7 +276,7 @@ test('should not transform @keyframes', () => {
   const expectValue = '@keyframes move {from {top: 0px;}to {top: 200px;}}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
@@ -285,7 +286,7 @@ test('should not transform @font-face', () => {
   const expectValue = '@font-face {font-family: "Open Sans";}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
@@ -296,7 +297,7 @@ test.skip('should not transform @page', () => {
   const expectValue = '@page {margin: 1cm;}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
@@ -307,7 +308,7 @@ test.skip('should not transform @import', () => {
   const expectValue = "@import 'custom.css'";
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });
@@ -315,10 +316,10 @@ test.skip('should not transform @import', () => {
 // jest cannot handle @media directive correctly
 test.skip('should transform @media', () => {
   const actualValue = '@media screen and (max-width: 300px) {div{margin: 1cm;}}';
-  const expectValue = '@media screen and (max-width: 300px) {div[data-qiankun=react15] div {margin: 1cm;}}';
+  const expectValue = '@media screen and (max-width: 300px) {div[data-qiankun="react15"] div {margin: 1cm;}}';
 
   const styleNode = fakeStyleNode(actualValue);
-  CSSProcessor.process(styleNode, 'div[data-qiankun=react15]');
+  CSSProcessor.process(styleNode, 'div[data-qiankun="react15"]');
 
   expect(removeWs(styleNode.textContent)).toBe(removeWs(expectValue));
 });

--- a/src/sandbox/patchers/css.ts
+++ b/src/sandbox/patchers/css.ts
@@ -110,7 +110,7 @@ class ScopedCSS {
   // eslint-disable-next-line class-methods-use-this
   private ruleStyle(rule: CSSStyleRule, prefix: string) {
     const rootSelectorRE = /((?:[^\w\-.#]|^)(body|html|:root))/gm;
-    const rootCombinationRE = /(html[^\w{]+)/gm;
+    const rootCombinationRE = /(html[^\w{[]+)/gm;
 
     const selector = rule.selectorText.trim();
 
@@ -152,7 +152,7 @@ class ScopedCSS {
           });
         }
 
-        return `${p}${prefix} ${s}`;
+        return `${p}${prefix} ${s.replace(/^ */, '')}`;
       }),
     );
 

--- a/src/sandbox/patchers/css.ts
+++ b/src/sandbox/patchers/css.ts
@@ -190,7 +190,7 @@ const process = (appWrapper: HTMLElement, stylesheetElement: HTMLStyleElement | 
   const tag = (mountDOM.tagName || '').toLowerCase();
 
   if (tag && stylesheetElement.tagName === 'STYLE') {
-    const prefix = `${tag}[${QiankunCSSRewriteAttr}=${appName}]`;
+    const prefix = `${tag}[${QiankunCSSRewriteAttr}="${appName}"]`;
     processor.process(stylesheetElement, prefix);
   }
 };


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

- The remaining problem in #833 :
```css
html [type="button"] {}
/* will be rewrite by mistake */
 type="button"] {}
/* right result with the next feature */
div[prefix] [type="button"] {}
```
- CSS styles will apply failed if app name contains some character:
```css
/* invalid rules */
div[data-qiankun=1f2a3n] {}
div[data-qiankun=http://] {}
/* valid rules */
div[data-qiankun="1f2a3n"] {}
div[data-qiankun="http://"] {}
```

So the quotes of attribute selector is required for a framework, reference: https://mathiasbynens.be/notes/unquoted-attribute-values