### PR TITLE
fix:addEventlistener memory leak.

### DIFF
--- a/src/sandbox/patchers/windowListener.ts
+++ b/src/sandbox/patchers/windowListener.ts
@@ -85,10 +85,10 @@ export default function patch(global: WindowProxy) {
     rawListener: EventListenerOrEventListenerObject,
     rawOptions?: boolean | AddEventListenerOptions,
   ) => {
-    const addLstener = addCacheListener(listenerMap, type, rawListener, rawOptions);
+    const addListener = addCacheListener(listenerMap, type, rawListener, rawOptions);
     // 如果返回空，则代表事件已经添加过了，不需要重复添加
-    if (!addLstener) return;
-    const { listener, options } = addLstener;
+    if (!addListener) return;
+    const { listener, options } = addListener;
     return rawAddEventListener.call(window, type, listener, options);
   };
 

--- a/src/sandbox/patchers/windowListener.ts
+++ b/src/sandbox/patchers/windowListener.ts
@@ -106,6 +106,8 @@ export default function patch(global: WindowProxy) {
       [...listeners].forEach(({ rawListener, options }) => 
         global.removeEventListener(type, rawListener, options)
     ));
+    // 清空listenerMap，避免listenerMap中还存有listener导致内存泄漏
+    listenerMap.clear();
     global.addEventListener = rawAddEventListener;
     global.removeEventListener = rawRemoveEventListener;
 

