### PR TITLE
fix: add write permissions for changeset workflow

### DIFF
--- a/.github/workflows/changeset-prerelease.yml
+++ b/.github/workflows/changeset-prerelease.yml
@@ -7,7 +7,8 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   changelog:

--- a/package.json
+++ b/package.json
@@ -58,15 +58,9 @@
   },
   "homepage": "https://github.com/umijs/qiankun#readme",
   "lint-staged": {
-    "**/*.{js,ts,json,css,md}": [
-      "prettier --write --ignore-unknown"
-    ],
-    "packages/*/{src,types}/**/*.ts": [
-      "eslint --cache --ext .js,.jsx,.ts,.tsx --format=pretty --fix"
-    ],
-    "packages/**/*.d.ts": [
-      "eslint --ext .ts"
-    ]
+    "**/*.{js,ts,json,css,md}": ["prettier --write --ignore-unknown"],
+    "packages/*/{src,types}/**/*.ts": ["eslint --cache --ext .js,.jsx,.ts,.tsx --format=pretty --fix"],
+    "packages/**/*.d.ts": ["eslint --ext .ts"]
   },
   "packageManager": "pnpm@9.15.0",
   "publishConfig": {

--- a/packages/sandbox/src/utils.ts
+++ b/packages/sandbox/src/utils.ts
@@ -66,8 +66,8 @@ export function isPropertyFrozen(target: object, p?: PropertyKey): boolean {
   const propertyDescriptor = getOwnPropertyDescriptor(target, p);
   const frozen = Boolean(
     propertyDescriptor &&
-      propertyDescriptor.configurable === false &&
-      (propertyDescriptor.writable === false || (propertyDescriptor.get && !propertyDescriptor.set)),
+    propertyDescriptor.configurable === false &&
+    (propertyDescriptor.writable === false || (propertyDescriptor.get && !propertyDescriptor.set)),
   );
 
   targetPropertiesFromCache[p] = frozen;


### PR DESCRIPTION
## Summary

Fix the changeset workflow permission error that caused [CI failure](https://github.com/umijs/qiankun/actions/runs/21657857124/job/62436304726).

**Error:**
```
remote: Permission to umijs/qiankun.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/umijs/qiankun/': The requested URL returned error: 403
```

**Root cause:** `contents: read` permission doesn't allow pushing branches.

**Fix:**
- `contents: write` - allows `git push` to the `changeset-release/next` branch
- `pull-requests: write` - allows creating the version update PR