### PR TITLE
🥔chore: css process exclude option selector

### DIFF
--- a/src/sandbox/patchers/css.ts
+++ b/src/sandbox/patchers/css.ts
@@ -150,8 +150,9 @@ export class ScopedCSS {
 
     // handle grouping selector, a,span,p,div { ... }
     cssText = cssText.replace(/^[\s\S]+{/, (selectors) =>
-      selectors.replace(/(^|,\n?)([^,]+)/g, (item, p, s) => {
+      selectors.replace(/(^|,\n?)([^,\[\]]+(?![^\[]*\]))/g, (item, p, s) => {
         // handle div,body,span { ... }
+        // exclude option selector
         if (rootSelectorRE.test(item)) {
           return item.replace(rootSelectorRE, (m) => {
             // do not discard valid previous character, such as body,html or *:not(:root)


### PR DESCRIPTION
开启sandbox BEM样式隔离时存在一个bug，style中的属性选择器会被打乱。例如
![Uploading image.png…]()
