### PR TITLE
✨ remove global way for recording current running sandbox to fix nested scenario

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 
 export { loadMicroApp, registerMicroApps, start } from './apis';
 export { initGlobalState } from './globalState';
+export { getCurrentRunningApp as __internalGetCurrentRunningApp } from './sandbox';
 export * from './errorHandler';
 export * from './effects';
 export * from './interfaces';

--- a/src/sandbox/common.ts
+++ b/src/sandbox/common.ts
@@ -5,18 +5,18 @@
 
 import { isBoundedFunction, isCallable, isConstructable } from '../utils';
 
-type SandboxInstance = { name: string; window: WindowProxy };
-let currentRunningSandboxProxy: SandboxInstance | null = null;
+type AppInstance = { name: string; window: WindowProxy };
+let currentRunningApp: AppInstance | null = null;
 /**
  * get the app that running tasks at current tick
  */
 export function getCurrentRunningApp() {
-  return currentRunningSandboxProxy;
+  return currentRunningApp;
 }
 
-export function setCurrentRunningApp(instance: { name: string; window: WindowProxy } | null) {
+export function setCurrentRunningApp(appInstance: { name: string; window: WindowProxy } | null) {
   // set currentRunningApp and it's proxySandbox to global window, as its only use case is for document.createElement from now on, which hijacked by a global way
-  currentRunningSandboxProxy = instance;
+  currentRunningApp = appInstance;
 }
 
 const functionBoundedValueMap = new WeakMap<CallableFunction, CallableFunction>();

--- a/src/sandbox/common.ts
+++ b/src/sandbox/common.ts
@@ -5,28 +5,18 @@
 
 import { isBoundedFunction, isCallable, isConstructable } from '../utils';
 
-declare global {
-  interface Window {
-    __currentRunningAppInSandbox__: { name: string; window: WindowProxy } | null;
-  }
-}
-
-// Get native global window with a sandbox disgusted way, thus we could share it between qiankun instances🤪
-// eslint-disable-next-line no-new-func
-const nativeGlobal: Window = new Function('return this')();
-Object.defineProperty(nativeGlobal, '__currentRunningAppInSandbox__', { enumerable: false, writable: true });
-
+type SandboxInstance = { name: string; window: WindowProxy };
+let currentRunningSandboxProxy: SandboxInstance | null = null;
 /**
  * get the app that running tasks at current tick
- * @warning this method only works with proxy sandbox, right now it is for internal use only.
  */
 export function getCurrentRunningApp() {
-  return nativeGlobal.__currentRunningAppInSandbox__;
+  return currentRunningSandboxProxy;
 }
 
 export function setCurrentRunningApp(instance: { name: string; window: WindowProxy } | null) {
   // set currentRunningApp and it's proxySandbox to global window, as its only use case is for document.createElement from now on, which hijacked by a global way
-  nativeGlobal.__currentRunningAppInSandbox__ = instance;
+  currentRunningSandboxProxy = instance;
 }
 
 const functionBoundedValueMap = new WeakMap<CallableFunction, CallableFunction>();

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -9,6 +9,7 @@ import ProxySandbox from './proxySandbox';
 import SnapshotSandbox from './snapshotSandbox';
 
 export { css } from './patchers';
+export { getCurrentRunningApp } from './common';
 
 /**
  * 生成应用运行时沙箱


### PR DESCRIPTION
当 A 通过 qiankun 加载 B，B 又通过 qiankun 加载 C 时，可能出现 C 的 js 运行时，先走到了 B 沙箱的 getter trap，然后继续再触发 A 沙箱的 getter trap，从而导致即便在 B 应用中调用 getCurrentRunningApp 方法，拿到的确实 A 的实例，因为 getCurrentRunningApp 里面是通过全局变量去记录的
 