### PR TITLE
🐛 compute container xpath at beginning to keep it consist around app running

### DIFF
--- a/src/apis.ts
+++ b/src/apis.ts
@@ -87,7 +87,7 @@ export function loadMicroApp<T extends ObjectType>(
   const { props, name } = app;
 
   const container = 'container' in app ? app.container : undefined;
-  // Must compute the container xpath at beginning to keep it consist around app mounting
+  // Must compute the container xpath at beginning to keep it consist around app running
   // If we compute it every time, the container dom structure most probably been changed and result in a different xpath value
   const containerXPath = getContainerXPath(container);
   const appContainerXPathKey = `${name}-${containerXPath}`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,3 +215,14 @@ export function getXPathForElement(el: Node, document: Document): string | void 
 export function getContainer(container: string | HTMLElement): HTMLElement | null {
   return typeof container === 'string' ? document.querySelector(container) : container;
 }
+
+export function getContainerXPath(container?: string | HTMLElement): string | void {
+  if (container) {
+    const containerElement = getContainer(container);
+    if (containerElement) {
+      return getXPathForElement(containerElement, document);
+    }
+  }
+
+  return undefined;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export { version } from '../package.json';
+export const version = '2.4.10';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '2.4.10';
+export { version } from '../package.json';


### PR DESCRIPTION
从调用 loadMicroApp 触发加载开始，到应用开始触发 mount，由于期间是全异步流程，容器的 xpath 很容易就发生变化，从而出现最开始取到的跟后面的 xpath 不一致。比如在取容器的 lifecycle cache 时算出来的 xpath，跟取容器上一共关联过哪些微应用是算出来的 xpath 不一致，导致针对同一容器上多个微应用需要排队加载的行为失效