### PR TITLE
fix: dynamic append element should support for the same container between micro apps

### DIFF
--- a/.changeset/smart-scissors-sell.md
+++ b/.changeset/smart-scissors-sell.md
@@ -1,0 +1,8 @@
+---
+"@qiankunjs/loader": patch
+"qiankun": patch
+"@qiankunjs/sandbox": patch
+"@qiankunjs/shared": patch
+---
+
+fix: dynamic append element should support for the same container between micro apps

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -104,7 +104,7 @@ export async function loadEntry<T>(entry: Entry, container: HTMLElement, opts: L
             queueDeferScript = queue;
           }
 
-          const transformedNode = nodeTransformer ? nodeTransformer(clone, entry, transformerOpts) : clone;
+          const transformedNode = nodeTransformer ? nodeTransformer(clone, transformerOpts) : clone;
 
           const script = transformedNode as unknown as HTMLScriptElement;
 

--- a/packages/qiankun/src/core/loadApp.ts
+++ b/packages/qiankun/src/core/loadApp.ts
@@ -29,9 +29,9 @@ export default async function loadApp<T extends ObjectType>(
   lifeCycles?: LifeCycles<T>,
 ): Promise<ParcelConfigObjectGetter> {
   const { name: appName, entry, container } = app;
-  const defaultNodeTransformer: AppConfiguration['nodeTransformer'] = (node, baseURI, opts) => {
+  const defaultNodeTransformer: AppConfiguration['nodeTransformer'] = (node, opts) => {
     const moduleResolver = (url: string) => defaultModuleResolver(url, sandboxMicroAppContainer, document.head);
-    return transpileAssets(node, baseURI, { ...opts, moduleResolver });
+    return transpileAssets(node, entry, { ...opts, moduleResolver });
   };
   const {
     fetch = window.fetch,

--- a/packages/qiankun/src/utils.ts
+++ b/packages/qiankun/src/utils.ts
@@ -85,6 +85,7 @@ export async function getPureHTMLStringWithoutScripts(entry: string, fetch: type
   const htmlDOM = domParser.parseFromString(htmlString, 'text/html');
   // remove all script tags who are been loaded before
   htmlDOM.querySelectorAll('script').forEach((script) => script.remove());
+  htmlDOM.querySelectorAll('link[rel=prefetch],link[rel=preload]').forEach((link) => link.remove());
 
   return htmlDOM.documentElement.outerHTML;
 }

--- a/packages/sandbox/src/patchers/dynamicAppend/common.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/common.ts
@@ -157,7 +157,7 @@ export function getOverwrittenAppendChildOrInsertBefore(
           }
 
           const { sandbox, nodeTransformer, fetch } = sandboxConfig;
-          const transpiledStyleSheetElement = nodeTransformer(stylesheetElement, location.href, {
+          const transpiledStyleSheetElement = nodeTransformer(stylesheetElement, {
             fetch,
             sandbox,
             rawNode: stylesheetElement,
@@ -199,7 +199,7 @@ export function getOverwrittenAppendChildOrInsertBefore(
             queueSyncScript = queue;
           }
 
-          const transpiledScriptElement = nodeTransformer(scriptElement, location.href, transformerOpts);
+          const transpiledScriptElement = nodeTransformer(scriptElement, transformerOpts);
 
           const result = appendChild.call(this, transpiledScriptElement, refChild) as T;
 
@@ -277,8 +277,8 @@ export function getNewRemoveChild(
 }
 
 export function rebuildCSSRules(
-  styleSheetElements: HTMLStyleElement[],
-  reAppendElement: (stylesheetElement: HTMLStyleElement) => Promise<boolean>,
+  styleSheetElements: Array<HTMLStyleElement | HTMLLinkElement>,
+  reAppendElement: (stylesheetElement: HTMLStyleElement | HTMLLinkElement) => Promise<boolean>,
 ): Array<Promise<void>> {
   return styleSheetElements.map(async (styleSheetElement) => {
     // re-append the dynamic stylesheet to sub-app container

--- a/packages/sandbox/src/patchers/dynamicAppend/forStandardSandbox.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/forStandardSandbox.ts
@@ -60,7 +60,9 @@ const getSandboxConfig = (element: HTMLElement) => elementAttachSandboxConfigMap
 
 function patchDocument(sandbox: Sandbox, getContainer: () => HTMLElement): CallableFunction {
   const container = getContainer();
-  if (patchCacheWeakMap.has(container)) {
+  // dom container might be reused by multiple apps,
+  // thus we check its attached sandbox is same with current to avoid duplicate patch
+  if (patchCacheWeakMap.get(container) === sandbox) {
     return () => {};
   }
 
@@ -171,7 +173,7 @@ function patchDocument(sandbox: Sandbox, getContainer: () => HTMLElement): Calla
     document: { value: proxyDocument, writable: false, enumerable: true, configurable: true },
   });
 
-  patchCacheWeakMap.set(container, true);
+  patchCacheWeakMap.set(container, sandbox);
 
   return () => {
     unpatch();
@@ -356,9 +358,16 @@ export function patchStandardSandbox(
     // the dynamic style sheet could be removed automatically while unmounting
     return async function rebuild() {
       const container = getContainer();
+      const isElementExisted = (element: HTMLStyleElement | HTMLLinkElement) => {
+        if (container.contains(element)) return true;
+        if ('rel' in element && element.rel === 'stylesheet' && element.href)
+          return !!container.querySelector(`link[rel=stylesheet][href=${element.href}]`);
+        return false;
+      };
+
       await Promise.all(
-        rebuildCSSRules(dynamicStyleSheetElements as HTMLStyleElement[], async (stylesheetElement) => {
-          if (!container.contains(stylesheetElement)) {
+        rebuildCSSRules(dynamicStyleSheetElements, async (stylesheetElement) => {
+          if (!isElementExisted(stylesheetElement)) {
             const mountDom =
               stylesheetElement[styleElementTargetSymbol] === 'head'
                 ? (() => {
@@ -372,13 +381,15 @@ export function patchStandardSandbox(
                   })()
                 : container;
 
-            // micro app rendering should wait unit the rebuilding link element is loaded, otherwise it may cause style blink
-            // As one link element will just trigger loaded event once, although we append it multiple times, we need to clone it before every appending
-            const cloneStyleElement = stylesheetElement.cloneNode(true) as HTMLLinkElement;
+            let styleElement = stylesheetElement;
+
             const deferred = new Deferred<boolean>();
-            if (cloneStyleElement.rel === 'stylesheet' && cloneStyleElement.href) {
-              cloneStyleElement.onload = () => deferred.resolve(true);
-              cloneStyleElement.onerror = () => deferred.resolve(false);
+            if ('rel' in styleElement && styleElement.rel === 'stylesheet' && styleElement.href) {
+              // micro app rendering should wait unit the rebuilding link element is loaded, otherwise it may cause style blink
+              // As one external link element will just trigger loaded event once, although we append it multiple times, we need to clone it before every appending
+              styleElement = styleElement.cloneNode(true) as HTMLLinkElement;
+              styleElement.onload = () => deferred.resolve(true);
+              styleElement.onerror = () => deferred.resolve(false);
             } else {
               deferred.resolve(true);
             }
@@ -388,9 +399,9 @@ export function patchStandardSandbox(
               // the reference node may be dynamic script comment which is not rebuilt while remounting thus reference node no longer exists
               // in this case, we should append the style element to the end of mountDom
               const refNode = mountDom.childNodes[refNo];
-              rawHeadInsertBefore.call(mountDom, cloneStyleElement, refNode);
+              rawHeadInsertBefore.call(mountDom, styleElement, refNode);
             } else {
-              rawHeadAppendChild.call(mountDom, cloneStyleElement);
+              rawHeadAppendChild.call(mountDom, styleElement);
             }
 
             return deferred.promise;

--- a/packages/shared/src/assets-transpilers/types.ts
+++ b/packages/shared/src/assets-transpilers/types.ts
@@ -15,11 +15,7 @@ export type BaseTranspilerOpts = BaseLoaderOpts & {
 
 export type AssetsTranspilerOpts = BaseTranspilerOpts & { rawNode: Node };
 
-export type NodeTransformer = <T extends Node>(
-  node: T,
-  baseURI: string,
-  opts: Omit<AssetsTranspilerOpts, 'moduleResolver'>,
-) => T;
+export type NodeTransformer = <T extends Node>(node: T, opts: Omit<AssetsTranspilerOpts, 'moduleResolver'>) => T;
 
 export type ScriptTranspilerOpts = AssetsTranspilerOpts &
   (


### PR DESCRIPTION
- [x] 当子应用使用的是同一个 container 时，需要通过 container 及 sandbox 实例做对比，从而减少不必要的重复 patch
- [x] 二次加载时过滤 prefetch、preload 的资源
- [x] remount 时仅 clone 外链样式，同时需要做样式是否已被加载过的判断，避免同一个外链 CSS 被加载多次
- [x] remount 时资源的 baseURI 也应该从 entry 计算得来