### PR TITLE
:bug: Allows the use of tag elements during script tag trigger events

### DIFF
--- a/src/sandbox/patchers/dynamicAppend.ts
+++ b/src/sandbox/patchers/dynamicAppend.ts
@@ -61,7 +61,7 @@ function setCachedRules(element: HTMLStyleElement, cssRules: CSSRuleList) {
   Object.defineProperty(element, styledComponentSymbol, { value: cssRules, configurable: true, enumerable: false });
 }
 
-function patchedCustomEvent(e: CustomEvent, elementGetter: () => HTMLScriptElement | null): CustomEvent {
+function patchCustomEvent(e: CustomEvent, elementGetter: () => HTMLScriptElement | null): CustomEvent {
   Object.defineProperties(e, {
     srcElement: {
       get: elementGetter,

--- a/src/sandbox/patchers/dynamicAppend.ts
+++ b/src/sandbox/patchers/dynamicAppend.ts
@@ -61,6 +61,18 @@ function setCachedRules(element: HTMLStyleElement, cssRules: CSSRuleList) {
   Object.defineProperty(element, styledComponentSymbol, { value: cssRules, configurable: true, enumerable: false });
 }
 
+function patchedCustomEvent(e: CustomEvent, elementGetter: () => HTMLScriptElement | null): CustomEvent {
+  Object.defineProperties(e, {
+    srcElement: {
+      get: elementGetter,
+    },
+    target: {
+      get: elementGetter,
+    },
+  });
+  return e;
+}
+
 function getOverwrittenAppendChildOrInsertBefore(opts: {
   appName: string;
   proxy: WindowProxy;
@@ -159,7 +171,7 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
                 // 2. addEventListener way, which toast-loader used, see https://github.com/pyrsmk/toast/blob/master/src/Toast.ts#L64
                 const loadEvent = new CustomEvent('load');
                 if (isFunction(element.onload)) {
-                  element.onload(loadEvent);
+                  element.onload(patchedCustomEvent(loadEvent, () => element));
                 } else {
                   element.dispatchEvent(loadEvent);
                 }
@@ -169,7 +181,7 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
               error: () => {
                 const errorEvent = new CustomEvent('error');
                 if (isFunction(element.onerror)) {
-                  element.onerror(errorEvent);
+                  element.onerror(patchedCustomEvent(errorEvent, () => element));
                 } else {
                   element.dispatchEvent(errorEvent);
                 }

--- a/src/sandbox/patchers/dynamicAppend.ts
+++ b/src/sandbox/patchers/dynamicAppend.ts
@@ -181,7 +181,7 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
               error: () => {
                 const errorEvent = new CustomEvent('error');
                 if (isFunction(element.onerror)) {
-                  element.onerror(patchedCustomEvent(errorEvent, () => element));
+                  element.onerror(patchCustomEvent(errorEvent, () => element));
                 } else {
                   element.dispatchEvent(errorEvent);
                 }

--- a/src/sandbox/patchers/dynamicAppend.ts
+++ b/src/sandbox/patchers/dynamicAppend.ts
@@ -171,7 +171,7 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
                 // 2. addEventListener way, which toast-loader used, see https://github.com/pyrsmk/toast/blob/master/src/Toast.ts#L64
                 const loadEvent = new CustomEvent('load');
                 if (isFunction(element.onload)) {
-                  element.onload(patchedCustomEvent(loadEvent, () => element));
+                  element.onload(patchCustomEvent(loadEvent, () => element));
                 } else {
                   element.dispatchEvent(loadEvent);
                 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

当我们在接入qiankun的时候，
发现其中的一个子项目有报错，
跟踪堆栈发现，是因为那个子项目中对于script标签都进行了onload事件监听，
并且使用了事件对象的target属性来获取src。

下面是伪代码：
```js
srcipt.onload = function(e) {
  console.log(e.target.src)
}
```

由于qiankun派发的自定义事件中没有定义target，
所以报错了，
这个PR中的getPatchedCustomEvent方法为以后可能需要添加更多属性提供了准备。
