### PR TITLE
⚡️ cache for loadMicroApp

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,4 +14,9 @@ module.exports = {
     'no-underscore-dangle': 0,
     'no-plusplus': 0,
   },
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.json',
+    createDefaultProgram: true,
+  },
 };

--- a/examples/main/multiple.js
+++ b/examples/main/multiple.js
@@ -9,6 +9,15 @@ const app1 = loadMicroApp(
   },
 );
 
+// for cached scenario
+setTimeout(() => {
+  app1.unmount();
+
+  setTimeout(() => {
+    loadMicroApp({ name: 'react15', entry: '//localhost:7102', container: '#react15' });
+  }, 1000 * 5);
+}, 1000 * 5);
+
 const app2 = loadMicroApp(
   { name: 'vue', entry: '//localhost:7101', container: '#vue' },
   {

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,4 +1,11 @@
-import { getWrapperId, getDefaultTplWrapper, validateExportLifecycle, sleep, Deferred } from '../utils';
+import {
+  Deferred,
+  getDefaultTplWrapper,
+  getWrapperId,
+  getXPathForElement,
+  sleep,
+  validateExportLifecycle,
+} from '../utils';
 
 test('should wrap the id [1]', () => {
   const id = 'REACT16';
@@ -85,4 +92,23 @@ test('Deferred should worked [2]', async () => {
   }
 
   expect(err).toBeInstanceOf(Error);
+});
+
+test('should getXPathForElement work well', () => {
+  const article = document.createElement('article');
+  article.innerHTML = `
+    <div>
+      <div></div>
+      <div id="testNode"></div>
+      <div></div>
+    </div>
+  `;
+
+  document.body.appendChild(article);
+  const testNode = document.querySelector('#testNode');
+  const xpath = getXPathForElement(testNode!, document);
+  expect(xpath).toEqual(
+    // eslint-disable-next-line max-len
+    `/*[name()='HTML' and namespace-uri()='http://www.w3.org/1999/xhtml']/*[name()='BODY' and namespace-uri()='http://www.w3.org/1999/xhtml'][1]/*[name()='ARTICLE' and namespace-uri()='http://www.w3.org/1999/xhtml'][1]/*[name()='DIV' and namespace-uri()='http://www.w3.org/1999/xhtml'][1]/*[name()='DIV' and namespace-uri()='http://www.w3.org/1999/xhtml'][2]`,
+  );
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,3 +126,40 @@ export function isEnableScopedCSS(opt: FrameworkConfiguration) {
 
   return !!opt.sandbox.experimentalStyleIsolation;
 }
+
+/**
+ * copy from https://developer.mozilla.org/zh-CN/docs/Using_XPath
+ * @param el
+ * @param xml
+ */
+export function getXPathForElement(el: Node, xml: Document) {
+  let xpath = '';
+  let pos;
+  let tmpEle;
+  let element = el;
+
+  while (element !== xml.documentElement) {
+    pos = 0;
+    tmpEle = element;
+    while (tmpEle) {
+      if (tmpEle.nodeType === 1 && tmpEle.nodeName === element.nodeName) {
+        // If it is ELEMENT_NODE of the same name
+        pos += 1;
+      }
+      tmpEle = tmpEle.previousSibling;
+    }
+
+    xpath = `*[name()='${element.nodeName}' and namespace-uri()='${
+      element.namespaceURI === null ? '' : element.namespaceURI
+    }'][${pos}]/${xpath}`;
+
+    element = element.parentNode!;
+  }
+
+  xpath = `/*[name()='${xml.documentElement.nodeName}' and namespace-uri()='${
+    element.namespaceURI === null ? '' : element.namespaceURI
+  }']/${xpath}`;
+  xpath = xpath.replace(/\/$/, '');
+
+  return xpath;
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

ref https://github.com/umijs/qiankun/issues/518

简版缓存，通过 container 的 xpath + appName 的方式来判断后续的渲染是否要沿用之前已经计算过的 lifecycles，从而减少不必要的二次 load 的开销

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/qiankun/986)
<!-- Reviewable:end -->
