### PR TITLE
fix: document proxy in strict sandbox mode replaces receiver with target in methods args

### DIFF
--- a/src/sandbox/patchers/dynamicAppend/__tests__/forStrictSandbox.test.ts
+++ b/src/sandbox/patchers/dynamicAppend/__tests__/forStrictSandbox.test.ts
@@ -1,0 +1,53 @@
+import { SandBoxType } from '../../../../interfaces';
+import { noop } from 'lodash';
+import { patchStrictSandbox } from '../forStrictSandbox';
+
+jest.mock('import-html-entry', () => ({
+  execScripts: jest.fn(),
+}));
+
+describe('forStrictSandbox test', () => {
+  const {
+    prototype: { createTreeWalker: originalCreateTreeWalker },
+  } = Document;
+
+  beforeAll(() => {
+    Document.prototype.createTreeWalker = function createTreeWalker(
+      this: Document,
+      root: Node,
+      whatToShow?: number | undefined,
+      filter?: NodeFilter | null | undefined,
+    ) {
+      if (document !== root) {
+        throw new TypeError('error');
+      }
+      return originalCreateTreeWalker.call(this, root, whatToShow, filter);
+    };
+  });
+
+  afterAll(() => {
+    Document.prototype.createTreeWalker = originalCreateTreeWalker;
+  });
+
+  it('should not throw on patched document', () => {
+    let patchedDocument!: Document;
+    const appName = 'test-app';
+    const wrapper = document.createElement('div');
+    const sandbox = {
+      name: appName,
+      type: SandBoxType.Proxy,
+      proxy: window,
+      sandboxRunning: true,
+      latestSetProp: null,
+      patchDocument: (patched: Document) => {
+        patchedDocument = patched;
+      },
+      active: noop,
+      inactive: noop,
+    };
+    patchStrictSandbox(appName, () => wrapper, sandbox, true, false, undefined, true);
+
+    expect(patchedDocument).toBeDefined();
+    expect(() => patchedDocument?.createTreeWalker(patchedDocument)).not.toThrow();
+  });
+});

--- a/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
@@ -53,7 +53,7 @@ function patchDocument(cfg: { sandbox: SandBox; speedy: boolean }) {
         (<any>target)[p] = value;
         return true;
       },
-      get: (target, p) => {
+      get: (target, p, receiver) => {
         if (p === 'createElement') {
           // Must store the original createElement function to avoid error in nested sandbox
           const targetCreateElement = target.createElement;
@@ -67,7 +67,9 @@ function patchDocument(cfg: { sandbox: SandBox; speedy: boolean }) {
         const value = (<any>target)[p];
         // must rebind the function to the target otherwise it will cause illegal invocation error
         if (typeof value === 'function' && !isBoundedFunction(value)) {
-          return value.bind(target);
+          return function proxiedFunction(...args: unknown) {
+            return value.call(target, ...args.map((arg) => arg === receiver ? target : arg))
+          }
         }
 
         return value;

--- a/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
@@ -67,8 +67,8 @@ function patchDocument(cfg: { sandbox: SandBox; speedy: boolean }) {
         const value = (<any>target)[p];
         // must rebind the function to the target otherwise it will cause illegal invocation error
         if (typeof value === 'function' && !isBoundedFunction(value)) {
-          return function proxiedFunction(...args: unknown) {
-            return value.call(target, ...args.map((arg) => arg === receiver ? target : arg));
+          return function proxiedFunction(...args: unknown[]) {
+            return value.call(target, ...args.map((arg) => (arg === receiver ? target : arg)));
           };
         }
 

--- a/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
@@ -68,8 +68,8 @@ function patchDocument(cfg: { sandbox: SandBox; speedy: boolean }) {
         // must rebind the function to the target otherwise it will cause illegal invocation error
         if (typeof value === 'function' && !isBoundedFunction(value)) {
           return function proxiedFunction(...args: unknown) {
-            return value.call(target, ...args.map((arg) => arg === receiver ? target : arg))
-          }
+            return value.call(target, ...args.map((arg) => arg === receiver ? target : arg));
+          };
         }
 
         return value;


### PR DESCRIPTION
When used as an argument, `document` should carry its own `Node` interface. If not invocations like
```javascript
const d = new Proxy(document, { /* handler */ }
d.createTreeWalker(d)
```
will throw

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL
