### PR TITLE
fix: createElement hijack must be paired to avoid rewriting leak

### DIFF
--- a/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
@@ -66,10 +66,7 @@ function patchDocument(cfg: { sandbox: SandBox; speedy: boolean }) {
 
     const proxyDocument = new Proxy(document, {
       /**
-       * Read and write must be synchronized, otherwise the write operation will leak to the global
-       * @param target
-       * @param p
-       * @param value
+       * Read and write must be paired, otherwise the write operation will leak to the global
        */
       set: (target, p, value) => {
         switch (p) {

--- a/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
@@ -59,16 +59,40 @@ function patchDocument(cfg: { sandbox: SandBox; speedy: boolean }) {
   };
 
   if (speedy) {
+    const modifications: {
+      createElement?: typeof document.createElement;
+      querySelector?: typeof document.querySelector;
+    } = {};
+
     const proxyDocument = new Proxy(document, {
+      /**
+       * Read and write must be synchronized, otherwise the write operation will leak to the global
+       * @param target
+       * @param p
+       * @param value
+       */
       set: (target, p, value) => {
-        (<any>target)[p] = value;
+        switch (p) {
+          case 'createElement': {
+            modifications.createElement = value;
+            break;
+          }
+          case 'querySelector': {
+            modifications.querySelector = value;
+            break;
+          }
+          default:
+            (<any>target)[p] = value;
+            break;
+        }
+
         return true;
       },
       get: (target, p, receiver) => {
         switch (p) {
           case 'createElement': {
             // Must store the original createElement function to avoid error in nested sandbox
-            const targetCreateElement = target.createElement;
+            const targetCreateElement = modifications.createElement || target.createElement;
             return function createElement(...args: Parameters<typeof document.createElement>) {
               if (!nativeGlobal.__currentLockingSandbox__) {
                 nativeGlobal.__currentLockingSandbox__ = sandbox.name;
@@ -87,7 +111,7 @@ function patchDocument(cfg: { sandbox: SandBox; speedy: boolean }) {
           }
 
           case 'querySelector': {
-            const targetQuerySelector = target.querySelector;
+            const targetQuerySelector = target.querySelector || modifications.querySelector;
             return function querySelector(...args: Parameters<typeof document.querySelector>) {
               const selector = args[0];
               switch (selector) {

--- a/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
+++ b/src/sandbox/patchers/dynamicAppend/forStrictSandbox.ts
@@ -108,7 +108,7 @@ function patchDocument(cfg: { sandbox: SandBox; speedy: boolean }) {
           }
 
           case 'querySelector': {
-            const targetQuerySelector = target.querySelector || modifications.querySelector;
+            const targetQuerySelector = modifications.querySelector || target.querySelector;
             return function querySelector(...args: Parameters<typeof document.querySelector>) {
               const selector = args[0];
               switch (selector) {


### PR DESCRIPTION
当子应用复写了 document.createElement 的时候，会导致全局的 document.createElement 也被改写，从而导致主应用的元素创建也被视为子应用，比如子应用中这样一段代码：
```js
const nativeCreateElement = document.createElement;
document.createElement = (...args) => {
  return nativeCreateElement.call(document, ...args);
}
```