### PR TITLE
✨ loose sandbox support mutaion with defineProperty

### DIFF
--- a/src/sandbox/legacy/__tests__/sandbox.test.ts
+++ b/src/sandbox/legacy/__tests__/sandbox.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @author Kuitos
+ * @since 2021-07-19
+ */
+
+import LooseSandbox from '../sandbox';
+
+describe('loose sandbox', () => {
+  it('should record the mutation from Object.defineProperty', () => {
+    const sandbox = new LooseSandbox('defineProperty');
+
+    const { proxy } = sandbox;
+
+    proxy.prop1 = 123;
+    Object.defineProperty(proxy, 'prop2', { value: 456, configurable: true, writable: true });
+
+    expect(proxy.prop1).toBe(123);
+    expect(window.prop1).toBe(123);
+    expect(proxy.prop2).toBe(456);
+    expect(window.prop2).toBe(456);
+
+    sandbox.inactive();
+
+    expect(window.prop1).toBeUndefined();
+    expect(window.prop2).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

umi mfsu 全量引了 cors-js，而 core-js 中通过 defineProperty 的方式[写了全局变量](https://github.com/zloirock/core-js/blob/c9c4397354f3e43727220ff8b08a3bf6c8c87cb5/packages/core-js/internals/set-global.js#L6)，导致 onex 场景会出错。