### PR TITLE
fix:  snapshotSandbox delete props escape to window

### DIFF
--- a/src/sandbox/__tests__/snapshotSandBox.test.ts
+++ b/src/sandbox/__tests__/snapshotSandBox.test.ts
@@ -1,0 +1,52 @@
+import SnapshotSandbox from '../snapshotSandbox';
+
+it('modify, add and delete  props should isolated at sandbox', () => {
+  window.globalProps = { a: 1 };
+  window.globalDeletedProps = { b: [] };
+  const sandbox1 = new SnapshotSandbox('app1');
+  const sandbox2 = new SnapshotSandbox('app2');
+  sandbox1.active();
+  window.globalProps = { a: 2 };
+  window.globalAddedProps = 3;
+  delete window.globalDeletedProps;
+  sandbox1.inactive();
+  // change to sandbox2
+  sandbox2.active();
+  expect(window.globalProps).toEqual({ a: 1 });
+  expect(window.globalAddedProps).not.toBeDefined();
+  expect(window.globalDeletedProps).toEqual({ b: [] });
+  sandbox2.inactive();
+  // restore sandbox1
+  sandbox1.active();
+  expect(window.globalProps).toEqual({ a: 2 });
+  expect(window.globalAddedProps).toEqual(3);
+  expect(window.globalDeletedProps).not.toBeDefined();
+  // add delete props
+  window.globalDeletedProps = { b: [2] };
+  sandbox1.inactive();
+  expect(window.globalDeletedProps).toEqual({ b: [] });
+  sandbox1.active();
+  expect(window.globalDeletedProps).toEqual({ b: [2] });
+  // delete props again
+  delete window.globalDeletedProps;
+  sandbox1.inactive();
+  expect(window.globalDeletedProps).toEqual({ b: [] });
+  sandbox1.active();
+  expect(window.globalDeletedProps).not.toBeDefined();
+  // 1. add props 2. modify props 2. delete props
+  window.globalDeletedProps = { b: [2] };
+  window.globalDeletedProps = { b: [3] };
+  delete window.globalDeletedProps;
+  sandbox1.inactive();
+  expect(window.globalDeletedProps).toEqual({ b: [] });
+  sandbox1.active();
+  expect(window.globalDeletedProps).not.toBeDefined();
+  // 1. delete props 2. add props 3. modify props
+  delete window.globalAddedProps;
+  window.globalAddedProps = 3;
+  window.globalAddedProps = 4;
+  sandbox1.inactive();
+  expect(window.globalAddedProps).not.toBeDefined();
+  sandbox1.active();
+  expect(window.globalAddedProps).toEqual(4);
+});

--- a/src/sandbox/snapshotSandbox.ts
+++ b/src/sandbox/snapshotSandbox.ts
@@ -31,7 +31,7 @@ export default class SnapshotSandbox implements SandBox {
 
   private modifyPropsMap: Record<any, any> = {};
 
-  private deletePropsSet: Set<string> = new Set();
+  private deletePropsSet: Set<any> = new Set();
 
   constructor(name: string) {
     this.name = name;
@@ -52,7 +52,7 @@ export default class SnapshotSandbox implements SandBox {
     });
 
     // 删除之前删除的属性
-    this.deletePropsSet.forEach((p: string) => {
+    this.deletePropsSet.forEach((p: any) => {
       delete window[p];
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
Ensure that delete props in the snapshotSandbox not affect the global environment
- resolve https://github.com/umijs/qiankun/issues/2629
