### PR TITLE
fix: expose currentScript during entry execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,18 @@ jobs:
         node-version: [14.x, 16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [18.x, 20.x]
+
+    env:
+      # father-build (1.x) and dumi (1.x) run on webpack 4, whose hashing breaks
+      # under OpenSSL 3 (Node 17+); fall back to the legacy provider.
+      NODE_OPTIONS: --openssl-legacy-provider
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
   },
   "resolutions": {
     "@types/history": "^4.x",
+    "@types/minimatch": "3.0.5",
     "@types/react": "^17.x"
   },
   "dependencies": {

--- a/src/__tests__/loader.test.ts
+++ b/src/__tests__/loader.test.ts
@@ -1,0 +1,120 @@
+import { importEntry } from 'import-html-entry';
+import { loadApp } from '../loader';
+
+jest.mock('import-html-entry', () => ({
+  importEntry: jest.fn(),
+}));
+
+const lifecycles = {
+  bootstrap: jest.fn(),
+  mount: jest.fn(),
+  unmount: jest.fn(),
+};
+
+const mockImportEntry = importEntry as jest.MockedFunction<typeof importEntry>;
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="container"></div>';
+  delete (window as any).app;
+  delete (window as any).asyncApp;
+  delete (window as any).microtaskApp;
+  delete (window as any).sandboxAsyncApp;
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('should expose document.currentScript while executing initial entry scripts', async () => {
+  const scriptUrl = 'http://localhost:7100/umi.js';
+
+  mockImportEntry.mockResolvedValue({
+    template: '<div></div>',
+    assetPublicPath: 'http://localhost:7100/',
+    getExternalScripts: () => Promise.resolve([]),
+    getExternalStyleSheets: () => Promise.resolve([]),
+    execScripts: (_global: Window, _strictGlobal: boolean, opts: any) => {
+      opts.beforeExec('window.__entry_loaded__ = true;', scriptUrl);
+
+      expect(document.currentScript).toBeInstanceOf(HTMLScriptElement);
+      expect((document.currentScript as HTMLScriptElement).src).toBe(scriptUrl);
+
+      opts.afterExec('window.__entry_loaded__ = true;', scriptUrl);
+      expect(document.currentScript).toBeNull();
+
+      return Promise.resolve(lifecycles);
+    },
+  } as any);
+
+  await loadApp(
+    {
+      name: 'app',
+      entry: 'http://localhost:7100/',
+      container: '#container',
+    },
+    {
+      sandbox: false,
+    } as any,
+  );
+});
+
+test('should cleanup document.currentScript when initial entry execution fails', async () => {
+  const scriptUrl = 'http://localhost:7100/umi.js';
+
+  mockImportEntry.mockResolvedValue({
+    template: '<div></div>',
+    assetPublicPath: 'http://localhost:7100/',
+    getExternalScripts: () => Promise.resolve([]),
+    getExternalStyleSheets: () => Promise.resolve([]),
+    execScripts: (_global: Window, _strictGlobal: boolean, opts: any) => {
+      opts.beforeExec('throw new Error("boom");', scriptUrl);
+      expect((document.currentScript as HTMLScriptElement).src).toBe(scriptUrl);
+
+      opts.error();
+      expect(document.currentScript).toBeNull();
+
+      return Promise.resolve(lifecycles);
+    },
+  } as any);
+
+  await loadApp(
+    {
+      name: 'app',
+      entry: 'http://localhost:7100/',
+      container: '#container',
+    },
+    {
+      sandbox: false,
+    },
+  );
+});
+
+test('should read lifecycle globals exposed in entry microtask', async () => {
+  mockImportEntry.mockResolvedValue({
+    template: '<div></div>',
+    assetPublicPath: 'http://localhost:7100/',
+    getExternalScripts: () => Promise.resolve([]),
+    getExternalStyleSheets: () => Promise.resolve([]),
+    execScripts: () => {
+      Promise.resolve().then(() => {
+        (window as any).microtaskApp = lifecycles;
+      });
+
+      return Promise.resolve({});
+    },
+  } as any);
+
+  await expect(
+    loadApp(
+      {
+        name: 'microtaskApp',
+        entry: 'http://localhost:7100/',
+        container: '#container',
+      },
+      {
+        sandbox: false,
+      },
+    ),
+  ).resolves.toEqual(expect.any(Function));
+});

--- a/src/__tests__/loader.test.ts
+++ b/src/__tests__/loader.test.ts
@@ -16,9 +16,7 @@ const mockImportEntry = importEntry as jest.MockedFunction<typeof importEntry>;
 beforeEach(() => {
   document.body.innerHTML = '<div id="container"></div>';
   delete (window as any).app;
-  delete (window as any).asyncApp;
   delete (window as any).microtaskApp;
-  delete (window as any).sandboxAsyncApp;
   jest.clearAllMocks();
 });
 
@@ -71,23 +69,26 @@ test('should cleanup document.currentScript when initial entry execution fails',
       opts.beforeExec('throw new Error("boom");', scriptUrl);
       expect((document.currentScript as HTMLScriptElement).src).toBe(scriptUrl);
 
-      opts.error();
-      expect(document.currentScript).toBeNull();
-
-      return Promise.resolve(lifecycles);
+      // simulate the entry script throwing: afterExec is not invoked and the promise rejects,
+      // so cleanup must happen through the `.finally` in loadApp
+      return Promise.reject(new Error('boom'));
     },
   } as any);
 
