### PR TITLE
fix redundancy tslib & @babel/runtime to reduce build size

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,8 +104,7 @@
     "@babel/runtime": "^7.10.5",
     "import-html-entry": "^1.9.0",
     "lodash": "^4.17.11",
-    "single-spa": "^5.9.2",
-    "tslib": "^1.10.0"
+    "single-spa": "^5.9.2"
   },
   "devDependencies": {
     "@types/jest": "^25.1.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "esnext",
     "module": "esnext",
     "lib": ["es2018", "dom"],
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "outDir": "./esm",
     "rootDir": "./",
-    "importHelpers": true,
+    "importHelpers": false,
     "downlevelIteration": true,
     "strict": true,
     "noImplicitAny": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "outDir": "./esm",
     "rootDir": "./",
-    "importHelpers": false,
+    "importHelpers": true,
     "downlevelIteration": true,
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
功能职责重复的 tslib 和 @babel/runtime 并存
![image](https://user-images.githubusercontent.com/5773264/188357013-6f08776f-769a-4d44-9777-b244aa64ae0b.png)
去掉tslib只留@babel/runtime，能使构建出的包体检减少tslib的部分
