### PR TITLE
🐛 not proxy document anymore to avoid causing dom type checking exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   "scripts": {
     "examples:install": "npm-run-all --serial build install:*",
     "examples:start": "npm-run-all --parallel start:*",
+    "examples:start-multiple": "run-p start:main-multiple start:react15 start:vue",
     "install:main": "cd examples/main && yarn",
     "start:main": "cd examples/main && yarn start",
+    "start:main-multiple": "cd examples/main && yarn start:multiple",
     "install:react16": "cd examples/react16 && yarn",
     "start:react16": "cd examples/react16 && yarn start",
     "install:react15": "cd examples/react15 && yarn",

--- a/src/sandbox/__tests__/proxySandbox.test.ts
+++ b/src/sandbox/__tests__/proxySandbox.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { isBoundedFunction } from '../../utils';
-import { setProxyPropertyGetter } from '../common';
+import { attachDocProxySymbol } from '../common';
 import ProxySandbox from '../proxySandbox';
 
 beforeAll(() => {
@@ -182,19 +182,17 @@ test('hasOwnProperty should always returns same reference', () => {
   expect(proxy.testA.hasOwnProperty).toBe(proxy.testB.hasOwnProperty);
 });
 
-test('property getter should just called once', () => {
-  const countFn = jest.fn();
-  const proxy = new ProxySandbox('property-getter-test').proxy as any;
-  setProxyPropertyGetter(proxy, 'document', () => {
-    countFn();
-    return document;
-  });
+test('document accessing should modify the attachDocProxySymbol value every time', () => {
+  const proxy1 = new ProxySandbox('doc-access-test1').proxy as any;
+  const proxy2 = new ProxySandbox('doc-access-test2').proxy as any;
 
-  const d1 = proxy.document;
-  const d2 = proxy.document;
+  const d1 = proxy1.document;
+  expect(d1[attachDocProxySymbol]).toBe(proxy1);
+  const d2 = proxy2.document;
+  expect(d2[attachDocProxySymbol]).toBe(proxy2);
 
   expect(d1).toBe(d2);
-  expect(countFn).toBeCalledTimes(1);
+  expect(d1).toBe(document);
 });
 
 test('bounded function should not be rebounded', () => {

--- a/src/sandbox/common.ts
+++ b/src/sandbox/common.ts
@@ -5,6 +5,14 @@
 
 import { isBoundedFunction, isCallable, isConstructable } from '../utils';
 
+export const attachDocProxySymbol = Symbol('attach-proxy-container');
+
+declare global {
+  interface Document {
+    [attachDocProxySymbol]: WindowProxy;
+  }
+}
+
 const boundValueSymbol = Symbol('bound value');
 
 export function getTargetValue(target: any, value: any): any {
@@ -27,7 +35,6 @@ export function getTargetValue(target: any, value: any): any {
   return value;
 }
 
-const proxyPropertyGetterMap = new Map<WindowProxy, Record<PropertyKey, CallableFunction>>();
 const getterInvocationResultMap = new Map<CallableFunction, any>();
 
 export function getProxyPropertyValue(getter: CallableFunction) {
@@ -39,21 +46,4 @@ export function getProxyPropertyValue(getter: CallableFunction) {
   }
 
   return getterResult;
-}
-
-export function getProxyPropertyGetter(proxy: WindowProxy, property: PropertyKey): any {
-  const getters = proxyPropertyGetterMap.get(proxy);
-  if (getters) {
-    return getters![property as string];
-  }
-
-  return undefined;
-}
-
-export function setProxyPropertyGetter(proxy: WindowProxy, property: PropertyKey, getter: () => any): Function {
-  const prevGetters = proxyPropertyGetterMap.get(proxy) || {};
-  proxyPropertyGetterMap.set(proxy, { ...prevGetters, [property]: getter });
-  return function deleteProxyPropertyGetter() {
-    proxyPropertyGetterMap.delete(proxy);
-  };
 }

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -25,6 +25,8 @@ export { css } from './patchers';
  * @param appName
  * @param elementGetter
  * @param singular
+ * @param scopedCSS
+ * @param excludeAssetFilter
  */
 export function createSandbox(
   appName: string,

--- a/src/sandbox/patchers/dynamicAppend.ts
+++ b/src/sandbox/patchers/dynamicAppend.ts
@@ -33,7 +33,7 @@ const SCRIPT_TAG_NAME = 'SCRIPT';
 const LINK_TAG_NAME = 'LINK';
 const STYLE_TAG_NAME = 'STYLE';
 
-const sandboxInfoMapper = new Map<WindowProxy, Record<string, any>>();
+const proxyContainerInfoMapper = new Map<WindowProxy, Record<string, any>>();
 
 /**
  * Check if a style element is a styled-component liked.
@@ -299,7 +299,7 @@ function patchDocumentCreateElement(
     return noop;
   }
 
-  sandboxInfoMapper.set(proxy, { appName, proxy, appWrapperGetter, dynamicStyleSheetElements, singular });
+  proxyContainerInfoMapper.set(proxy, { appName, proxy, appWrapperGetter, dynamicStyleSheetElements, singular });
 
   if (Document.prototype.createElement === rawDocumentCreateElement) {
     Document.prototype.createElement = function createElement<K extends keyof HTMLElementTagNameMap>(
@@ -309,7 +309,7 @@ function patchDocumentCreateElement(
     ): HTMLElement {
       const element = rawDocumentCreateElement.call(this, tagName, options);
       if (tagName?.toLowerCase() === 'style' || tagName?.toLowerCase() === 'script') {
-        const proxyContainerInfo = sandboxInfoMapper.get(this[attachDocProxySymbol]);
+        const proxyContainerInfo = proxyContainerInfoMapper.get(this[attachDocProxySymbol]);
         if (proxyContainerInfo) {
           Object.defineProperty(element, attachElementContainerSymbol, {
             value: proxyContainerInfo,
@@ -323,7 +323,7 @@ function patchDocumentCreateElement(
   }
 
   return function unpatch(recoverPrototype: boolean) {
-    sandboxInfoMapper.delete(proxy);
+    proxyContainerInfoMapper.delete(proxy);
     if (recoverPrototype) {
       Document.prototype.createElement = rawDocumentCreateElement;
     }

--- a/src/sandbox/patchers/dynamicAppend.ts
+++ b/src/sandbox/patchers/dynamicAppend.ts
@@ -288,7 +288,7 @@ function patchHTMLDynamicAppendPrototypeFunctions(
   };
 }
 
-function patchDocumentCreate(
+function patchDocumentCreateElement(
   appName: string,
   appWrapperGetter: () => HTMLElement | ShadowRoot,
   singular: boolean,
@@ -310,10 +310,12 @@ function patchDocumentCreate(
       const element = rawDocumentCreateElement.call(this, tagName, options);
       if (tagName?.toLowerCase() === 'style' || tagName?.toLowerCase() === 'script') {
         const proxyContainerInfo = sandboxInfoMapper.get(this[attachDocProxySymbol]);
-        Object.defineProperty(element, attachElementContainerSymbol, {
-          value: proxyContainerInfo,
-          enumerable: false,
-        });
+        if (proxyContainerInfo) {
+          Object.defineProperty(element, attachElementContainerSymbol, {
+            value: proxyContainerInfo,
+            enumerable: false,
+          });
+        }
       }
 
       return element;
@@ -354,7 +356,7 @@ export default function patch(
 ): Freer {
   let dynamicStyleSheetElements: Array<HTMLLinkElement | HTMLStyleElement> = [];
 
-  const unpatchDocumentCreate = patchDocumentCreate(
+  const unpatchDocumentCreate = patchDocumentCreateElement(
     appName,
     appWrapperGetter,
     singular,

--- a/src/sandbox/proxySandbox.ts
+++ b/src/sandbox/proxySandbox.ts
@@ -5,7 +5,7 @@
  */
 import { SandBox, SandBoxType } from '../interfaces';
 import { uniq } from '../utils';
-import { getProxyPropertyGetter, getProxyPropertyValue, getTargetValue } from './common';
+import { attachDocProxySymbol, getTargetValue } from './common';
 import { clearSystemJsProps, interceptSystemJsProps } from './noise/systemjs';
 
 // zone.js will overwrite Object.defineProperty
@@ -62,7 +62,6 @@ function createFakeWindow(global: Window) {
           p === 'top' ||
           p === 'self' ||
           p === 'window' ||
-          p === 'document' ||
           (process.env.NODE_ENV === 'test' && (p === 'mockTop' || p === 'mockSafariTop'))
         ) {
           descriptor.configurable = true;
@@ -102,9 +101,9 @@ export default class ProxySandbox implements SandBox {
 
   name: string;
 
-  proxy: WindowProxy;
-
   type: SandBoxType;
+
+  proxy: WindowProxy;
 
   sandboxRunning = true;
 
@@ -177,10 +176,10 @@ export default class ProxySandbox implements SandBox {
           return hasOwnProperty;
         }
 
-        // call proxy getter interceptors
-        const proxyPropertyGetter = getProxyPropertyGetter(proxy, p);
-        if (proxyPropertyGetter) {
-          return getProxyPropertyValue(proxyPropertyGetter);
+        // mark the symbol to document while accessing as document.createElement could know is invoked by which sandbox for dynamic append patcher
+        if (p === 'document') {
+          document[attachDocProxySymbol] = proxy;
+          return document;
         }
 
         // eslint-disable-next-line no-bitwise


### PR DESCRIPTION
changelist:
1. 合并了 appendChild 和 insertBefore 方法的重写
2. 不再代理 document，改为重写 Document.prototype.createElement 并从 this 中确认当前沙箱身份

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- resolve https://github.com/umijs/qiankun/issues/841
- resolve https://github.com/umijs/qiankun/issues/668
- resolve https://github.com/umijs/qiankun/issues/634

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/qiankun/846)
<!-- Reviewable:end -->
