### PR TITLE
feat: add transformer options for app loader

### DIFF
--- a/.changeset/ninety-rivers-check.md
+++ b/.changeset/ninety-rivers-check.md
@@ -1,0 +1,6 @@
+---
+"@qiankunjs/loader": patch
+"qiankun": patch
+---
+
+feat: add transformer options for app loader

--- a/packages/qiankun/src/core/loadApp.ts
+++ b/packages/qiankun/src/core/loadApp.ts
@@ -28,7 +28,7 @@ export default async function loadApp<T extends ObjectType>(
   lifeCycles?: LifeCycles<T>,
 ) {
   const { name: appName, entry, container } = app;
-  const { fetch = window.fetch, sandbox, globalContext = window } = configuration || {};
+  const { fetch = window.fetch, sandbox, globalContext = window, transformer } = configuration || {};
 
   const markName = `[qiankun] App ${appName} Loading`;
   if (process.env.NODE_ENV === 'development') {
@@ -56,7 +56,7 @@ export default async function loadApp<T extends ObjectType>(
     unmountSandbox = () => sandboxContainer.unmount();
   }
 
-  const containerOpts: LoaderOpts = { fetch, sandbox: sandboxInstance };
+  const containerOpts: LoaderOpts = { fetch, sandbox: sandboxInstance, transformer };
 
   const assetPublicPath = calcPublicPath(entry);
   const {

--- a/packages/qiankun/src/types.ts
+++ b/packages/qiankun/src/types.ts
@@ -2,7 +2,7 @@
  * @author Kuitos
  * @since 2023-04-25
  */
-import type { BaseLoaderOpts } from '@qiankunjs/shared';
+import type { LoaderOpts } from '@qiankunjs/loader';
 import type { LifeCycles as ParcelLifeCycles, Parcel, RegisterApplicationConfig } from 'single-spa';
 
 declare global {
@@ -41,7 +41,7 @@ export type RegistrableApp<T extends ObjectType> = LoadableApp<T> & {
   activeRule: RegisterApplicationConfig['activeWhen'];
 };
 
-export type AppConfiguration = Partial<BaseLoaderOpts> & {
+export type AppConfiguration = Pick<LoaderOpts, 'fetch' | 'transformer'> & {
   sandbox?: boolean;
   globalContext?: WindowProxy;
 };


### PR DESCRIPTION
1. Add transformer configuration for users who want to modify the entry HTML with a stream.
2. Remove the implementation of firstScriptStartLoadDeferred because the script execution in the entry is synchronous, and it doesn't make sense to insert asynchronous logic in the middle with beforeLoad. It cannot guarantee that beforeLoad will execute the sub-application script first and then execute. This will cause a breaking change for anyone using beforeLoad to monitor the performance of asset downloads.