--- a/src/sandbox/patchers/windowListener.ts
+++ b/src/sandbox/patchers/windowListener.ts
@@ -22,7 +22,7 @@ const removeCacheListener = (
   listenerMap: Map<string, ListenerMapObject[]>,
   type: string,
   rawListener: EventListenerOrEventListenerObject,
-  rawOptions?: boolean | AddEventListenerOptions
+  rawOptions?: boolean | AddEventListenerOptions,
 ): ListenerMapObject => {
   // 处理 options，确保它是一个对象
   let options = typeof rawOptions === 'object' ? rawOptions : { capture: !!rawOptions };
@@ -33,7 +33,7 @@ const removeCacheListener = (
   // listener和capture/useCapture都相同，认为是同一个监听
   // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener
   const findIndex = cachedTypeListeners.findIndex(
-    item => item.rawListener === rawListener && item.options.capture == options.capture
+    (item) => item.rawListener === rawListener && item.options.capture == options.capture,
   );
   if (findIndex > -1) {
     const cacheListener = cachedTypeListeners[findIndex];
@@ -50,7 +50,7 @@ const addCacheListener = (
   listenerMap: Map<string, ListenerMapObject[]>,
   type: string,
   rawListener: EventListenerOrEventListenerObject,
-  rawOptions?: boolean | AddEventListenerOptions
+  rawOptions?: boolean | AddEventListenerOptions,
 ): ListenerMapObject => {
   // 处理 options，确保它是一个对象
   let options = typeof rawOptions === 'object' ? rawOptions : { capture: !!rawOptions };
@@ -61,7 +61,7 @@ const addCacheListener = (
   // listener和capture/useCapture都相同，认为是同一个监听
   // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener
   const findIndex = cachedTypeListeners.findIndex(
-    item => item.rawListener === rawListener && item.options.capture == options.capture
+    (item) => item.rawListener === rawListener && item.options.capture == options.capture,
   );
   if (findIndex > -1) {
     const { listener: findListener, options: findOptions } = cachedTypeListeners[findIndex];
@@ -71,10 +71,11 @@ const addCacheListener = (
   }
   let listener: EventListenerOrEventListenerObject = rawListener;
 
-  if (options.once) listener = (event: Event) => {
-    (rawListener as EventListener)(event);
-    removeCacheListener(listenerMap, type, rawListener, options);
-  };
+  if (options.once)
+    listener = (event: Event) => {
+      (rawListener as EventListener)(event);
+      removeCacheListener(listenerMap, type, rawListener, options);
+    };
   const cacheListener = { listener, options, rawListener };
   listenerMap.set(type, [...cachedTypeListeners, cacheListener]);
   return cacheListener;
@@ -103,9 +104,8 @@ export default function patch(global: WindowProxy) {
 
   return function free() {
     listenerMap.forEach((listeners, type) =>
-      [...listeners].forEach(({ rawListener, options }) => 
-        global.removeEventListener(type, rawListener, options)
-    ));
+      [...listeners].forEach(({ rawListener, options }) => global.removeEventListener(type, rawListener, options)),
+    );
     // 清空listenerMap，避免listenerMap中还存有listener导致内存泄漏
     listenerMap.clear();
     global.addEventListener = rawAddEventListener;

--- a/src/sandbox/patchers/windowListener.ts
+++ b/src/sandbox/patchers/windowListener.ts
@@ -9,35 +9,103 @@ import { noop } from 'lodash';
 const rawAddEventListener = window.addEventListener;
 const rawRemoveEventListener = window.removeEventListener;
 
+type ListenerMapObject = {
+  listener: EventListenerOrEventListenerObject;
+  options: AddEventListenerOptions;
+  rawListener: EventListenerOrEventListenerObject;
+};
+
+const DEFAULT_OPTIONS: AddEventListenerOptions = { capture: false, once: false, passive: false };
+
+// 添加监听构造一个cacheListener对象，考虑到多次添加同一个监听和once的情况
+const addCacheListener = (
+  listenerMap: Map<string, ListenerMapObject[]>,
+  type: string,
+  rawListener: EventListenerOrEventListenerObject,
+  rawOptions?: boolean | AddEventListenerOptions
+): ListenerMapObject => {
+  // 处理 options，确保它是一个对象
+  let options = typeof rawOptions === 'object' ? rawOptions : { capture: !!rawOptions };
+  // 如果 options 为 null，使用默认值
+  options = options ?? DEFAULT_OPTIONS;
+
+  const cachedTypeListeners = listenerMap.get(type) || [];
+  // listener和capture/useCapture都相同，认为是同一个监听
+  // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener
+  const findIndex = cachedTypeListeners.findIndex(
+    item => item.rawListener === rawListener && item.options.capture == options.capture
+  );
+  if (findIndex > -1) {
+    const { listener, options } = cachedTypeListeners[findIndex];
+    // 如果存在相同的监听，先移除之前的监听，在添加新的监听
+    rawRemoveEventListener.call(window, type, listener, options);
+    cachedTypeListeners.splice(findIndex, 1);
+  }
+  let listener: EventListenerOrEventListenerObject = rawListener;
+
+  if (options.once) listener = (event: Event) => {
+    (rawListener as EventListener)(event);
+    removeCacheListener(listenerMap, type, rawListener, options);
+  };
+  const cacheListener = { listener, options, rawListener };
+  listenerMap.set(type, [...cachedTypeListeners, cacheListener]);
+  return cacheListener;
+};
+
+// 移除cacheListener
+const removeCacheListener = (
+  listenerMap: Map<string, ListenerMapObject[]>,
+  type: string,
+  rawListener: EventListenerOrEventListenerObject,
+  rawOptions?: boolean | AddEventListenerOptions
+): ListenerMapObject => {
+  // 处理 options，确保它是一个对象
+  let options = typeof rawOptions === 'object' ? rawOptions : { capture: !!rawOptions };
+  // 如果 options 为 null，使用默认值
+  options = options ?? DEFAULT_OPTIONS;
+
+  const cachedTypeListeners = listenerMap.get(type) || [];
+  // listener和capture/useCapture都相同，认为是同一个监听
+  // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener
+  const findIndex = cachedTypeListeners.findIndex(
+    item => item.rawListener === rawListener && item.options.capture == options.capture
+  );
+  if (findIndex > -1) {
+    const cacheListener = cachedTypeListeners[findIndex];
+    cachedTypeListeners.splice(findIndex, 1);
+    return cacheListener;
+  }
+
+  // 返回原始listener和options
+  return { listener: rawListener, rawListener, options };
+};
+
 export default function patch(global: WindowProxy) {
-  const listenerMap = new Map<string, EventListenerOrEventListenerObject[]>();
+  const listenerMap = new Map<string, ListenerMapObject[]>();
 
   global.addEventListener = (
     type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions,
+    rawListener: EventListenerOrEventListenerObject,
+    rawOptions?: boolean | AddEventListenerOptions,
   ) => {
-    const listeners = listenerMap.get(type) || [];
-    listenerMap.set(type, [...listeners, listener]);
+    const { listener, options } = addCacheListener(listenerMap, type, rawListener, rawOptions);
     return rawAddEventListener.call(window, type, listener, options);
   };
 
   global.removeEventListener = (
     type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions,
+    rawListener: EventListenerOrEventListenerObject,
+    rawOptions?: boolean | AddEventListenerOptions,
   ) => {
-    const storedTypeListeners = listenerMap.get(type);
-    if (storedTypeListeners && storedTypeListeners.length && storedTypeListeners.indexOf(listener) !== -1) {
-      storedTypeListeners.splice(storedTypeListeners.indexOf(listener), 1);
-    }
+    const { listener, options } = removeCacheListener(listenerMap, type, rawListener, rawOptions);
     return rawRemoveEventListener.call(window, type, listener, options);
   };
 
   return function free() {
     listenerMap.forEach((listeners, type) =>
-      [...listeners].forEach((listener) => global.removeEventListener(type, listener)),
-    );
+      [...listeners].forEach(({ rawListener, options }) => 
+        global.removeEventListener(type, rawListener, options)
+    ));
     global.addEventListener = rawAddEventListener;
     global.removeEventListener = rawRemoveEventListener;
 


### PR DESCRIPTION
场景1:当用户通过addEventlistener多次添加同一个监听时，如果listener和capture/useCapture都相同，浏览器会认为是同一个监听，后添加的监听会覆盖之前添加的监听，取消的时候也只需要取消一次；
场景2:另外当options的once为true时，如果监听执行了是不需要取消的。

问题：针对以上两种情形，如果用户多次添加同一个监听，或者options中的once设为true，没有移除监听，就会导致listenerMap中的监听无法移除。

解决方案：针对多次添加同一个监听情况做判断，如果是同一个监听capture/useCapture都相同，则先移除之前的监听在添加新的监听，针对once场景，当监听执行后自动移除listenerMap中的监听。