### PR TITLE
feat(loader): pass single-spa props to frameworkLifeCycles

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,7 +3,7 @@
  * @since 2019-05-16
  */
 import type { ImportEntryOpts } from 'import-html-entry';
-import type { RegisterApplicationConfig, StartOpts, Parcel } from 'single-spa';
+import type { RegisterApplicationConfig, StartOpts, Parcel, AppProps } from 'single-spa';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -88,7 +88,11 @@ type QiankunSpecialOpts = {
 };
 export type FrameworkConfiguration = QiankunSpecialOpts & ImportEntryOpts & StartOpts;
 
-export type LifeCycleFn<T extends ObjectType> = (app: LoadableApp<T>, global: typeof window) => Promise<any>;
+export type LifeCycleFn<T extends ObjectType> = (
+  app: LoadableApp<T>,
+  global: typeof window,
+  props?: AppProps,
+) => Promise<any>;
 export type FrameworkLifeCycles<T extends ObjectType> = {
   beforeLoad?: LifeCycleFn<T> | Array<LifeCycleFn<T>>; // function before app load
   beforeMount?: LifeCycleFn<T> | Array<LifeCycleFn<T>>; // function before app mount


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- 将single-spa生命周期的钩子的参数传递给框架的生命周期函数,以便特殊情况下手动加卸载子应用或者查看子应用状态
