### PR TITLE
🐛 compatible with old browser like chrome55

### DIFF
--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -42,12 +42,14 @@ export function createSandboxContainer(
 ) {
   let sandbox: SandBox;
   if (window.Proxy) {
-    sandbox = useLooseSandbox ? new LegacySandbox(appName, globalContext) : new ProxySandbox(appName, globalContext);
+    sandbox = useLooseSandbox
+      ? new LegacySandbox(appName, globalContext)
+      : new ProxySandbox(appName, globalContext, { speedy: !!speedySandBox });
   } else {
     sandbox = new SnapshotSandbox(appName);
   }
 
-  // some side effect could be be invoked while bootstrapping, such as dynamic stylesheet injection with style-loader, especially during the development phase
+  // some side effect could be invoked while bootstrapping, such as dynamic stylesheet injection with style-loader, especially during the development phase
   const bootstrappingFreers = patchAtBootstrapping(
     appName,
     elementGetter,

--- a/src/sandbox/patchers/dynamicAppend/common.ts
+++ b/src/sandbox/patchers/dynamicAppend/common.ts
@@ -397,7 +397,7 @@ export function patchHTMLDynamicAppendPrototypeFunctions(
   isInvokedByMicroApp: (element: HTMLElement) => boolean,
   containerConfigGetter: (element: HTMLElement) => ContainerConfig,
 ) {
-  // Just overwrite it while it have not been overwrite
+  // Just overwrite it while it have not been overwritten
   if (
     HTMLHeadElement.prototype.appendChild === rawHeadAppendChild &&
     HTMLBodyElement.prototype.appendChild === rawBodyAppendChild &&
@@ -424,7 +424,7 @@ export function patchHTMLDynamicAppendPrototypeFunctions(
     }) as typeof rawHeadInsertBefore;
   }
 
-  // Just overwrite it while it have not been overwrite
+  // Just overwrite it while it have not been overwritten
   if (
     HTMLHeadElement.prototype.removeChild === rawHeadRemoveChild &&
     HTMLBodyElement.prototype.removeChild === rawBodyRemoveChild


### PR DESCRIPTION
Browsers like chrome55 has a different result in document descriptor.

```js
// chrome 100
Object.getOwnPropertyDescriptor(window, 'document');
// {set: undefined, enumerable: true, configurable: false, get: ƒ}

// chrome 55
Object.getOwnPropertyDescriptor(window, 'document');
// {writable:false,enumerable:true,configurable:false,value:document}
```

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL