### PR TITLE
convert dynamic append link to style avoid style flash

### DIFF
--- a/src/sandbox/patchers/dynamicAppend/common.ts
+++ b/src/sandbox/patchers/dynamicAppend/common.ts
@@ -174,27 +174,25 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
           }
 
           const mountDOM = appWrapperGetter();
+          // exclude link elements like <link rel="icon" href="favicon.ico">
+          const linkElementUsingStylesheet =
+            element.tagName?.toUpperCase() === LINK_TAG_NAME &&
+            (element as HTMLLinkElement).rel === 'stylesheet' &&
+            (element as HTMLLinkElement).href;
 
-          if (scopedCSS) {
-            // exclude link elements like <link rel="icon" href="favicon.ico">
-            const linkElementUsingStylesheet =
-              element.tagName?.toUpperCase() === LINK_TAG_NAME &&
-              (element as HTMLLinkElement).rel === 'stylesheet' &&
-              (element as HTMLLinkElement).href;
-            if (linkElementUsingStylesheet) {
-              const fetch =
-                typeof frameworkConfiguration.fetch === 'function'
-                  ? frameworkConfiguration.fetch
-                  : frameworkConfiguration.fetch?.fn;
-              stylesheetElement = convertLinkAsStyle(
-                element,
-                (styleElement) => css.process(mountDOM, styleElement, appName),
-                fetch,
-              );
-              dynamicLinkAttachedInlineStyleMap.set(element, stylesheetElement);
-            } else {
-              css.process(mountDOM, stylesheetElement, appName);
-            }
+          if (linkElementUsingStylesheet) {
+            const fetch =
+              typeof frameworkConfiguration.fetch === 'function'
+                ? frameworkConfiguration.fetch
+                : frameworkConfiguration.fetch?.fn;
+            stylesheetElement = convertLinkAsStyle(
+              element,
+              scopedCSS ? (styleElement) => css.process(mountDOM, styleElement, appName) : () => {},
+              fetch,
+            );
+            dynamicLinkAttachedInlineStyleMap.set(element, stylesheetElement);
+          } else if (scopedCSS) {
+            css.process(mountDOM, stylesheetElement, appName);
           }
 
           // eslint-disable-next-line no-shadow


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

Just want to fix a dynamic import style bug, maybe also fix this issue #857 .
Bug demo github link: https://github.com/wanglam/qiankun-dynamic-css-reapply-example

It seems like we need to load dynamic append css files again after sub-app switch. I convert this link element to style element, and will rebuild without network loading on sub-app switch. So the bug fixed.

I can't find some test files about `getOverwrittenAppendChildOrInsertBefore`. So I have not add some test about this change.
I'm not sure if the commit message follow the guideline. I can't open the contributors guide in master branch.


