### PR TITLE
🐛window variable should in with lexical scope while speedy mode enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.5",
-    "import-html-entry": "^1.14.0",
+    "import-html-entry": "^1.14.1",
     "lodash": "^4.17.11",
     "single-spa": "^5.9.2"
   },

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -18,7 +18,7 @@ import type {
   ObjectType,
 } from './interfaces';
 import { createSandboxContainer, css } from './sandbox';
-import { trustedGlobals } from './sandbox/common';
+import { scopedGlobals } from './sandbox/common';
 import {
   Deferred,
   genAppInstanceIdByName,
@@ -345,7 +345,7 @@ export async function loadApp<T extends ObjectType>(
 
   // get the lifecycle hooks from module exports
   const scriptExports: any = await execScripts(global, sandbox && !useLooseSandbox, {
-    scopedGlobalVariables: speedySandbox ? trustedGlobals : [],
+    scopedGlobalVariables: speedySandbox ? scopedGlobals : [],
   });
   const { bootstrap, mount, unmount, update } = getLifecyclesFromExports(
     scriptExports,

--- a/src/sandbox/common.ts
+++ b/src/sandbox/common.ts
@@ -5,7 +5,6 @@
 
 import { isBoundedFunction, isCallable, isConstructable } from '../utils';
 import { globals } from './globals';
-import { without } from 'lodash';
 
 type AppInstance = { name: string; window: WindowProxy };
 let currentRunningApp: AppInstance | null = null;
@@ -22,8 +21,8 @@ export function setCurrentRunningApp(appInstance: { name: string; window: Window
   currentRunningApp = appInstance;
 }
 
-const spiedGlobals = ['window', 'self', 'globalThis', 'top', 'parent', 'hasOwnProperty', 'document', 'eval'];
-export const trustedGlobals = [...without(globals, ...spiedGlobals), 'requestAnimationFrame'];
+export const overwrittenGlobals = ['window', 'self', 'globalThis'];
+export const scopedGlobals = Array.from(new Set([...globals, ...overwrittenGlobals, 'requestAnimationFrame']));
 
 const functionBoundedValueMap = new WeakMap<CallableFunction, CallableFunction>();
 

--- a/src/sandbox/patchers/dynamicAppend/common.ts
+++ b/src/sandbox/patchers/dynamicAppend/common.ts
@@ -6,7 +6,7 @@ import { execScripts } from 'import-html-entry';
 import { isFunction } from 'lodash';
 import { frameworkConfiguration } from '../../../apis';
 import { qiankunHeadTagName } from '../../../utils';
-import { trustedGlobals } from '../../common';
+import { scopedGlobals } from '../../common';
 import * as css from '../css';
 
 export const rawHeadAppendChild = HTMLHeadElement.prototype.appendChild;
@@ -280,7 +280,7 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
           const { fetch } = frameworkConfiguration;
           const referenceNode = mountDOM.contains(refChild) ? refChild : null;
 
-          const scopedGlobalVariables = speedySandbox ? trustedGlobals : [];
+          const scopedGlobalVariables = speedySandbox ? scopedGlobals : [];
 
           if (src) {
             let isRedfinedCurrentScript = false;


### PR DESCRIPTION
* resolves #2385 
* resolves #2386