### PR TITLE
fix: Fixed the problem that the cssText attribute cannot be obtained …

### DIFF
--- a/src/sandbox/patchers/css.ts
+++ b/src/sandbox/patchers/css.ts
@@ -102,7 +102,10 @@ export class ScopedCSS {
           css += this.ruleSupport(rule as CSSSupportsRule, prefix);
           break;
         default:
-          css += `${rule.cssText}`;
+          if (typeof rule.cssText === 'string') {
+            css += `${rule.cssText}`;
+          }
+
           break;
       }
     });
@@ -121,7 +124,11 @@ export class ScopedCSS {
 
     const selector = rule.selectorText.trim();
 
-    let { cssText } = rule;
+    let cssText = '';
+    if (typeof rule.cssText === 'string') {
+      cssText = rule.cssText;
+    }
+
     // handle html { ... }
     // handle body { ... }
     // handle :root { ... }


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change
fix: Fixed the problem that the cssText attribute cannot be obtained when @keyfram has a -webkit prefix style in IE11

ie11环境下，当@keyframe带有-webkit-私有前缀时，使用cssRules获取不到cssText导致报错: 找不到成员。
例如使用autoprefixe插件自动添加前缀
```css
// 转换前
@keyframes donghua {
    from {
        transform: rotate(0deg);
    }
    to {
        transform: rotate(360deg);
    }
}
// autoprefixe插件转换后
@keyframes donghua {
    from {
        transform: rotate(0deg);
        -webkit-transform: rotate(0deg);
    }
    to {
        transform: rotate(360deg);
        -webkit-transform: rotate(360deg);
    }
}
```
**希望能在qiankun代码里进行错误捕获。防止获取cssText报错**


- close https://github.com/umijs/qiankun/issues/2527
