### PR TITLE
🐛 fix the counter issue while multiple apps mounting concurrently

### DIFF
--- a/src/sandbox/patchers/dynamicAppend/forLooseSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forLooseSandbox.ts
@@ -5,10 +5,13 @@
 
 import { checkActivityFunctions } from 'single-spa';
 import type { Freer } from '../../../interfaces';
-import { patchHTMLDynamicAppendPrototypeFunctions, rebuildCSSRules, recordStyledComponentsCSSRules } from './common';
-
-let bootstrappingPatchCount = 0;
-let mountingPatchCount = 0;
+import {
+  calcAppCount,
+  isAllAppsUnmounted,
+  patchHTMLDynamicAppendPrototypeFunctions,
+  rebuildCSSRules,
+  recordStyledComponentsCSSRules,
+} from './common';
 
 /**
  * Just hijack dynamic head append, that could avoid accidentally hijacking the insertion of elements except in head.
@@ -52,17 +55,15 @@ export function patchLooseSandbox(
     }),
   );
 
-  if (!mounting) bootstrappingPatchCount++;
-  if (mounting) mountingPatchCount++;
+  if (!mounting) calcAppCount(appName, 'increase', 'bootstrapping');
+  if (mounting) calcAppCount(appName, 'increase', 'mounting');
 
   return function free() {
-    // bootstrap patch just called once but its freer will be called multiple times
-    if (!mounting && bootstrappingPatchCount !== 0) bootstrappingPatchCount--;
-    if (mounting) mountingPatchCount--;
+    if (!mounting) calcAppCount(appName, 'decrease', 'bootstrapping');
+    if (mounting) calcAppCount(appName, 'decrease', 'mounting');
 
-    const allMicroAppUnmounted = mountingPatchCount === 0 && bootstrappingPatchCount === 0;
     // release the overwrite prototype after all the micro apps unmounted
-    if (allMicroAppUnmounted) unpatchDynamicAppendPrototypeFunctions();
+    if (isAllAppsUnmounted()) unpatchDynamicAppendPrototypeFunctions();
 
     recordStyledComponentsCSSRules(dynamicStyleSheetElements);
 


### PR DESCRIPTION
当出现如下操作路径时，原逻辑会出现 bug：

微应用 A 加载 -> remount（unmount -> mount），此时计数会为 { b:0, m: 1 }
微应用 B 加载 -> 同时触发 微应用 A 卸载，如果微应用 B 的 bootstrap 先触发了，计数会变为 { b:1, m:1 }，之后微应用 A 的 unmount 才开始执行，会判定 allAppsUnmounted 为 true，从而导致针对 document 的全局复写被回滚