### PR TITLE
feat: improve fetch error message by prepending url

### DIFF
--- a/.changeset/spotty-plums-hear.md
+++ b/.changeset/spotty-plums-hear.md
@@ -1,0 +1,6 @@
+---
+"@qiankunjs/loader": patch
+"@qiankunjs/shared": patch
+---
+
+feat: improve fetch error message by prepending url

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -143,7 +143,7 @@ export async function loadEntry<T>(
                 } else {
                   entryScriptLoadedDeferred.reject(
                     new QiankunError(
-                      `Entry ${entryUrl} load failed as entry script ${script.dataset.src || script.src} load failed}`,
+                      `Entry ${entryUrl} load failed as entry script ${script.dataset.src || script.src} execution failed`,
                     ),
                   );
                 }

--- a/packages/shared/src/fetch-utils/__tests__/makeFetchThrowable.test.ts
+++ b/packages/shared/src/fetch-utils/__tests__/makeFetchThrowable.test.ts
@@ -8,6 +8,7 @@ import { makeFetchThrowable } from '../makeFetchThrowable';
 const slogan = 'Hello Qiankun 3.0';
 
 it('should throw error while response status is not 200~400', async () => {
+  expect.assertions(2);
   const fetch = vi.fn(() => {
     return Promise.resolve(new Response(slogan, { status: 400 }));
   });
@@ -23,6 +24,7 @@ it('should throw error while response status is not 200~400', async () => {
 });
 
 it('should prepend url to error message while fetch failed', async () => {
+  expect.assertions(1);
   const fetch = vi.fn(() => {
     return Promise.reject(new Error('Failed to fetch'));
   });
@@ -44,4 +46,55 @@ it('should work well while response status is 200', async () => {
   const url = 'https://success.qiankun.org';
   const res = await wrappedFetch(url);
   expect(res.status).toBe(200);
+});
+
+it('should still throw error when error.message is readonly', async () => {
+  expect.assertions(1);
+  const readonlyError = new TypeError('Network error');
+  Object.defineProperty(readonlyError, 'message', {
+    value: 'Network error',
+    writable: false,
+    configurable: false,
+  });
+  const fetch = vi.fn(() => {
+    return Promise.reject(readonlyError);
+  });
+  const wrappedFetch = makeFetchThrowable(fetch);
+  const url = 'https://readonly.qiankun.org';
+  try {
+    await wrappedFetch(url);
+  } catch (e) {
+    // The error should still be thrown even if message is readonly
+    expect(e).toBe(readonlyError);
+  }
+});
+
+it('should prepend url when url is a URL object', async () => {
+  expect.assertions(1);
+  const fetch = vi.fn(() => {
+    return Promise.reject(new Error('Failed to fetch'));
+  });
+  const wrappedFetch = makeFetchThrowable(fetch);
+  const url = new URL('https://url-object.qiankun.org/path');
+  try {
+    await wrappedFetch(url);
+  } catch (e) {
+    const error = e as unknown as Error;
+    expect(error.message).toBe(`${url.href} Failed to fetch`);
+  }
+});
+
+it('should prepend url when url is a Request object', async () => {
+  expect.assertions(1);
+  const fetch = vi.fn(() => {
+    return Promise.reject(new Error('Failed to fetch'));
+  });
+  const wrappedFetch = makeFetchThrowable(fetch);
+  const request = new Request('https://request-object.qiankun.org/path');
+  try {
+    await wrappedFetch(request);
+  } catch (e) {
+    const error = e as unknown as Error;
+    expect(error.message).toBe(`${request.url} Failed to fetch`);
+  }
 });

--- a/packages/shared/src/fetch-utils/__tests__/makeFetchThrowable.test.ts
+++ b/packages/shared/src/fetch-utils/__tests__/makeFetchThrowable.test.ts
@@ -16,7 +16,23 @@ it('should throw error while response status is not 200~400', async () => {
   try {
     await wrappedFetch(url);
   } catch (e) {
-    expect((e as unknown as Error).message).include('RESPONSE_ERROR_AS_STATUS_INVALID');
+    const error = e as unknown as Error;
+    expect(error.message).include('RESPONSE_ERROR_AS_STATUS_INVALID');
+    expect(error.message).include(url);
+  }
+});
+
+it('should prepend url to error message while fetch failed', async () => {
+  const fetch = vi.fn(() => {
+    return Promise.reject(new Error('Failed to fetch'));
+  });
+  const wrappedFetch = makeFetchThrowable(fetch);
+  const url = 'https://fail.qiankun.org';
+  try {
+    await wrappedFetch(url);
+  } catch (e) {
+    const error = e as unknown as Error;
+    expect(error.message).toBe(`${url} Failed to fetch`);
   }
 });
 

--- a/packages/shared/src/fetch-utils/makeFetchThrowable.ts
+++ b/packages/shared/src/fetch-utils/makeFetchThrowable.ts
@@ -8,13 +8,27 @@ import { type Fetch, isValidResponse } from './utils';
 
 export const makeFetchThrowable: (fetch: Fetch) => Fetch = (fetch) => {
   return async (url, init) => {
-    const res = await fetch(url, init);
+    const urlString = typeof url === 'string' ? url : 'url' in url ? url.url : url.href;
+
+    let res: Response;
+    try {
+      res = await fetch(url, init);
+    } catch (e) {
+      // The error message of fetch failed is usually "Failed to fetch"
+      // We need to prepend the url to the error message to make it easier to debug
+      // e.g. "https://example.com/script.js Failed to fetch"
+      try {
+        if (e instanceof Error && !e.message.includes(urlString)) {
+          e.message = `${urlString} ${e.message}`;
+        }
+      } catch (_) {
+        // e.message may be readonly
+      }
+      throw e;
+    }
+
     if (!isValidResponse(res.status)) {
-      throw new Error(
-        `[RESPONSE_ERROR_AS_STATUS_INVALID] ${res.status} ${res.statusText} ${
-          typeof url === 'string' ? url : 'url' in url ? url.url : url.href
-        } ${JSON.stringify(init)}`,
-      );
+      throw new Error(`${urlString} [RESPONSE_ERROR_AS_STATUS_INVALID] ${res.status} ${res.statusText}`);
     }
 
     return res;


### PR DESCRIPTION
## Summary
This PR improves the error messages for fetch operations by prepending the request URL. This makes it easier to identify which resource failed to load from monitoring logs or error reports.

It addresses issue #2973 by:
1. Wrapping `fetch` calls in `makeFetchThrowable` with a try-catch block to intercept network errors.
2. Prepending the URL to the error message for both network errors (e.g., "Failed to fetch") and invalid response status errors (e.g., 404, 500).

## Related Issue
Fixes #2973

## Changes
- Modified `packages/shared/src/fetch-utils/makeFetchThrowable.ts` to prepend URL to error messages.
- Updated `packages/shared/src/fetch-utils/__tests__/makeFetchThrowable.test.ts` to verify the new error message format.

## Verification
- Added new test case for network error: `should prepend url to error message while fetch failed`.
- Updated existing test case for invalid status: `should throw error while response status is not 200~400`.
- Ran tests via `pnpm run test packages/shared/src/fetch-utils/__tests__/makeFetchThrowable.test.ts`.