### PR TITLE
🐛 prevent element from processing multi times in nest sandbox

### DIFF
--- a/src/sandbox/patchers/dynamicAppend/common.ts
+++ b/src/sandbox/patchers/dynamicAppend/common.ts
@@ -269,7 +269,7 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
 
         case SCRIPT_TAG_NAME: {
           const { src, text } = element as HTMLScriptElement;
-          // some script like jsonp maybe not support cors which should't use execScripts
+          // some script like jsonp maybe not support cors which shouldn't use execScripts
           if ((excludeAssetFilter && src && excludeAssetFilter(src)) || !isExecutableScriptType(element)) {
             return rawDOMAppendOrInsertBefore.call(this, element, refChild) as T;
           }

--- a/src/sandbox/patchers/dynamicAppend/forLooseSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forLooseSandbox.ts
@@ -71,7 +71,7 @@ export function patchLooseSandbox(
     recordStyledComponentsCSSRules(dynamicStyleSheetElements);
 
     // As now the sub app content all wrapped with a special id container,
-    // the dynamic style sheet would be removed automatically while unmoutting
+    // the dynamic style sheet would be removed automatically while unmounting
 
     return function rebuild() {
       rebuildCSSRules(dynamicStyleSheetElements, (stylesheetElement) => {


### PR DESCRIPTION
嵌套沙箱场景，`document.createElement` 创建出来的元素会被每一层沙箱处理，且在后续 appendChild 时，也会因为 `isInvokedByMicroApp` 判断为 true 导致层层冒泡到最上层的沙箱，最终导致 element 被插到了最上层的微应用中，最后引入 bug，比如内层的微应用卸载时，自己动态插入的样式却没有卸载。