### PR TITLE
完善isSlowNetwork方法的判断逻辑

### DIFF
--- a/src/prefetch.ts
+++ b/src/prefetch.ts
@@ -64,7 +64,7 @@ const isSlowNetwork = navigator.connection
  */
 function prefetch(entry: Entry, opts?: ImportEntryOpts): void {
   if (!navigator.onLine || isSlowNetwork) {
-    // Don't prefetch if in a slow network.
+    // Don't prefetch if in a slow network or offline
     return;
   }
 

--- a/src/prefetch.ts
+++ b/src/prefetch.ts
@@ -51,11 +51,13 @@ const requestIdleCallback =
   };
 
 const isSlowNetwork = navigator.connection
-  ? navigator.connection.saveData ||
+  ? !navigator.onLine ||
+    navigator.connection.saveData ||
     (navigator.connection.type !== 'wifi' &&
       navigator.connection.type !== 'ethernet' &&
       /(2|3)g/.test(navigator.connection.effectiveType))
   : false;
+
 
 /**
  * prefetch assets, do nothing while in mobile network

--- a/src/prefetch.ts
+++ b/src/prefetch.ts
@@ -51,13 +51,11 @@ const requestIdleCallback =
   };
 
 const isSlowNetwork = navigator.connection
-  ? !navigator.onLine ||
-    navigator.connection.saveData ||
+  ? navigator.connection.saveData ||
     (navigator.connection.type !== 'wifi' &&
       navigator.connection.type !== 'ethernet' &&
       /(2|3)g/.test(navigator.connection.effectiveType))
   : false;
-
 
 /**
  * prefetch assets, do nothing while in mobile network
@@ -65,7 +63,7 @@ const isSlowNetwork = navigator.connection
  * @param opts
  */
 function prefetch(entry: Entry, opts?: ImportEntryOpts): void {
-  if (isSlowNetwork) {
+  if (!navigator.onLine || isSlowNetwork) {
     // Don't prefetch if in a slow network.
     return;
   }


### PR DESCRIPTION
完善isSlowNetwork方法的判断逻辑 -- effectiveType属性是使用[最近一次]的值,所以比如上一次是4g,当前是断网的话会判定为还是4g，从而再去做预加载操作，导致多N个404错误以及无效的404报警

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL
