### PR TITLE
feat(loader): supports passing Response as entry parameter for loadEntry function

### DIFF
--- a/.changeset/red-islands-mate.md
+++ b/.changeset/red-islands-mate.md
@@ -1,0 +1,6 @@
+---
+"@qiankunjs/loader": patch
+"qiankun": patch
+---
+
+feat(loader): supports passing Response as entry parameter for loadEntry function

--- a/packages/loader/src/utils.ts
+++ b/packages/loader/src/utils.ts
@@ -1,9 +1,3 @@
-export function getEntireUrl(uri: string, baseURI: string): string {
-  const publicPath = new URL(baseURI, window.location.href);
-  const entireUrl = new URL(uri, publicPath.toString());
-  return entireUrl.toString();
-}
-
 export function isUrlHasOwnProtocol(url: string): boolean {
   const protocols = ['http://', 'https://', '//', 'blob:', 'data:'];
   return protocols.some((protocol) => url.startsWith(protocol));

--- a/packages/qiankun/src/core/loadApp.ts
+++ b/packages/qiankun/src/core/loadApp.ts
@@ -140,7 +140,11 @@ export default async function loadApp<T extends ObjectType>(
             initContainer(mountContainer, appName, { sandboxCfg: sandbox, mountTimes, instanceId });
             // html scripts should be removed to avoid repeatedly execute
             const htmlString = await getPureHTMLStringWithoutScripts(entry, fetchWithLruCache);
-            await loadEntry(htmlString, mountContainer, containerOpts);
+            await loadEntry(
+              { url: entry, res: new Response(htmlString, { status: 200, statusText: 'OK' }) },
+              mountContainer,
+              containerOpts,
+            );
           }
         },
         async () => {


### PR DESCRIPTION
entry 可能是相对路径，如 `/index.html`，直接在 loadEntry 入参里区分是外链还是已经有内容的，而不是通过字符串判断