### PR TITLE
proxySandbox  code causes the main application to insert style link script errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "docs:dev": "dumi dev",
     "docs:build": "dumi build",
     "ci": "yarn lint && yarn test",
-    "test": "NODE_ENV=test jest"
+    "test": "cross-env NODE_ENV=test jest"
   },
   "repository": {
     "type": "git",
@@ -73,6 +73,7 @@
     "@umijs/fabric": "^2.0.7",
     "babel-plugin-import": "^1.12.1",
     "check-prettier": "^1.0.3",
+    "cross-env": "7.0.2",
     "dumi": "^1.0.24",
     "father-build": "^1.7.0",
     "husky": "^2.3.0",

--- a/src/sandbox/__tests__/proxySandbox.test.ts
+++ b/src/sandbox/__tests__/proxySandbox.test.ts
@@ -5,6 +5,7 @@
 
 import { isBoundedFunction } from '../../utils';
 import { attachDocProxySymbol } from '../common';
+import './util';
 import ProxySandbox from '../proxySandbox';
 
 beforeAll(() => {
@@ -190,9 +191,10 @@ test('document accessing should modify the attachDocProxySymbol value every time
   expect(d1[attachDocProxySymbol]).toBe(proxy1);
   const d2 = proxy2.document;
   expect(d2[attachDocProxySymbol]).toBe(proxy2);
-
-  expect(d1).toBe(d2);
-  expect(d1).toBe(document);
+  // d1 d2 should be different
+  expect(d1 !== d2).toBeTruthy();
+  // d1 should be different from document
+  expect(d1 !== document).toBeTruthy();
 });
 
 test('bounded function should not be rebounded', () => {

--- a/src/sandbox/__tests__/util.ts
+++ b/src/sandbox/__tests__/util.ts
@@ -1,0 +1,9 @@
+// for pass import-html-entry [import-html-entry] Here is no "fetch" on the window env, you need to polyfill it
+Object.defineProperty(window, 'fetch', {
+  get() {
+    return () => {};
+  },
+  set() {},
+  configurable: false,
+  enumerable: false,
+});

--- a/src/sandbox/patchers/dynamicAppend.ts
+++ b/src/sandbox/patchers/dynamicAppend.ts
@@ -6,6 +6,7 @@ import { execScripts } from 'import-html-entry';
 import { isFunction, noop } from 'lodash';
 import { checkActivityFunctions } from 'single-spa';
 import { frameworkConfiguration } from '../../apis';
+import { sleep } from '../../utils';
 import { Freer } from '../../interfaces';
 import * as css from './css';
 
@@ -70,7 +71,7 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
   scopedCSS: boolean;
   excludeAssetFilter?: CallableFunction;
 }) {
-  return function appendChildOrInsertBefore<T extends Node>(
+  return async function appendChildOrInsertBefore<T extends Node>(
     this: HTMLHeadElement | HTMLBodyElement,
     newChild: T,
     refChild?: Node | null,
@@ -95,7 +96,9 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
         // eslint-disable-next-line prefer-destructuring
         proxy = storedContainerInfo.proxy;
       }
-
+      if (singular) {
+        await sleep(0);
+      }
       const invokedByMicroApp = singular
         ? // check if the currently specified application is active
           // While we switch page from qiankun app to a normal react routing page, the normal one may load stylesheet dynamically while page rendering,

--- a/src/sandbox/snapshotSandbox.ts
+++ b/src/sandbox/snapshotSandbox.ts
@@ -33,6 +33,11 @@ export default class SnapshotSandbox implements SandBox {
     this.name = name;
     this.proxy = window;
     this.type = SandBoxType.Snapshot;
+    // 初始化当前快照
+    this.windowSnapshot = {} as Window;
+    iter(window, prop => {
+      this.windowSnapshot[prop] = window[prop];
+    });
   }
 
   active() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included

##### Description of change
主要修改以下问题

1. npm test 兼容各平台
2. snapshotSandbox sandboxRunning 默认为`ture`，因此首次`active`被调用时直接return 导致 `windowSnapshot` 未被赋值 在首次 `inactive` 时[if (window[prop] !== this.windowSnapshot[prop])](https://github.com/umijs/qiankun/blob/master/src/sandbox/snapshotSandbox.ts#L61)报 `windowSnapshot` `undefined` 错误
3. 解决 各个 sandbox 主框架及子应用 插入 `style` `link` `script` 标签当前环境识别错误问题 主要是主框架识别错误 [相关issues #578](https://github.com/umijs/qiankun/issues/578)

   1. multiple mode proxySandbox

       1. multiple mode `proxySandbox` 下子应用中调用的是`window` 的 `proxy` 代理对象，在获取`document`时，会自动给`document`上自动赋值当前proxy [document[attachDocProxySymbol] = proxy;](https://github.com/umijs/qiankun/blob/master/src/sandbox/proxySandbox.ts#L182)，配合 dynamicAppend 中 [const proxyContainerInfo = proxyContainerInfoMapper.get(this[attachDocProxySymbol]);](https://github.com/umijs/qiankun/blob/master/src/sandbox/patchers/dynamicAppend.ts#L326)来获取子应用的环境配置.
       2. 在子应用下没有问题，但是使用的`document`是原始对象，同时没有相应的释放机制，导致主框架在微应用加载后插入时会读到最后一个微应用`proxy`，插入 `style` `link` `script` 时被误判为相应的微应用环境，导致主框架脚本或样式丢失，
       3. 因此子应用`document`也通过代理去设置，在代理过程中去设置`createElement`，`attachDocProxySymbol`作用更多是标识是否初始化`createElement`，这样在子应用中不会污染到主框架的`createElement`，主框架在插入就不会识别错误

   2. singler mode proxySandbox
       1. 首先 `snapshotSandbox` 及旧版的 `proxySandbox` 共用了一个window实例，导致各个hack方法需要提前赋值.
       2. 因此刷新子应用，从子应用跳转到主应用时，主应用插入 `style` `link` `script` 时，通过[let { appName，appWrapperGetter，proxy，singular，dynamicStyleSheetElements } = opts;](https://github.com/umijs/qiankun/blob/master/src/sandbox/patchers/dynamicAppend.ts#L83)能获取子应用的配置，由于single-spa unmount等操作都是异步的及vue框架下主应用插入时机比浏览器地址切换时机要快[在#578示例里表现是这样](https://github.com/umijs/qiankun/issues/578)，因此通过[checkActivityFunctions(window.location).some(name => name === appName)](https://github.com/umijs/qiankun/blob/master/src/sandbox/patchers/dynamicAppend.ts#L107) 或 `singleSpa.getAppStatus(appName)` 都无法判断是否处于主应用环境，导致主框架脚本或样式丢失.
       3. 旧版的 proxySandbox的proxy模式不够彻底，不能复用multiple mode proxySandbox解决方案，所以在 singler 模式下插入时延迟了一个微任务时差来解决改问题. **由于存在延迟，该方案需要实践验证是否可行** [在#578示例验证通过](https://github.com/umijs/qiankun/issues/578)

close https://github.com/umijs/qiankun/issues/578
