### PR TITLE
修复切换vue3时编译失败的问题;

### DIFF
--- a/examples/vue3/src/components/HelloWorld.vue
+++ b/examples/vue3/src/components/HelloWorld.vue
@@ -46,9 +46,9 @@ export default {
 };
 </script>
 
-<style vars="{nameColor}">
+<style>
 .name {
-  color: var(--nameColor);
+  color: v-bind(nameColor);
 }
 </style>
 


### PR DESCRIPTION
Module Error (from ./node_modules/vue-loader-v16/dist/index.js):

<style vars> has been replaced by a new proposal: https://github.com/vuejs/rfcs/pull/231
 

##### Checklist
- [√] `npm test` passes
- [√] tests are included
- [√] documentation is changed or added
- [√] commit message follows commit guidelines


##### remarks
本次PR 为 https://github.com/umijs/qiankun/pull/1135 的沟通后重新PR, 合并本次后, 可关闭1135
