### PR TITLE
🐛 Make sure singular is always false when using loadMicroApp

### DIFF
--- a/src/apis.ts
+++ b/src/apis.ts
@@ -76,8 +76,8 @@ export function loadMicroApp<T extends object = {}>(
    * the micro app would not load and evaluate its lifecycles again
    */
   const memorizedLoadingFn = async (): Promise<ParcelConfigObject> => {
-    frameworkConfiguration.singular = false;
-    const { $$cacheLifecycleByAppName } = configuration ?? frameworkConfiguration;
+    const userConfiguration = configuration ?? { ...frameworkConfiguration, singular: false };
+    const { $$cacheLifecycleByAppName } = userConfiguration;
     const container = 'container' in app ? app.container : undefined;
 
     if (container) {
@@ -94,7 +94,7 @@ export function loadMicroApp<T extends object = {}>(
       }
     }
 
-    const parcelConfigObjectGetterPromise = loadApp(app, configuration ?? frameworkConfiguration, lifeCycles);
+    const parcelConfigObjectGetterPromise = loadApp(app, userConfiguration, lifeCycles);
 
     if (container) {
       if ($$cacheLifecycleByAppName) {

--- a/src/apis.ts
+++ b/src/apis.ts
@@ -52,7 +52,7 @@ export function loadMicroApp<T extends object = {}>(
   lifeCycles?: FrameworkLifeCycles<T>,
 ): MicroApp {
   const { props, name } = app;
-  
+
   const getContainerXpath = (container: string | HTMLElement): string | void => {
     const containerElement = getContainer(container);
     if (containerElement) {

--- a/src/apis.ts
+++ b/src/apis.ts
@@ -52,7 +52,7 @@ export function loadMicroApp<T extends object = {}>(
   lifeCycles?: FrameworkLifeCycles<T>,
 ): MicroApp {
   const { props, name } = app;
-
+  
   const getContainerXpath = (container: string | HTMLElement): string | void => {
     const containerElement = getContainer(container);
     if (containerElement) {
@@ -76,6 +76,7 @@ export function loadMicroApp<T extends object = {}>(
    * the micro app would not load and evaluate its lifecycles again
    */
   const memorizedLoadingFn = async (): Promise<ParcelConfigObject> => {
+    frameworkConfiguration.singular = false;
     const { $$cacheLifecycleByAppName } = configuration ?? frameworkConfiguration;
     const container = 'container' in app ? app.container : undefined;
 


### PR DESCRIPTION

##### Checklist

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Description of change

如果先使用 `start` 函数，默认的 `singular` 值会变成 `true`，再使用 `loadMicroApp` ， `singular`  就还是 `true`
