### PR TITLE
fix: document.all proxy error in naughtySafari

### DIFF
--- a/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
@@ -65,6 +65,10 @@ function patchDocument(cfg: { sandbox: SandBox; speedy: boolean }) {
         }
 
         const value = (<any>target)[p];
+        // fix document.all proxy error in naughtySafari
+        if (p === 'all') {
+          return value;
+        }
         // must rebind the function to the target otherwise it will cause illegal invocation error
         if (typeof value === 'function' && !isBoundedFunction(value)) {
           return function proxiedFunction(...args: unknown[]) {

--- a/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Freer, SandBox } from '../../../interfaces';
-import { isBoundedFunction, nativeDocument, nativeGlobal } from '../../../utils';
+import { isBoundedFunction, nativeDocument, nativeGlobal, isCallable } from '../../../utils';
 import { getCurrentRunningApp } from '../../common';
 import type { ContainerConfig } from './common';
 import {
@@ -65,12 +65,8 @@ function patchDocument(cfg: { sandbox: SandBox; speedy: boolean }) {
         }
 
         const value = (<any>target)[p];
-        // fix document.all proxy error in naughtySafari
-        if (p === 'all') {
-          return value;
-        }
         // must rebind the function to the target otherwise it will cause illegal invocation error
-        if (typeof value === 'function' && !isBoundedFunction(value)) {
+        if (isCallable(value) && !isBoundedFunction(value)) {
           return function proxiedFunction(...args: unknown[]) {
             return value.call(target, ...args.map((arg) => (arg === receiver ? target : arg)));
           };


### PR DESCRIPTION
因为个别版本 Safari 中 typeof document.all === 'undefined'  和 typeof document.all === 'function' 都为 true，并且qiankun 中判断函数是否绑定过的方法 `isBoundedFunction` 里用到了 `fn.name.indexOf`，导致用到了 `document.all` 的地方会报错

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL
