### PR TITLE
:bug: allow window.top & window.parent to escape sandbox while in iframe

### DIFF
--- a/src/sandbox/__tests__/proxySandbox.test.ts
+++ b/src/sandbox/__tests__/proxySandbox.test.ts
@@ -42,14 +42,26 @@ test('iterator should be worked the same as the raw window', () => {
   expect(Object.keys(proxy)).toEqual([...Object.keys(window), 'additionalProp']);
 });
 
-test('window.top & window.self & window.window should equals with sandbox', () => {
+test('window.self & window.window & window.top & window.parent should equals with sandbox', () => {
   const { proxy } = new ProxySandbox('unit-test');
+
+  expect(proxy.self).toBe(proxy);
+  expect(proxy.window).toBe(proxy);
 
   expect((<any>proxy).mockTop).toBe(proxy);
   expect((<any>proxy).mockSafariTop).toBe(proxy);
   expect(proxy.top).toBe(proxy);
-  expect(proxy.self).toBe(proxy);
-  expect(proxy.window).toBe(proxy);
+  expect(proxy.parent).toBe(proxy);
+});
+
+test('allow window.top & window.parent to escape sandbox while in iframe', () => {
+  // change window.parent to cheat ProxySandbox is in iframe
+  Object.defineProperty(window, 'parent', { value: 'parent' });
+  Object.defineProperty(window, 'top', { value: 'top' });
+  const { proxy } = new ProxySandbox('iframe-test');
+
+  expect(proxy.top).toBe('top');
+  expect(proxy.parent).toBe('parent');
 });
 
 test('eval should never be represented', () => {

--- a/src/sandbox/proxySandbox.ts
+++ b/src/sandbox/proxySandbox.ts
@@ -174,9 +174,8 @@ export default class ProxySandbox implements SandBox {
           // if your master app in an iframe context, allow these props escape the sandbox
           if (rawWindow === rawWindow.parent) {
             return proxy;
-          } 
-            return (rawWindow as any)[p];
-          
+          }
+          return (rawWindow as any)[p];
         }
 
         // proxy.hasOwnProperty would invoke getter firstly, then its value represented as rawWindow.hasOwnProperty


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL


如果整个应用以 iframe 的形式被嵌入，那么应该允许 window.parent 和 window.top 逃逸出沙箱

