### PR TITLE
fix: unit tests failed due to 'tslib' missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "prettier": "^2.1.2",
     "rimraf": "^3.0.0",
     "ts-jest": "^25.2.1",
-    "typescript": "^4.8.2"
+    "typescript": "^4.8.2",
+    "tslib": "^2.6.2"
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

Tried to run unit tests and found two were failed due to the same reason:

<img width="734" alt="image" src="https://github.com/umijs/qiankun/assets/3401641/993c5251-3865-4590-bcc4-9a3bc10eb4be">

After installing `tslib`, seems everything works fine:

<img width="578" alt="image" src="https://github.com/umijs/qiankun/assets/3401641/dd1ac4fa-99a0-45e3-8bf1-f64097064e3a">



