### PR TITLE
fix: catch aborted error

### DIFF
--- a/src/sandbox/patchers/dynamicAppend/common.ts
+++ b/src/sandbox/patchers/dynamicAppend/common.ts
@@ -234,6 +234,9 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
                 manualInvokeElementOnError(element);
                 element = null;
               },
+            }).catch(() => {
+              manualInvokeElementOnError(element);
+              element = null;
             });
 
             const dynamicScriptCommentElement = document.createComment(`dynamic script ${src} replaced by qiankun`);


### PR DESCRIPTION
当用户取消 fetch js 资源，需要捕捉异常，然后抛出。
当然用户可以在 fetch 内部捕捉，非必要补丁，若有其他场景考虑，请关闭。

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

因业务场景与架构有所不同，在处理当页面切换时候，懒加载资源还没加载完，我采用了 abort 沙箱内部的 fetch 实例方式，取消前个页面的所有未加载完的资源。

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL
