### PR TITLE
fix: invoking nextTick will trigger infinite angular change detection

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,8 +16,9 @@ export function sleep(ms: number) {
 }
 
 // Promise.then might be synchronized in Zone.js context, we need to use setTimeout instead to mock next tick.
+// Since zone.js will hijack the setTimeout callback, and notify angular to do change detection, so we need to use the  __zone_symbol__setTimeout to avoid this, see https://github.com/umijs/qiankun/issues/2384
 const nextTick: (cb: () => void) => void =
-  typeof window.Zone === 'function' ? setTimeout : (cb) => Promise.resolve().then(cb);
+  typeof window.Zone === 'function' ? window.__zone_symbol__setTimeout : (cb) => Promise.resolve().then(cb);
 
 let globalTaskPending = false;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->
Since working with Angular, setTimeout will be monkey patching by Zone.js, so when invoking nextTick
```javascript
const nextTick: (cb: () => void) => void =
  typeof window.Zone === 'function' ? window.setTimeout : (cb) => Promise.resolve().then(cb);
``` 
Zone.js will hijack the callback. When the microTask queue is Empty, Zone.js will notify Angular to perform change detection.

This is correct, though. But during the change detection, Angular will still access the global variables, and qiankun will call nextTick to remove currentRunningApp mark:
```typescript
private registerRunningApp(name: string, proxy: Window) {
    if (this.sandboxRunning) {
      const currentRunningApp = getCurrentRunningApp();
      if (!currentRunningApp || currentRunningApp.name !== name) {
        setCurrentRunningApp({ name, window: proxy });
      }
      // FIXME if you have any other good ideas
      // remove the mark in next tick, thus we can identify whether it in micro app or not
      // this approach is just a workaround, it could not cover all complex cases, such as the micro app runs in the same task context with master in some case
      nextTask(clearCurrentRunningApp);
    }
  }
```
This behavior makes Angular app perform infinite change detection which causing a bad performance circumstance.

To prevent qiankun notifying the Angular app to do change detection, the setTimeout fn in nextTick should replace with the native setTimeout fn.
```javascript
const nextTick: (cb: () => void) => void =
  typeof window.Zone === 'function' ? window.__zone_symbol__setTimeout : (cb) => Promise.resolve().then(cb);
```



##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- replace the monkey patching setTimeout with native setTimeout in nextTick function
- close https://github.com/umijs/qiankun/issues/2384
