### PR TITLE
Update links to single-spa

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 > In Chinese, `qian(乾)` means heaven and `kun(坤)` earth. `qiankun` is the universe.
 
-Qiankun enables you and your teams to build next-generation and enterprise-ready web applications leveraging [Micro Frontends](https://micro-frontends.org/). It is inspired by and based on [single-spa](https://github.com/CanopyTax/single-spa).
+Qiankun enables you and your teams to build next-generation and enterprise-ready web applications leveraging [Micro Frontends](https://micro-frontends.org/). It is inspired by and based on [single-spa](https://github.com/single-spa/single-spa).
 
 ## 🤔 Motivation
 
@@ -43,7 +43,7 @@ After solving these common problems of micro frontends and lots of polishing and
 
 ## :sparkles: Features
 
-Qiankun inherits many benefits from [single-spa](https://github.com/CanopyTax/single-spa):
+Qiankun inherits many benefits from [single-spa](https://github.com/single-spa/single-spa):
 
 - 📦 **Micro-apps Independent Deployment**
 - 🛴 **Lazy Load**
@@ -130,7 +130,7 @@ Thanks to all the contributors!
 
 ## 🎁 Acknowledgements
 
-- [single-spa](https://github.com/CanopyTax/single-spa) What an awesome meta-framework for micro-frontends!
+- [single-spa](https://github.com/single-spa/single-spa) What an awesome meta-framework for micro-frontends!
 - [writable-dom](https://github.com/marko-js/writable-dom/) Utility to stream HTML content into a live document.
 
 ## 📄 License


### PR DESCRIPTION
##### Description of change

The single-spa repository was transferred to the single-spa organization, this pull request updates the links.

I also see that the [qiankun package.json](https://github.com/umijs/qiankun/blob/af8d1d6934c39aa152c890bb86baaae04ac603ea/packages/qiankun/package.json#L39) has a dependency on single-spa@6, with some typescript imports. Single-spa@7 is in beta and has been rewritten to typescript: does qiankun plan to continue using the single-spa library and upgrade to single-spa@7? I have not kept up-to-date with qiankun 3's roadmap or plans, and understand if the project has diverged enough to no longer collaborate. My progress on single-spa roadmap and maintenance is slow and unpredictable, but I hope to continue improving the project. If any collaboration between the two projects would be beneficial for qiankun, I am happy to discuss it. Regardless, I wish the qiankun project and community best wishes.