### PR TITLE
🐛 should trigger scripts loading before them executing

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -263,7 +263,9 @@ export async function loadApp<T extends ObjectType>(
   } = configuration;
 
   // get the entry html content and script executor
-  const { template, execScripts, assetPublicPath } = await importEntry(entry, importEntryOpts);
+  const { template, execScripts, assetPublicPath, getExternalScripts } = await importEntry(entry, importEntryOpts);
+  // trigger external scripts loading to make sure all assets are ready before execScripts calling
+  await getExternalScripts();
 
   // as single-spa load and bootstrap new app parallel with other apps unmounting
   // (see https://github.com/CanopyTax/single-spa/blob/master/src/navigation/reroute.js#L74)


### PR DESCRIPTION
Thus we could make sure that all assets are fetched while beforeLoad lifecycle calling, and the execScripts overhead is just js execution timing.