### PR TITLE
fix(loader): we should invoke our script load listener before its own

### DIFF
--- a/.changeset/thin-ways-allow.md
+++ b/.changeset/thin-ways-allow.md
@@ -1,0 +1,5 @@
+---
+"@qiankunjs/loader": patch
+---
+
+fix(loader): we should invoke our script load listener before its own


### PR DESCRIPTION
- Use the onload/onerror approach to listen to script events in order to follow the writable-dom.
- Our script load listener should be invoked before the script's own listener, as the listener might append another script, thus causing our entry to be fired delayed.