### PR TITLE
fix: lower version chrome does't support css rule: conditionText #2128

### DIFF
--- a/src/sandbox/patchers/css.ts
+++ b/src/sandbox/patchers/css.ts
@@ -177,7 +177,7 @@ export class ScopedCSS {
   // @supports (display: grid) {}
   private ruleSupport(rule: CSSSupportsRule, prefix: string) {
     const css = this.rewrite(arrayify(rule.cssRules), prefix);
-    return `@supports ${rule.conditionText|| rule.cssText.split('{')[0]} {${css}}`;
+    return `@supports ${rule.conditionText || rule.cssText.split('{')[0]} {${css}}`;
   }
 }
 

--- a/src/sandbox/patchers/css.ts
+++ b/src/sandbox/patchers/css.ts
@@ -170,7 +170,7 @@ export class ScopedCSS {
   // @media screen and (max-width: 300px) {}
   private ruleMedia(rule: CSSMediaRule, prefix: string) {
     const css = this.rewrite(arrayify(rule.cssRules), prefix);
-    return `@media ${rule.conditionText|| rule.media.mediaText} {${css}}`;
+    return `@media ${rule.conditionText || rule.media.mediaText} {${css}}`;
   }
 
   // handle case:

--- a/src/sandbox/patchers/css.ts
+++ b/src/sandbox/patchers/css.ts
@@ -170,14 +170,14 @@ export class ScopedCSS {
   // @media screen and (max-width: 300px) {}
   private ruleMedia(rule: CSSMediaRule, prefix: string) {
     const css = this.rewrite(arrayify(rule.cssRules), prefix);
-    return `@media ${rule.conditionText} {${css}}`;
+    return `@media ${rule.conditionText|| rule.media.mediaText} {${css}}`;
   }
 
   // handle case:
   // @supports (display: grid) {}
   private ruleSupport(rule: CSSSupportsRule, prefix: string) {
     const css = this.rewrite(arrayify(rule.cssRules), prefix);
-    return `@supports ${rule.conditionText} {${css}}`;
+    return `@supports ${rule.conditionText|| rule.cssText.split('{')[0]} {${css}}`;
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

##### Description of change
Below ChromeV56，CSSMediaRule and CSSSupportsRule does't have conditionText prop.
Refer: https://developer.mozilla.org/zh-CN/docs/Web/API/CSSConditionRule
<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL
