### PR TITLE
🐛  fix NodeList forEach method compatibility problem

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -4,7 +4,7 @@
  */
 
 import { importEntry } from 'import-html-entry';
-import { concat, mergeWith } from 'lodash';
+import { concat, mergeWith, forEach } from 'lodash';
 import { LifeCycles, ParcelConfigObject } from 'single-spa';
 import getAddOns from './addons';
 import { getMicroAppStateActions } from './globalState';
@@ -242,7 +242,7 @@ export async function loadApp<T extends object>(
   let element: HTMLElement | null = createElement(appContent, strictStyleIsolation);
   if (element && isEnableScopedCSS(configuration)) {
     const styleNodes = element.querySelectorAll('style') || [];
-    styleNodes.forEach(stylesheetElement => {
+    forEach(styleNodes, (stylesheetElement: HTMLStyleElement) => {
       css.process(element!, stylesheetElement, appName);
     });
   }


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change

`const styleNodes = element.querySelectorAll('style')` 返回的是NodeList，在chrome51才开始支持，兼容之。

![image](https://user-images.githubusercontent.com/4470552/94425674-e6a63b80-01be-11eb-8894-7174688b3608.png)
