### PR TITLE
fix: fix proxyWindow setter

### DIFF
--- a/src/sandbox/proxySandbox.ts
+++ b/src/sandbox/proxySandbox.ts
@@ -181,7 +181,7 @@ export default class ProxySandbox implements SandBox {
           if (!target.hasOwnProperty(p) && rawWindow.hasOwnProperty(p)) {
             const descriptor = Object.getOwnPropertyDescriptor(rawWindow, p);
             const { writable, configurable, enumerable } = descriptor!;
-            if (writable) {
+            if (writable || typeof writable === 'undefined') {
               Object.defineProperty(target, p, {
                 configurable,
                 enumerable,


### PR DESCRIPTION
##### Description of change

window自带read-only属性比如window.name的writeable是undefined，在chrome和firefox里面都是这么实现，所以window.name其实可以修改，按照原来逻辑会导致proxyWindow上的name无法修改，和rawWindow不一致。
