### PR TITLE
🐛 compatible with nested sandbox to avoid stack overflow while createElement calling

### DIFF
--- a/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
@@ -50,8 +50,10 @@ function patchDocument(cfg: { sandbox: SandBox; speedy: boolean }) {
       },
       get: (target, p) => {
         if (p === 'createElement') {
-          return (...args: Parameters<typeof document.createElement>) => {
-            const element = document.createElement(...args);
+          // Must store the original createElement function to avoid error in nested sandbox
+          const targetCreateElement = target.createElement;
+          return function createElement(...args: Parameters<typeof document.createElement>) {
+            const element = targetCreateElement.call(target, ...args);
             attachElementToProxy(element, sandbox.proxy);
             return element;
           };


### PR DESCRIPTION
考虑这个场景：
1. 主应用 A 嵌入 应用 B，沙箱配置为 speedy
2. 应用 B 嵌入应用 C，沙箱配置为非 speedy
3. C 启动时，因为沙箱未非 speedy，走原型链修改方式 patch document，此时会先获取原始的 createElement 方法，即 document.createElement -> proxyDocument.createElement
4. 将 proxyDocument.createElement 缓存作为原始 createElement 之后，B 实例化的沙箱会修改 Document.prototype.createElement
5. C 应用真实调用 document.createElement 时，实际调用链路为： Document.prototype.createElement 方法 -> 使用缓存的 proxyDocument.createElement -> proxyDocument.createElement 调用 document.createElement 创建元素 -> 使用 Document.prototype.createElement
6. 出现循环依赖，爆栈