### PR TITLE
🐛 document head in micro app should use the proxied appendChild methods

### DIFF
--- a/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
@@ -96,7 +96,10 @@ function patchDocument(cfg: { sandbox: SandBox; speedy: boolean }) {
                 case 'head': {
                   const containerConfig = proxyAttachContainerConfigMap.get(sandbox.proxy);
                   if (containerConfig) {
-                    return getAppWrapperHeadElement(containerConfig.appWrapperGetter());
+                    const qiankunHead = getAppWrapperHeadElement(containerConfig.appWrapperGetter());
+                    qiankunHead.appendChild = HTMLHeadElement.prototype.appendChild;
+                    qiankunHead.insertBefore = HTMLHeadElement.prototype.insertBefore;
+                    return qiankunHead;
                   }
                   break;
                 }


### PR DESCRIPTION
子应用里通过 `document.querySelector('head')` 获取到 target 后调用 target.appendChild 时，会因为不走代理后的 appendChild 方法导致样式劫持失效