-  await loadApp(
-    {
-      name: 'app',
-      entry: 'http://localhost:7100/',
-      container: '#container',
-    },
-    {
-      sandbox: false,
-    },
-  );
+  await expect(
+    loadApp(
+      {
+        name: 'app',
+        entry: 'http://localhost:7100/',
+        container: '#container',
+      },
+      {
+        sandbox: false,
+      },
+    ),
+  ).rejects.toThrow('boom');
+
+  expect(document.currentScript).toBeNull();
 });
 
 test('should read lifecycle globals exposed in entry microtask', async () => {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -21,11 +21,13 @@ import { createSandboxContainer, css } from './sandbox';
 import { cachedGlobals } from './sandbox/proxySandbox';
 import {
   Deferred,
+  createFakeCurrentScript,
   genAppInstanceIdByName,
   getContainer,
   getDefaultTplWrapper,
   getWrapperId,
   isEnableScopedCSS,
+  patchCurrentScript,
   performanceGetEntriesByName,
   performanceMark,
   performanceMeasure,
@@ -208,6 +210,7 @@ function getLifecyclesFromExports(
   appName: string,
   global: WindowProxy,
   globalLatestSetProp?: PropertyKey | null,
+  silent = false,
 ) {
   if (validateExportLifecycle(scriptExports)) {
     return scriptExports;
@@ -221,7 +224,7 @@ function getLifecyclesFromExports(
     }
   }
 
-  if (process.env.NODE_ENV === 'development') {
+  if (!silent && process.env.NODE_ENV === 'development') {
     console.warn(
       `[qiankun] lifecycle not found from ${appName} entry exports, fallback to get from window['${appName}']`,
     );
@@ -315,7 +318,7 @@ export async function loadApp<T extends ObjectType>(
   const useLooseSandbox = typeof sandbox === 'object' && !!sandbox.loose;
   // enable speedy mode by default
   const speedySandbox = typeof sandbox === 'object' ? sandbox.speedy !== false : true;
-  let sandboxContainer;
+  let sandboxContainer: ReturnType<typeof createSandboxContainer> | undefined;
   if (sandbox) {
     sandboxContainer = createSandboxContainer(
       appInstanceId,
@@ -343,16 +346,34 @@ export async function loadApp<T extends ObjectType>(
 
   await execHooksChain(toArray(beforeLoad), app, global);
 
+  let resetCurrentScript = () => {};
+
   // get the lifecycle hooks from module exports
-  const scriptExports: any = await execScripts(global, sandbox && !useLooseSandbox, {
+  const execScriptOpts = {
     scopedGlobalVariables: speedySandbox ? cachedGlobals : [],
-  });
-  const { bootstrap, mount, unmount, update } = getLifecyclesFromExports(
-    scriptExports,
-    appName,
-    global,
-    sandboxContainer?.instance?.latestSetProp,
-  );
+    beforeExec: (_code: string, script: string) => {
+      resetCurrentScript();
+      resetCurrentScript = patchCurrentScript(createFakeCurrentScript(script));
+    },
+    afterExec: () => {
+      resetCurrentScript();
+      resetCurrentScript = () => {};
+    },
+    error: () => {
+      resetCurrentScript();
+      resetCurrentScript = () => {};
+    },
+  } as any;
+
+  let lifecycles: any;
+  try {
+    const scriptExports: any = await execScripts(global, sandbox && !useLooseSandbox, execScriptOpts);
+    lifecycles = getLifecyclesFromExports(scriptExports, appName, global, sandboxContainer?.instance?.latestSetProp);
+  } finally {
+    resetCurrentScript();
+  }
+
+  const { bootstrap, mount, unmount, update } = lifecycles;
 
   const { onGlobalStateChange, setGlobalState, offGlobalStateChange }: Record<string, CallableFunction> =
     getMicroAppStateActions(appInstanceId);

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -3,8 +3,8 @@
  * @since 2020-04-01
  */
 
-import { importEntry } from 'import-html-entry';
-import { concat, forEach, mergeWith } from 'lodash';
+import { importEntry, type ExecScriptOpts } from 'import-html-entry';
+import { concat, forEach, mergeWith, noop } from 'lodash';
 import type { LifeCycles, ParcelConfigObject } from 'single-spa';
 import getAddOns from './addons';
 import { QiankunError } from './error';
@@ -210,7 +210,6 @@ function getLifecyclesFromExports(
   appName: string,
   global: WindowProxy,
   globalLatestSetProp?: PropertyKey | null,
-  silent = false,
 ) {
   if (validateExportLifecycle(scriptExports)) {
     return scriptExports;
@@ -224,7 +223,7 @@ function getLifecyclesFromExports(
     }
   }
 
-  if (!silent && process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV === 'development') {
     console.warn(
       `[qiankun] lifecycle not found from ${appName} entry exports, fallback to get from window['${appName}']`,
     );
@@ -346,34 +345,33 @@ export async function loadApp<T extends ObjectType>(
 
   await execHooksChain(toArray(beforeLoad), app, global);
 
-  let resetCurrentScript = () => {};
-
-  // get the lifecycle hooks from module exports
-  const execScriptOpts = {
+  // Expose a browser-like `document.currentScript` while import-html-entry executes the entry scripts.
+  // Bundlers such as Turbopack/utoopack may resolve chunk URLs from `document.currentScript`, which is
+  // otherwise null during qiankun's fetch + eval execution. `afterExec` clears it after each script, and
+  // the `.finally` below guarantees cleanup when a script throws (where `afterExec` is not invoked).
+  let resetCurrentScript = noop;
+  const execScriptOpts: ExecScriptOpts = {
     scopedGlobalVariables: speedySandbox ? cachedGlobals : [],
-    beforeExec: (_code: string, script: string) => {
+    beforeExec: (_code, script) => {
       resetCurrentScript();
       resetCurrentScript = patchCurrentScript(createFakeCurrentScript(script));
     },
     afterExec: () => {
       resetCurrentScript();
-      resetCurrentScript = () => {};
+      resetCurrentScript = noop;
     },
-    error: () => {
-      resetCurrentScript();
-      resetCurrentScript = () => {};
-    },
-  } as any;
+  };
 
-  let lifecycles: any;
-  try {
-    const scriptExports: any = await execScripts(global, sandbox && !useLooseSandbox, execScriptOpts);
-    lifecycles = getLifecyclesFromExports(scriptExports, appName, global, sandboxContainer?.instance?.latestSetProp);
-  } finally {
-    resetCurrentScript();
-  }
-
-  const { bootstrap, mount, unmount, update } = lifecycles;
+  // get the lifecycle hooks from module exports
+  const scriptExports = await execScripts<LifeCycles<any>>(global, sandbox && !useLooseSandbox, execScriptOpts).finally(
+    () => resetCurrentScript(),
+  );
+  const { bootstrap, mount, unmount, update } = getLifecyclesFromExports(
+    scriptExports,
+    appName,
+    global,
+    sandboxContainer?.instance?.latestSetProp,
+  );
 
   const { onGlobalStateChange, setGlobalState, offGlobalStateChange }: Record<string, CallableFunction> =
     getMicroAppStateActions(appInstanceId);

--- a/src/sandbox/__tests__/proxySandbox.test.ts
+++ b/src/sandbox/__tests__/proxySandbox.test.ts
@@ -427,12 +427,15 @@ describe('should work well while the property existed in global context before',
 
     Object.defineProperty(window, 'readonlyPropertyInGlobalContext', {
       get() {
-        return '123';
+        // keep the same value/type as the descriptor above, so the assertion does not depend on whether
+        // the sandbox reads the cached descriptor or the live getter (which differs across jsdom versions)
+        return 123;
       },
       configurable: true,
     });
     const { proxy: proxy2 } = new ProxySandbox('readonly-sandbox');
     proxy2.readonlyPropertyInGlobalContext = 456;
+    // the readonly getter has no setter, so the sandbox write is ignored and the original value is read back
     expect(proxy2.readonlyPropertyInGlobalContext).toBe(123);
   });
 

--- a/src/sandbox/patchers/dynamicAppend/common.ts
+++ b/src/sandbox/patchers/dynamicAppend/common.ts
@@ -5,7 +5,7 @@
 import { execScripts } from 'import-html-entry';
 import { isFunction } from 'lodash';
 import { frameworkConfiguration } from '../../../apis';
-import { qiankunHeadTagName } from '../../../utils';
+import { patchCurrentScript, qiankunHeadTagName } from '../../../utils';
 import { cachedGlobals } from '../../proxySandbox';
 import * as css from '../css';
 
@@ -305,40 +305,22 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
           const scopedGlobalVariables = speedySandbox ? cachedGlobals : [];
 
           if (src) {
-            let isRedfinedCurrentScript = false;
+            let resetCurrentScript = () => {};
             execScripts(null, [src], proxy, {
               fetch,
               strictGlobal,
               scopedGlobalVariables,
               beforeExec: () => {
-                const isCurrentScriptConfigurable = () => {
-                  const descriptor = Object.getOwnPropertyDescriptor(document, 'currentScript');
-                  return !descriptor || descriptor.configurable;
-                };
-                if (isCurrentScriptConfigurable()) {
-                  Object.defineProperty(document, 'currentScript', {
-                    get(): any {
-                      return element;
-                    },
-                    configurable: true,
-                  });
-                  isRedfinedCurrentScript = true;
-                }
+                resetCurrentScript = patchCurrentScript(element as HTMLScriptElement);
               },
               success: () => {
                 manualInvokeElementOnLoad(element);
-                if (isRedfinedCurrentScript) {
-                  // @ts-ignore
-                  delete document.currentScript;
-                }
+                resetCurrentScript();
                 element = null;
               },
               error: () => {
                 manualInvokeElementOnError(element);
-                if (isRedfinedCurrentScript) {
-                  // @ts-ignore
-                  delete document.currentScript;
-                }
+                resetCurrentScript();
                 element = null;
               },
             });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,6 +139,41 @@ export const isConstDestructAssignmentSupported = memoize(() => {
 
 export const qiankunHeadTagName = 'qiankun-head';
 
+const noop = () => {};
+
+function isCurrentScriptConfigurable() {
+  const descriptor = Object.getOwnPropertyDescriptor(document, 'currentScript');
+  return !descriptor || descriptor.configurable;
+}
+
+export function patchCurrentScript(currentScript: HTMLScriptElement | null) {
+  if (!currentScript || !isCurrentScriptConfigurable()) {
+    return noop;
+  }
+
+  Object.defineProperty(document, 'currentScript', {
+    get(): HTMLScriptElement {
+      return currentScript;
+    },
+    configurable: true,
+  });
+
+  return () => {
+    // @ts-ignore
+    delete document.currentScript;
+  };
+}
+
+export function createFakeCurrentScript(scriptUrl: string) {
+  if (!scriptUrl || scriptUrl.indexOf('<') === 0) {
+    return null;
+  }
+
+  const script = document.createElement('script');
+  script.src = scriptUrl;
+  return script;
+}
+
 export function getDefaultTplWrapper(name: string, sandboxOpts: FrameworkConfiguration['sandbox']) {
   return (tpl: string) => {
     let tplWithSimulatedHead: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "typeRoots": ["typings", "node_modules/@types"],
+    "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
## Summary

Expose a browser-like `document.currentScript` while `import-html-entry` executes a micro app's **entry** scripts, and refactor the existing dynamic-script `currentScript` patch into shared helpers.

### Changes

- Add `patchCurrentScript` / `createFakeCurrentScript` helpers in `src/utils.ts`:
  - `patchCurrentScript(script)` defines a temporary, configurable `document.currentScript` getter and returns a reset function (a no-op when `currentScript` is non-configurable or when no script is provided).
  - `createFakeCurrentScript(scriptUrl)` builds a detached `<script>` with the given `src`. A detached script element does not trigger a network request. It returns `null` for inline scripts — `import-html-entry` passes the raw `<script>…` marker as the script id, detected via the leading `<`.
- `src/loader.ts`: during `execScripts`, set the fake `document.currentScript` in `beforeExec` and clear it in `afterExec`; a trailing `.finally` guarantees cleanup if an entry script throws (where `afterExec` is not invoked). The opts are typed with `import-html-entry`'s `ExecScriptOpts`.
- `src/sandbox/patchers/dynamicAppend/common.ts`: reuse `patchCurrentScript` for dynamically appended scripts, replacing the inlined `isRedfinedCurrentScript` bookkeeping (behavior preserved).
- Tests: add `src/__tests__/loader.test.ts` covering currentScript exposure during entry execution, cleanup when the entry execution fails, and reading lifecycle globals that the entry publishes in a microtask.

## Why

Bundlers such as Turbopack/utoopack may resolve chunk URLs from `document.currentScript`. qiankun 2 executes a micro app's initial entry scripts through fetch + `eval`, so `document.currentScript` was `null` during that phase — even though dynamically appended scripts already received a qiankun-provided `currentScript`. This patch makes the entry phase consistent with both the browser and qiankun's existing dynamic-script behavior.

Lifecycles that an app publishes synchronously, or within a microtask during entry execution, are still picked up by the existing `getLifecyclesFromExports` → `window[appName]` fallback: qiankun reads it after the entry promise resolves, by which point the entry microtask has already run.

## Test

- `yarn test src/__tests__/loader.test.ts --runInBand` — 3 passed
- `yarn lint:js -- src/loader.ts src/utils.ts src/__tests__/loader.test.ts` — clean
- `prettier -c src/loader.ts src/__tests__/loader.test.ts` — clean
- `tsc --noEmit --skipLibCheck --types jest,node` — no errors in the changed files
