### PR TITLE
fix: could pass `undefined` to Node.contains()

### DIFF
--- a/src/sandbox/patchers/dynamicAppend/common.ts
+++ b/src/sandbox/patchers/dynamicAppend/common.ts
@@ -144,7 +144,7 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
   return function appendChildOrInsertBefore<T extends Node>(
     this: HTMLHeadElement | HTMLBodyElement,
     newChild: T,
-    refChild?: Node | null,
+    refChild: Node | null = null,
   ) {
     let element = newChild as any;
     const { rawDOMAppendOrInsertBefore, isInvokedByMicroApp, containerConfigGetter } = opts;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

由于 refChild 是可选参数，那么在 202 行和 215 行有可能将 undefined 作为 mountDOM.contains() 的参数。尽管通常情况下，将 undefined 作为参数时，浏览器并不会抛出错误，但是：

1. 根据 Web 标准，Node.contains() 的参数不是可选的，但是可以设置为 null（https://developer.mozilla.org/en-US/docs/Web/API/Node/contains）
2. 某些第三方的库，有可能会基于这个约定，来改写 contains 方法，这时就有可能出现错误
3. 事实上，百度地图的 webGL 版 js sdk 就改写了 contains 方法，尽管改写后的方法也没有兼容参数为 null 的情况 😒 ：

```js
// 百度地图 sdk 中的这段代码，没有考虑 contains 的参数为 null 或 undefined 的情况，造成我在主应用中加载 sdk 时报错了，我只能自己在项目中重新改写 `contains` 方法临时解决

if (typeof HTMLElement != "undefined" && !window.opera) {
        HTMLElement.prototype.contains = function(e) {
            if (e == this) {
                return true
            }
            // 由于 qiankun 中调用这个方法时，e 为 undefined，导致浏览器抛出了错误
            while (e = e.parentNode) {
                if (e == this) {
                    return true
                }
            }
            return false
        }
    }
```

以下为报错信息：

![image](https://user-images.githubusercontent.com/11363971/145364845-beb39420-11f7-43db-93ac-710180ba39f2.png)

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL
