### PR TITLE
feat: automatically open project demo in browser when running examples

### DIFF
--- a/examples/main/webpack.config.js
+++ b/examples/main/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   entry: process.env.MODE === 'multiple' ? './multiple.js' : './index.js',
   devtool: 'source-map',
   devServer: {
+    open: true,
     port: '7099',
     clientLogLevel: 'warning',
     disableHostCheck: true,


### PR DESCRIPTION
##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- Automatically open browser after main app is built
- close https://github.com/umijs/qiankun/issues/1082
