### PR TITLE
fix: 修复qiankun本身在沙箱下运行时，可能出现无法劫持document.createElement元素问题

### DIFF
--- a/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
@@ -25,9 +25,12 @@ function patchDocumentCreateElement() {
       tagName: K,
       options?: ElementCreationOptions,
     ): HTMLElement {
+      // 这里必须使用this，因为原生的createElement方法调用上下文必须是原始的document对象，否则会出现`Uncaught TypeError: Illegal invocation`
       const element = rawDocumentCreateElement.call(this, tagName, options);
       if (isHijackingTag(tagName)) {
-        const attachProxy = documentAttachProxyMap.get(this);
+        // 这里使用document来获取比this更加健壮，因为之前set的时候是传入的document：
+        // 因为document不一定是原生的document，这种情况出现在qiankun本身就在另一个沙箱下运行的情况，而那个沙箱可能连document都重写了。
+        const attachProxy = documentAttachProxyMap.get(document);
         if (attachProxy) {
           const proxyContainerConfig = proxyAttachContainerConfigMap.get(attachProxy);
           if (proxyContainerConfig) {

--- a/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
@@ -25,7 +25,6 @@ function patchDocumentCreateElement() {
       tagName: K,
       options?: ElementCreationOptions,
     ): HTMLElement {
-      // 这里必须使用this，因为原生的createElement方法调用上下文必须是原始的document对象，否则会出现`Uncaught TypeError: Illegal invocation`
       const element = rawDocumentCreateElement.call(this, tagName, options);
       if (isHijackingTag(tagName)) {
         // 这里使用document来获取比this更加健壮，因为之前set的时候是传入的document：


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- 优化了沙箱劫持document.createElement的逻辑： 当qiankun运行在另一个沙箱下的时候，可能document已经被重写为新的实例，这个时候在`documentAttachProxyMap`内存储的是被重写document实例，而在`patchDocumentCreateElement`获取的时候，this指向的是原生的document，会导致无法获取`attachProxy`
