### PR TITLE
feat(option): loadMicroApp 增加 disableCache 配置项

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -161,6 +161,8 @@ By linking the micro-application to some url rules, the function of automaticall
 
     - excludeAssetFilter - `(assetUrl: string) => boolean` - optional，some special dynamic loaded micro app resources should not be handled by qiankun hijacking
 
+    - disableCache - `boolean` - optional，qiankun will not load resources and excute code repeatedly when loading the same micro app multiple times, so it can improve performace and avoid the risk of memory leaks, default is `false`.
+
 - Usage
 
   Start qiankun.

--- a/docs/api/README.zh.md
+++ b/docs/api/README.zh.md
@@ -269,6 +269,8 @@ toc: menu
 
     - excludeAssetFilter - `(assetUrl: string) => boolean` - 可选，指定部分特殊的动态加载的微应用资源（css/js) 不被 qiankun 劫持处理
 
+    - disableCache - `boolean` - 可选，是否禁用缓存，在多次加载相同微应用的时候，qiankun 不会重复加载资源和执行代码，这样可以提升性能和避免内存泄漏的风险，默认为 `false`
+
 - 返回值 - `MicroApp` - 微应用实例
 
   - mount(): Promise&lt;null&gt;;

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -802,3 +802,31 @@ As the requests to pull micro-app entry are all cross-domain, when your micro-ap
     },
   });
   ```
+
+  ## Why bootstrap hook only run once when loading the same micro app multi times by using loadMicroApp method?
+
+  By default，to improve performace and avoid the risk of memory leaks, qiankun will not load resources and excute code repeatedly when loading the same micro app multiple times, so it will skip bootstrap hook, and remount the micro app directly. 
+
+  You can disable cache to solve the problem, however, be ware this method may cause performance and memory problems.
+
+    ```js
+  import { loadMicroApp } from 'qiankun';
+
+  loadMicroApp(app, {
+    disableCache: true
+  });
+  ```
+
+  ## Why global data being cached when loading the same micro app multi times by using loadMicroApp method?
+
+  By default，to improve performace and avoid the risk of memory leaks, qiankun will not load resources and excute code repeatedly when loading the same micro app multiple times, so it will reuse the global data cache of last time.
+
+  You can disable cache to solve the problem, however, be ware this method may cause performance and memory problems.
+
+    ```js
+  import { loadMicroApp } from 'qiankun';
+
+  loadMicroApp(app, {
+    disableCache: true
+  });
+  ```

--- a/docs/faq/README.zh.md
+++ b/docs/faq/README.zh.md
@@ -828,3 +828,31 @@ export async function mount(props) {
     }
   }
   ```
+
+  ## 为什么使用 loadMicroApp 多次加载相同微应用时，bootstrap 方法只会执行一次？
+
+  默认情况下，为了提升性能和避免内存泄漏的风险，在多次加载相同微应用的时候，qiankun 不会重复加载资源和执行代码，因此会跳过 bootstrap 钩子，直接 mount 微应用。
+
+  可以通过禁用缓存解决，但需要注意的是该方法可能会导致性能和内存的问题。
+
+    ```js
+  import { loadMicroApp } from 'qiankun';
+
+  loadMicroApp(app, {
+    disableCache: true, // 禁用缓存
+  });
+  ```
+
+  ## 为什么使用 loadMicroApp 多次加载相同微应用时，一些全局状态会保留？
+
+  默认情况下，为了提升性能和避免内存泄漏的风险，在多次加载相同微应用的时候，qiankun 不会重复加载资源和执行代码，会直接复用缓存在内存里的代码，因此会保留之前的全局状态。
+
+  可以通过禁用缓存解决，但需要注意的是该方法可能会导致性能和内存的问题。
+
+    ```js
+  import { loadMicroApp } from 'qiankun';
+
+  loadMicroApp(app, {
+    disableCache: true, // 禁用缓存
+  });
+  ```

--- a/src/apis.ts
+++ b/src/apis.ts
@@ -84,6 +84,7 @@ export function loadMicroApp<T extends ObjectType>(
   lifeCycles?: FrameworkLifeCycles<T>,
 ): MicroApp {
   const { props, name } = app;
+  const { disableCache } = configuration || {};
 
   const container = 'container' in app ? app.container : undefined;
   // Must compute the container xpath at beginning to keep it consist around app running
@@ -137,7 +138,7 @@ export function loadMicroApp<T extends ObjectType>(
     );
     const { $$cacheLifecycleByAppName } = userConfiguration;
 
-    if (container) {
+    if (container && !disableCache) {
       // using appName as cache for internal experimental scenario
       if ($$cacheLifecycleByAppName) {
         const parcelConfigGetterPromise = appConfigPromiseGetterMap.get(name);
@@ -152,7 +153,7 @@ export function loadMicroApp<T extends ObjectType>(
 
     const parcelConfigObjectGetterPromise = loadApp(app, userConfiguration, lifeCycles);
 
-    if (container) {
+    if (container && !disableCache) {
       if ($$cacheLifecycleByAppName) {
         appConfigPromiseGetterMap.set(name, parcelConfigObjectGetterPromise);
       } else if (containerXPath) appConfigPromiseGetterMap.set(appContainerXPathKey, parcelConfigObjectGetterPromise);
@@ -171,7 +172,7 @@ export function loadMicroApp<T extends ObjectType>(
 
   microApp = mountRootParcel(memorizedLoadingFn, { domElement: document.createElement('div'), ...props });
 
-  if (container) {
+  if (container && !disableCache) {
     if (containerXPath) {
       // Store the microApps which they mounted on the same container
       const microAppsRef = containerMicroAppsMap.get(appContainerXPathKey) || [];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -90,6 +90,10 @@ type QiankunSpecialOpts = {
    * skip some scripts or links intercept, like JSONP
    */
   excludeAssetFilter?: (url: string) => boolean;
+  /**
+   * disable the cache when loading the same micro app multi times
+   */
+  disableCache?: boolean;
 
   globalContext?: typeof window;
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

默认情况下，为了提升性能和避免内存泄漏的风险（见 <https://github.com/umijs/qiankun/issues/832>），在多次加载相同微应用的时候，qiankun 不会重复加载资源和执行代码（见 <https://github.com/umijs/qiankun/issues/518>），但这样会带来一些副作用：
1. bootstrap 钩子会被跳过，直接 remount，一些写在 bootstrap 方法里的逻辑无法被执行，见 <https://github.com/umijs/qiankun/issues/1273>
2. 一些全局数据会被缓存，比如全局变量、全局 store 等，见 <https://github.com/umijs/qiankun/issues/2267>

虽然这些问题可以通过一些方式解决，比如将 bootstrap 的逻辑放到 mount 里，比如在 unmount 的时候重置全局变量、store，但是：
1. 这样改变了用户对 bootstrap 钩子的理解心智
2. 一些无法修改的代码（比如第三方依赖的代码）无法进行处理

此处增加了 `disableCache` 的配置项，让用户可以选择关闭缓存，解决上述问题，同时在文档中也注明了可能带来性能和内存问题的风险

```js
import { loadMicroApp } from 'qiankun';

loadMicroApp(app, {
  disableCache: true, // 禁用缓存
});
```
