### PR TITLE
fix(a11y): Add alt attributes to group images for accessibility

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -133,7 +133,7 @@ export async function unmount(props) {
 
 | GitHub Discussions | DingTalk Group | WeChat Group |
 | --- | --- | --- |
-| [qiankun discussions](https://github.com/umijs/qiankun/discussions) | <img src="https://mdn.alipayobjects.com/huamei_zvchwx/afts/img/A*GG8zTJaUnTAAAAAAAAAAAAAADuWEAQ/original" width="150" /> | [view group QR code](https://github.com/umijs/qiankun/discussions/2343) |
+| [qiankun discussions](https://github.com/umijs/qiankun/discussions) | <img src="https://mdn.alipayobjects.com/huamei_zvchwx/afts/img/A*GG8zTJaUnTAAAAAAAAAAAAAADuWEAQ/original" width="150" alt="DingTalk Group QR Code" /> | [view group QR code](https://github.com/umijs/qiankun/discussions/2343) |
 
 <style>
 .features-grid {

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -133,7 +133,7 @@ export async function unmount(props) {
 
 | GitHub 讨论 | 钉钉群 | 微信群 |
 | --- | --- | --- |
-| [qiankun 讨论](https://github.com/umijs/qiankun/discussions) | <img src="https://mdn.alipayobjects.com/huamei_zvchwx/afts/img/A*GG8zTJaUnTAAAAAAAAAAAAAADuWEAQ/original" width="150" /> | [查看群二维码](https://github.com/umijs/qiankun/discussions/2343) |
+| [qiankun 讨论](https://github.com/umijs/qiankun/discussions) | <img src="https://mdn.alipayobjects.com/huamei_zvchwx/afts/img/A*GG8zTJaUnTAAAAAAAAAAAAAADuWEAQ/original" width="150" alt="钉钉群二维码" /> | [查看群二维码](https://github.com/umijs/qiankun/discussions/2343) |
 
 <style>
 .features-grid {


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests.
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试。
Contributors guide: https://github.com/umijs/qiankun/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

### **Issue Description**
When running [IBM Accessibility Checker](https://github.com/IBMa/equal-access) (Version 4.0.9) on the [website](https://qiankun.umijs.org/), 1 violation was identified in the `.md` doc. The discussion group QR code images in documentation files were missing alt attributes, making it inaccessible to screen reader users.

<img width="2560" height="925" alt="image" src="https://github.com/user-attachments/assets/a7d4524d-40db-4087-8220-9cf1a8d2ce2b" />

Why is this important?
When an image contains important information, providing a text alternative makes the same information accessible through assistive technologies, such as a Braille display. When an image is decorative or redundant, providing correct markup allows assistive technologies to ignore or not repeat the information.

### **Fix Description**

Added descriptive alt attributes to the group image:

- English documentation: `alt="DingTalk Group QR Code"`
- Chinese documentation: `alt="钉钉群二维码"`

This ensures that users relying on assistive technologies can understand these are QR codes for joining discussion groups.

**Generated Patch**

```
diff --git a/docs/index.md b/docs/index.md
index f1cded0a..6d21d569 100644
--- a/docs/index.md
+++ b/docs/index.md
@@ -133,7 +133,7 @@ export async function unmount(props) {
 
 | GitHub Discussions | DingTalk Group | WeChat Group |
 | --- | --- | --- |
-| [qiankun discussions](https://github.com/umijs/qiankun/discussions) | <img src="https://mdn.alipayobjects.com/huamei_zvchwx/afts/img/A*GG8zTJaUnTAAAAAAAAAAAAAADuWEAQ/original" width="150" /> | [view group QR code](https://github.com/umijs/qiankun/discussions/2343) |
+| [qiankun discussions](https://github.com/umijs/qiankun/discussions) | <img src="https://mdn.alipayobjects.com/huamei_zvchwx/afts/img/A*GG8zTJaUnTAAAAAAAAAAAAAADuWEAQ/original" width="150" alt="DingTalk Group QR Code" /> | [view group QR code](https://github.com/umijs/qiankun/discussions/2343) |
 
 <style>
 .features-grid {
@@ -165,4 +165,4 @@ export async function unmount(props) {
   color: var(--vp-c-text-2);
   line-height: 1.5;
 }
-</style> 
\ No newline at end of file
+</style> 
diff --git a/docs/zh-CN/index.md b/docs/zh-CN/index.md
index e2c7f2f6..6523a89e 100644
--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -133,7 +133,7 @@ export async function unmount(props) {
 
 | GitHub 讨论 | 钉钉群 | 微信群 |
 | --- | --- | --- |
-| [qiankun 讨论](https://github.com/umijs/qiankun/discussions) | <img src="https://mdn.alipayobjects.com/huamei_zvchwx/afts/img/A*GG8zTJaUnTAAAAAAAAAAAAAADuWEAQ/original" width="150" /> | [查看群二维码](https://github.com/umijs/qiankun/discussions/2343) |
+| [qiankun 讨论](https://github.com/umijs/qiankun/discussions) | <img src="https://mdn.alipayobjects.com/huamei_zvchwx/afts/img/A*GG8zTJaUnTAAAAAAAAAAAAAADuWEAQ/original" width="150" alt="钉钉群二维码" /> | [查看群二维码](https://github.com/umijs/qiankun/discussions/2343) |
 
 <style>
 .features-grid {
@@ -165,4 +165,4 @@ export async function unmount(props) {
   color: var(--vp-c-text-2);
   line-height: 1.5;
 }
-</style> 
\ No newline at end of file
+</style> 

```

The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications.
The generated fixes were manually reviewed and validated before submission.

**Fix Before:**
<img width="1786" height="914" alt="image" src="https://github.com/user-attachments/assets/00234192-cdbe-46ad-b423-38c34f5355f6" />

**Fix After:**
<img width="1869" height="914" alt="image" src="https://github.com/user-attachments/assets/846a6775-8c22-4855-a544-d0e3f311a428" />




