### PR TITLE
feat: remove webpack chunk cache attributes just while there are multi instances loaded on document

### DIFF
--- a/.changeset/orange-boats-allow.md
+++ b/.changeset/orange-boats-allow.md
@@ -1,0 +1,6 @@
+---
+"qiankun": patch
+"@qiankunjs/shared": patch
+---
+
+feat: remove webpack chunk cache attributes just while there are multi instances loaded on document

--- a/packages/shared/src/assets-transpilers/script.ts
+++ b/packages/shared/src/assets-transpilers/script.ts
@@ -79,11 +79,6 @@ export default function transpileScript(
   const srcAttribute = script.getAttribute('src');
   const { sandbox, scriptTranspiledDeferred } = opts;
 
-  // To prevent webpack from skipping reload logic and causing the js not to re-execute when a micro app is loaded multiple times, the data-webpack attribute of the script must be removed.
-  // see https://github.com/webpack/webpack/blob/1f13ff9fe587e094df59d660b4611b1bd19aed4c/lib/runtime/LoadScriptRuntimeModule.js#L131-L136
-  // FIXME We should determine whether the current micro application is being loaded for the second time. If not, this removal should not be performed.
-  script.removeAttribute('data-webpack');
-
   try {
     const { mode, result } = preTranspile(
       {


### PR DESCRIPTION
当且仅当文档上同时挂载`同一个应用多次`时，需要移除 webpack 的缓存，从而避免后续挂载的子应用实例因为命中了 webpack 的缓存，从而不再新建对应的 chunk script，导致 chunk 缺失

- ref https://github.com/umijs/qiankun/issues/2727