### PR TITLE
🐛 add getPrototypeOf trap in sandbox to keep the `window instanceof Window` returns true in microapp

### DIFF
--- a/src/sandbox/__tests__/proxySandbox.test.ts
+++ b/src/sandbox/__tests__/proxySandbox.test.ts
@@ -332,3 +332,18 @@ test('falsy values should return as expected', () => {
   expect(proxy.nullvar).toBeNull();
   expect(proxy.zero).toBe(0);
 });
+
+it('should return true while [[GetPrototypeOf]] invoked by proxy object', () => {
+  // window.__proto__ not equals window prototype in jest environment
+  // eslint-disable-next-line no-proto
+  expect(window.__proto__ === Object.getPrototypeOf(window)).toBeFalsy();
+  // we must to set the prototype of window as jest modified window `__proto__` property but not changed it internal [[Prototype]] property
+  // eslint-disable-next-line no-proto
+  Object.setPrototypeOf(window, window.__proto__);
+
+  const { proxy } = new ProxySandbox('window-prototype');
+  expect(proxy instanceof Window).toBeTruthy();
+  expect(Object.getPrototypeOf(proxy)).toBe(Object.getPrototypeOf(window));
+  expect(Reflect.getPrototypeOf(proxy)).toBe(Reflect.getPrototypeOf(window));
+  expect(Reflect.getPrototypeOf(proxy)).toBe(Object.getPrototypeOf(window));
+});

--- a/src/sandbox/proxySandbox.ts
+++ b/src/sandbox/proxySandbox.ts
@@ -332,6 +332,11 @@ export default class ProxySandbox implements SandBox {
 
         return true;
       },
+
+      // makes sure `window instanceof Window` returns truthy in micro app
+      getPrototypeOf() {
+        return Reflect.getPrototypeOf(rawWindow);
+      },
     });
 
     this.proxy = proxy;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL