### PR TITLE
fix: loadMicroApp场景下也能设置全局的微前端配置。在umi使用qiankun的时候是用的loadMicroApp，目前发现添加withCredital之后，qiankun对子应用懒加载的js不会携带cookie

### DIFF
--- a/src/apis.ts
+++ b/src/apis.ts
@@ -98,7 +98,8 @@ export function loadMicroApp<T extends ObjectType>(
   lifeCycles?: FrameworkLifeCycles<T>,
 ): MicroApp {
   const { props, name } = app;
-
+  const { autoStart, ...restConfiguration } = configuration ?? {};
+  frameworkConfiguration = { prefetch: true, singular: true, sandbox: true, ...restConfiguration };
   const container = 'container' in app ? app.container : undefined;
   // Must compute the container xpath at beginning to keep it consist around app running
   // If we compute it every time, the container dom structure most probably been changed and result in a different xpath value


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

- any feature?
- close https://github.com/umijs/qiankun/ISSUE_URL
