### PR TITLE
Feat/umd export name

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -229,7 +229,8 @@ A criterion for judging whether the business is closely related: <strong>Look at
     - entry - `string | { scripts?: string[]; styles?: string[]; html?: string }` - Required, The entry of the micro application(The detailed description is the same as above).
     - container - `string | HTMLElement` - Required, selector or Element instance of the container node of the micro application. Such as `container: '#root'` or `container: document.querySelector('#root')`.
     - props - `object` - Optional, the data that needs to be passed to the micro-application during initialization.
-
+    - libraryName - `string` Optional，qiankun will fallback to get `window[name]` as micro-application's lifecycles when it has not been found from entry exports, `libraryName` allows you to manually specify micro-application's umd library name.
+ 
   - configuration - `Configuration` - Optional, configuration information of the micro application
 
     - sandbox - `boolean` | `{ strictStyleIsolation?: boolean, experimentalStyleIsolation?: boolean }` - optional, whether to open the js sandbox, default is `true`.

--- a/docs/api/README.zh.md
+++ b/docs/api/README.zh.md
@@ -233,6 +233,7 @@ toc: menu
     - entry - `string | { scripts?: string[]; styles?: string[]; html?: string }` - 必选，微应用的入口（详细说明同上）。
     - container - `string | HTMLElement` - 必选，微应用的容器节点的选择器或者 Element 实例。如`container: '#root'` 或 `container: document.querySelector('#root')`。
     - props - `object` - 可选，初始化时需要传递给微应用的数据。
+    - libraryName - `string` 可选，手动指定子应用umd的导出变量名（当无法从微应用的entry exports找到生命周期函数时，qiankun会试图读取`window[name]`变量作为生命周期）。
 
   - configuration - `Configuration` - 可选，微应用的配置信息
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -29,6 +29,8 @@ export type HTMLContentRender = (props: { appContent: string; loading: boolean }
 export type AppMetadata = {
   // app name
   name: string;
+  // umd library name
+  libraryName?: string;
   // app entry
   entry: Entry;
 };

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -213,6 +213,7 @@ function getLifecyclesFromExports(
   appName: string,
   global: WindowProxy,
   globalLatestSetProp?: PropertyKey | null,
+  libraryName?: string,
 ) {
   if (validateExportLifecycle(scriptExports)) {
     return scriptExports;
@@ -226,14 +227,16 @@ function getLifecyclesFromExports(
     }
   }
 
+  const exportName = libraryName || appName;
+
   if (process.env.NODE_ENV === 'development') {
     console.warn(
-      `[qiankun] lifecycle not found from ${appName} entry exports, fallback to get from window['${appName}']`,
+      `[qiankun] lifecycle not found from ${appName} entry exports, fallback to get from window['${exportName}']`,
     );
   }
 
-  // fallback to global variable who named with ${appName} while module exports not found
-  const globalVariableExports = (global as any)[appName];
+  // fallback to global variable who named with ${exportName} while module exports not found
+  const globalVariableExports = (global as any)[exportName];
 
   if (validateExportLifecycle(globalVariableExports)) {
     return globalVariableExports;
@@ -251,7 +254,7 @@ export async function loadApp<T extends ObjectType>(
   configuration: FrameworkConfiguration = {},
   lifeCycles?: FrameworkLifeCycles<T>,
 ): Promise<ParcelConfigObjectGetter> {
-  const { entry, name: appName } = app;
+  const { entry, name: appName, libraryName = '' } = app;
   const appInstanceId = `${appName}_${+new Date()}_${Math.floor(Math.random() * 1000)}`;
 
   const markName = `[qiankun] App ${appInstanceId} Loading`;
@@ -337,6 +340,7 @@ export async function loadApp<T extends ObjectType>(
     appName,
     global,
     sandboxContainer?.instance?.latestSetProp,
+    libraryName,
   );
 
   const { onGlobalStateChange, setGlobalState, offGlobalStateChange }: Record<string, CallableFunction> =


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- feat: app配置增加`libraryName`项，用于手动指定子应用的umd library名称（在一些低端机上，当qiankun无法从entry export上面拿到微应用生命周期时会尝试从window对象上获取，默认是取window[appName]，当微应用导出的library name和appName不一致时，需要手动指定）。
