### PR TITLE
Fix the rendering issue when subapp-container is not present in the DOM

### DIFF
--- a/examples/main/render/ReactRender.jsx
+++ b/examples/main/render/ReactRender.jsx
@@ -16,6 +16,13 @@ function Render(props) {
 }
 
 export default function render({ loading }) {
+  let subappContainer;
   const container = document.getElementById('subapp-container');
-  ReactDOM.render(<Render loading={loading} />, container);
+  if (container == null) {
+    subappContainer = document.createElement('main');
+    subappContainer.setAttribute('id', 'subapp-container');
+    document.body.appendChild(subappContainer);
+  }
+  ReactDOM.render(<Render loading={loading} />, container || subappContainer);
 }
+                  

--- a/examples/react15/App.jsx
+++ b/examples/react15/App.jsx
@@ -5,6 +5,11 @@ import Logo from './components/Logo'
 import HelloModal from './components/HelloModal'
 
 export default class App extends React.Component {
+  
+  componentDidMount() {
+    document.body.innerHTML = "";
+  }
+  
   render() {
     return (
       <div className="react15-main">


### PR DESCRIPTION
This PR fixes the rendering issue. When trying to load a micro app and in the container app sometimes the subapp-container doesn't exist. We get the error cannot mount because the element didn't exist. 
This change handles this gracefully to check if the subapp-container element is present. If not, it creates a placeholder and proceeds with the ReactDOM.render method. Thus, the micro app is loaded onto the container app successfully each time.

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL

