### PR TITLE
fix: correct toString for functions

### DIFF
--- a/src/sandbox/__tests__/common.test.ts
+++ b/src/sandbox/__tests__/common.test.ts
@@ -61,9 +61,22 @@ describe('getTargetValue', () => {
   });
 
   it("should work well while function's toString()'s return value keeps the same as the origin", () => {
-    function callableFunction() {}
+    function callableFunction1() {}
+    function callableFunction2() {}
+    function callableFunction3() {}
+    callableFunction2.toString = () => 'instance toString';
+    Object.defineProperty(callableFunction3, 'toString', {
+      get() {
+        return () => 'instance toString';
+      },
+    });
 
-    const boundFn = getTargetValue(window, callableFunction);
-    expect(boundFn.toString()).toBe(callableFunction.toString());
+    const boundFn1 = getTargetValue(window, callableFunction1);
+    const boundFn2 = getTargetValue(window, callableFunction2);
+    const boundFn3 = getTargetValue(window, callableFunction3);
+
+    expect(boundFn1.toString()).toBe(callableFunction1.toString());
+    expect(boundFn2.toString()).toBe(callableFunction2.toString());
+    expect(boundFn3.toString()).toBe(callableFunction3.toString());
   });
 });

--- a/src/sandbox/__tests__/common.test.ts
+++ b/src/sandbox/__tests__/common.test.ts
@@ -59,4 +59,11 @@ describe('getTargetValue', () => {
     const boundFn = getTargetValue(window, callableFunction);
     expect(boundFn.prototype).toBe(callableFunction.prototype);
   });
+
+  it("should work well while function's toString()'s return value keeps the same as the origin", () => {
+    function callableFunction() {}
+
+    const boundFn = getTargetValue(window, callableFunction);
+    expect(boundFn.toString()).toBe(callableFunction.toString());
+  });
 });

--- a/src/sandbox/common.ts
+++ b/src/sandbox/common.ts
@@ -51,6 +51,18 @@ export function getTargetValue(target: any, value: any): any {
       Object.defineProperty(boundValue, 'prototype', { value: value.prototype, enumerable: false, writable: true });
     }
 
+    // some utils, like `function isNative() {  return typeof Ctor === 'function' && /native code/.test(Ctor.toString()) }`
+    // rely on the correct `toString()` result. While bound functions' will be "function() {[native code]}", which is misleading
+    const valueHasInstanceToString = value.hasOwnProperty('toString') && !boundValue.hasOwnProperty('toString');
+    const boundValueHasPrototypeToString = boundValue.toString === Function.prototype.toString;
+
+    if (valueHasInstanceToString || boundValueHasPrototypeToString) {
+      Object.defineProperty(boundValue, 'toString', {
+        ...Object.getOwnPropertyDescriptor(valueHasInstanceToString ? value : Function.prototype, 'toString'),
+        value: () => value.toString(),
+      });
+    }
+
     functionBoundedValueMap.set(value, boundValue);
     return boundValue;
   }

--- a/src/sandbox/common.ts
+++ b/src/sandbox/common.ts
@@ -52,7 +52,6 @@ export function getTargetValue(target: any, value: any): any {
     }
 
     // Some util, like `function isNative() {  return typeof Ctor === 'function' && /native code/.test(Ctor.toString()) }` relies on the original `toString()` result, but bound functions will always return "function() {[native code]}" for `toString`, which is misleading
-    // rely on the correct `toString()` result. While bound functions' will be "function() {[native code]}", which is misleading
     const valueHasInstanceToString = value.hasOwnProperty('toString') && !boundValue.hasOwnProperty('toString');
     const boundValueHasPrototypeToString = boundValue.toString === Function.prototype.toString;
 

--- a/src/sandbox/common.ts
+++ b/src/sandbox/common.ts
@@ -53,18 +53,21 @@ export function getTargetValue(target: any, value: any): any {
 
     // Some util, like `function isNative() {  return typeof Ctor === 'function' && /native code/.test(Ctor.toString()) }` relies on the original `toString()` result
     // but bound functions will always return "function() {[native code]}" for `toString`, which is misleading
-    const valueHasInstanceToString = value.hasOwnProperty('toString') && !boundValue.hasOwnProperty('toString');
-    const boundValueHasPrototypeToString = boundValue.toString === Function.prototype.toString;
-    const originToStringDescriptor = Object.getOwnPropertyDescriptor(
-      valueHasInstanceToString ? value : Function.prototype,
-      'toString',
-    );
+    if (typeof value.toString === 'function') {
+      const valueHasInstanceToString = value.hasOwnProperty('toString') && !boundValue.hasOwnProperty('toString');
+      const boundValueHasPrototypeToString = boundValue.toString === Function.prototype.toString;
 
-    if (valueHasInstanceToString || boundValueHasPrototypeToString) {
-      Object.defineProperty(boundValue, 'toString', {
-        ...originToStringDescriptor,
-        ...(originToStringDescriptor?.get ? null : { value: () => value.toString() }),
-      });
+      if (valueHasInstanceToString || boundValueHasPrototypeToString) {
+        const originToStringDescriptor = Object.getOwnPropertyDescriptor(
+          valueHasInstanceToString ? value : Function.prototype,
+          'toString',
+        );
+
+        Object.defineProperty(boundValue, 'toString', {
+          ...originToStringDescriptor,
+          ...(originToStringDescriptor?.get ? null : { value: () => value.toString() }),
+        });
+      }
     }
 
     functionBoundedValueMap.set(value, boundValue);

--- a/src/sandbox/common.ts
+++ b/src/sandbox/common.ts
@@ -51,7 +51,7 @@ export function getTargetValue(target: any, value: any): any {
       Object.defineProperty(boundValue, 'prototype', { value: value.prototype, enumerable: false, writable: true });
     }
 
-    // some utils, like `function isNative() {  return typeof Ctor === 'function' && /native code/.test(Ctor.toString()) }`
+    // Some util, like `function isNative() {  return typeof Ctor === 'function' && /native code/.test(Ctor.toString()) }` relies on the original `toString()` result, but bound functions will always return "function() {[native code]}" for `toString`, which is misleading
     // rely on the correct `toString()` result. While bound functions' will be "function() {[native code]}", which is misleading
     const valueHasInstanceToString = value.hasOwnProperty('toString') && !boundValue.hasOwnProperty('toString');
     const boundValueHasPrototypeToString = boundValue.toString === Function.prototype.toString;


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change
有些工具函数，比如：

```js
function isNative() {  return typeof Ctor === 'function' && /native code/.test(Ctor.toString()) }
```
依赖于函数对象的`toString`方法的正确的返回值。目前 qiankun 沙箱中导出的函数，`toString`方法的返回值都是`function() {[native code]}`，导致上面的工具函数失灵。

我在社区里找到一个相关场景：

https://github.com/baidu/san/issues/627#issuecomment-876098885

[关闭这个 issue 的 commit](https://github.com/baidu/san/commit/800b35122e4f73232a603766c5a32cae08648f68)，就是使用了上文所述的`isNative`函数作 workaround。但就 qiankun 的实现而言，这个 workaround 应该没有解决问题。我在公司的项目里也遇到了类似的问题。

PR 的副作用是函数对象凭空多了一个实例方法`toString`。但是它的枚举性和之前一样，影响应该不算太大。在 Github 上搜整个社区的代码库，使用 `/native code/`做判断的代码，远比关心`hasOwnProperty('toString')`的代码要多。例如 [Vue 也用到了`isNative`](https://github.com/vuejs/vue/blob/0603ff695d2f41286239298210113cbe2b209e28/src/core/util/next-tick.js)