### PR TITLE
fix: support async lifecycle exports in entry execution

### DIFF
--- a/src/__tests__/loader.test.ts
+++ b/src/__tests__/loader.test.ts
@@ -1,0 +1,89 @@
+import { importEntry } from 'import-html-entry';
+import { loadApp } from '../loader';
+
+jest.mock('import-html-entry', () => ({
+  importEntry: jest.fn(),
+}));
+
+const lifecycles = {
+  bootstrap: jest.fn(),
+  mount: jest.fn(),
+  unmount: jest.fn(),
+};
+
+const mockImportEntry = importEntry as jest.MockedFunction<typeof importEntry>;
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="container"></div>';
+  jest.clearAllMocks();
+});
+
+test('should expose document.currentScript while executing initial entry scripts', async () => {
+  const beforeExec = jest.fn();
+  const afterExec = jest.fn();
+  const scriptUrl = 'http://localhost:7100/umi.js';
+
+  mockImportEntry.mockResolvedValue({
+    template: '<div></div>',
+    assetPublicPath: 'http://localhost:7100/',
+    getExternalScripts: () => Promise.resolve([]),
+    getExternalStyleSheets: () => Promise.resolve([]),
+    execScripts: (_global: Window, _strictGlobal: boolean, opts: any) => {
+      opts.beforeExec('window.__entry_loaded__ = true;', scriptUrl);
+
+      expect(document.currentScript).toBeInstanceOf(HTMLScriptElement);
+      expect((document.currentScript as HTMLScriptElement).src).toBe(scriptUrl);
+      expect(beforeExec).toHaveBeenCalledWith('window.__entry_loaded__ = true;', scriptUrl);
+
+      opts.afterExec('window.__entry_loaded__ = true;', scriptUrl);
+      expect(document.currentScript).toBeNull();
+      expect(afterExec).toHaveBeenCalledWith('window.__entry_loaded__ = true;', scriptUrl);
+
+      return Promise.resolve(lifecycles);
+    },
+  } as any);
+
+  await loadApp(
+    {
+      name: 'app',
+      entry: 'http://localhost:7100/',
+      container: '#container',
+    },
+    {
+      sandbox: false,
+      beforeExec,
+      afterExec,
+    } as any,
+  );
+});
+
+test('should cleanup document.currentScript when initial entry execution fails', async () => {
+  const scriptUrl = 'http://localhost:7100/umi.js';
+
+  mockImportEntry.mockResolvedValue({
+    template: '<div></div>',
+    assetPublicPath: 'http://localhost:7100/',
+    getExternalScripts: () => Promise.resolve([]),
+    getExternalStyleSheets: () => Promise.resolve([]),
+    execScripts: (_global: Window, _strictGlobal: boolean, opts: any) => {
+      opts.beforeExec('throw new Error("boom");', scriptUrl);
+      expect((document.currentScript as HTMLScriptElement).src).toBe(scriptUrl);
+
+      opts.error();
+      expect(document.currentScript).toBeNull();
+
+      return Promise.resolve(lifecycles);
+    },
+  } as any);
+
+  await loadApp(
+    {
+      name: 'app',
+      entry: 'http://localhost:7100/',
+      container: '#container',
+    },
+    {
+      sandbox: false,
+    },
+  );
+});

--- a/src/__tests__/loader.test.ts
+++ b/src/__tests__/loader.test.ts
@@ -21,8 +21,6 @@ beforeEach(() => {
 });
 
 test('should expose document.currentScript while executing initial entry scripts', async () => {
-  const beforeExec = jest.fn();
-  const afterExec = jest.fn();
   const scriptUrl = 'http://localhost:7100/umi.js';
 
   mockImportEntry.mockResolvedValue({
@@ -35,11 +33,9 @@ test('should expose document.currentScript while executing initial entry scripts
 
       expect(document.currentScript).toBeInstanceOf(HTMLScriptElement);
       expect((document.currentScript as HTMLScriptElement).src).toBe(scriptUrl);
-      expect(beforeExec).toHaveBeenCalledWith('window.__entry_loaded__ = true;', scriptUrl);
 
       opts.afterExec('window.__entry_loaded__ = true;', scriptUrl);
       expect(document.currentScript).toBeNull();
-      expect(afterExec).toHaveBeenCalledWith('window.__entry_loaded__ = true;', scriptUrl);
 
       return Promise.resolve(lifecycles);
     },
@@ -53,8 +49,6 @@ test('should expose document.currentScript while executing initial entry scripts
     },
     {
       sandbox: false,
-      beforeExec,
-      afterExec,
     } as any,
   );
 });

--- a/src/__tests__/loader.test.ts
+++ b/src/__tests__/loader.test.ts
@@ -15,6 +15,8 @@ const mockImportEntry = importEntry as jest.MockedFunction<typeof importEntry>;
 
 beforeEach(() => {
   document.body.innerHTML = '<div id="container"></div>';
+  delete (window as any).app;
+  delete (window as any).asyncApp;
   jest.clearAllMocks();
 });
 
@@ -86,4 +88,37 @@ test('should cleanup document.currentScript when initial entry execution fails',
       sandbox: false,
     },
   );
+});
+
+test('should wait for lifecycle globals exposed after entry execution', async () => {
+  mockImportEntry.mockResolvedValue({
+    template: '<div></div>',
+    assetPublicPath: 'http://localhost:7100/',
+    getExternalScripts: () => Promise.resolve([]),
+    getExternalStyleSheets: () => Promise.resolve([]),
+    execScripts: () => {
+      setTimeout(() => {
+        (window as any).asyncApp = lifecycles;
+      }, 5);
+
+      return Promise.resolve({});
+    },
+  } as any);
+
+  await expect(
+    loadApp(
+      {
+        name: 'asyncApp',
+        entry: 'http://localhost:7100/',
+        container: '#container',
+      },
+      {
+        sandbox: false,
+        waitForLifecycleReady: {
+          timeout: 100,
+          interval: 1,
+        },
+      } as any,
+    ),
+  ).resolves.toBeInstanceOf(Function);
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -61,6 +61,11 @@ export type PrefetchStrategy =
   | string[]
   | ((apps: AppMetadata[]) => { criticalAppNames: string[]; minorAppsName: string[] });
 
+export type WaitForLifecycleReadyOptions = {
+  timeout?: number;
+  interval?: number;
+};
+
 type QiankunSpecialOpts = {
   /**
    * @deprecated internal api, don't used it as normal, might be removed after next version
@@ -93,6 +98,8 @@ type QiankunSpecialOpts = {
   excludeAssetFilter?: (url: string) => boolean;
 
   globalContext?: typeof window;
+
+  waitForLifecycleReady?: boolean | WaitForLifecycleReadyOptions;
 };
 export type FrameworkConfiguration = QiankunSpecialOpts & ImportEntryOpts & StartOpts;
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -210,6 +210,7 @@ function getLifecyclesFromExports(
   appName: string,
   global: WindowProxy,
   globalLatestSetProp?: PropertyKey | null,
+  silent = false,
 ) {
   if (validateExportLifecycle(scriptExports)) {
     return scriptExports;
@@ -223,7 +224,7 @@ function getLifecyclesFromExports(
     }
   }
 
-  if (process.env.NODE_ENV === 'development') {
+  if (!silent && process.env.NODE_ENV === 'development') {
     console.warn(
       `[qiankun] lifecycle not found from ${appName} entry exports, fallback to get from window['${appName}']`,
     );
@@ -237,6 +238,60 @@ function getLifecyclesFromExports(
   }
 
   throw new QiankunError(`You need to export lifecycle functions in ${appName} entry`);
+}
+
+const DEFAULT_LIFECYCLE_READY_TIMEOUT = 3000;
+const DEFAULT_LIFECYCLE_READY_INTERVAL = 16;
+
+type LifecycleReadyOptions = Exclude<FrameworkConfiguration['waitForLifecycleReady'], undefined | false>;
+
+function normalizeLifecycleReadyOptions(options: LifecycleReadyOptions): { timeout: number; interval: number } {
+  if (options === true) {
+    return {
+      timeout: DEFAULT_LIFECYCLE_READY_TIMEOUT,
+      interval: DEFAULT_LIFECYCLE_READY_INTERVAL,
+    };
+  }
+
+  return {
+    timeout: Math.max(0, options.timeout ?? DEFAULT_LIFECYCLE_READY_TIMEOUT),
+    interval: Math.max(1, options.interval ?? DEFAULT_LIFECYCLE_READY_INTERVAL),
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function getLifecyclesFromExportsWhenReady(
+  getLifecycles: (silent: boolean) => any,
+  waitForLifecycleReady: FrameworkConfiguration['waitForLifecycleReady'],
+): Promise<any> {
+  if (!waitForLifecycleReady) {
+    return getLifecycles(false);
+  }
+
+  const { timeout, interval } = normalizeLifecycleReadyOptions(waitForLifecycleReady);
+  const startedAt = Date.now();
+
+  do {
+    try {
+      return getLifecycles(true);
+    } catch {
+      // retry until timeout, then surface the original qiankun lifecycle error below
+    }
+
+    const remaining = timeout - (Date.now() - startedAt);
+    if (remaining <= 0) {
+      break;
+    }
+
+    await sleep(Math.min(interval, remaining));
+  } while (Date.now() - startedAt <= timeout);
+
+  return getLifecycles(false);
 }
 
 let prevAppUnmountedDeferred: Deferred<void>;
@@ -267,6 +322,7 @@ export async function loadApp<T extends ObjectType>(
     sandbox = true,
     excludeAssetFilter,
     globalContext = window,
+    waitForLifecycleReady,
     ...importEntryOpts
   } = configuration;
 
@@ -323,7 +379,7 @@ export async function loadApp<T extends ObjectType>(
   const useLooseSandbox = typeof sandbox === 'object' && !!sandbox.loose;
   // enable speedy mode by default
   const speedySandbox = typeof sandbox === 'object' ? sandbox.speedy !== false : true;
-  let sandboxContainer;
+  let sandboxContainer: ReturnType<typeof createSandboxContainer> | undefined;
   if (sandbox) {
     sandboxContainer = createSandboxContainer(
       appInstanceId,
@@ -375,11 +431,10 @@ export async function loadApp<T extends ObjectType>(
   } as any;
 
   const scriptExports: any = await execScripts(global, sandbox && !useLooseSandbox, execScriptOpts);
-  const { bootstrap, mount, unmount, update } = getLifecyclesFromExports(
-    scriptExports,
-    appName,
-    global,
-    sandboxContainer?.instance?.latestSetProp,
+  const { bootstrap, mount, unmount, update } = await getLifecyclesFromExportsWhenReady(
+    (silent) =>
+      getLifecyclesFromExports(scriptExports, appName, global, sandboxContainer?.instance?.latestSetProp, silent),
+    waitForLifecycleReady,
   );
 
   const { onGlobalStateChange, setGlobalState, offGlobalStateChange }: Record<string, CallableFunction> =

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -21,11 +21,13 @@ import { createSandboxContainer, css } from './sandbox';
 import { cachedGlobals } from './sandbox/proxySandbox';
 import {
   Deferred,
+  createFakeCurrentScript,
   genAppInstanceIdByName,
   getContainer,
   getDefaultTplWrapper,
   getWrapperId,
   isEnableScopedCSS,
+  patchCurrentScript,
   performanceGetEntriesByName,
   performanceMark,
   performanceMeasure,
@@ -241,6 +243,12 @@ let prevAppUnmountedDeferred: Deferred<void>;
 
 export type ParcelConfigObjectGetter = (remountContainer?: string | HTMLElement) => ParcelConfigObject;
 
+type ExecScriptHooks = {
+  beforeExec?: (code: string, script: string) => string | void;
+  afterExec?: (code: string, script: string) => void;
+  error?: CallableFunction;
+};
+
 export async function loadApp<T extends ObjectType>(
   app: LoadableApp<T>,
   configuration: FrameworkConfiguration = {},
@@ -343,10 +351,30 @@ export async function loadApp<T extends ObjectType>(
 
   await execHooksChain(toArray(beforeLoad), app, global);
 
+  const { beforeExec, afterExec, error } = importEntryOpts as ExecScriptHooks;
+  let resetCurrentScript = () => {};
+
   // get the lifecycle hooks from module exports
-  const scriptExports: any = await execScripts(global, sandbox && !useLooseSandbox, {
+  const execScriptOpts = {
     scopedGlobalVariables: speedySandbox ? cachedGlobals : [],
-  });
+    beforeExec: (code: string, script: string) => {
+      resetCurrentScript();
+      resetCurrentScript = patchCurrentScript(createFakeCurrentScript(script));
+      return beforeExec?.(code, script);
+    },
+    afterExec: (code: string, script: string) => {
+      resetCurrentScript();
+      resetCurrentScript = () => {};
+      afterExec?.(code, script);
+    },
+    error: () => {
+      resetCurrentScript();
+      resetCurrentScript = () => {};
+      error?.();
+    },
+  } as any;
+
+  const scriptExports: any = await execScripts(global, sandbox && !useLooseSandbox, execScriptOpts);
   const { bootstrap, mount, unmount, update } = getLifecyclesFromExports(
     scriptExports,
     appName,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -298,12 +298,6 @@ let prevAppUnmountedDeferred: Deferred<void>;
 
 export type ParcelConfigObjectGetter = (remountContainer?: string | HTMLElement) => ParcelConfigObject;
 
-type ExecScriptHooks = {
-  beforeExec?: (code: string, script: string) => string | void;
-  afterExec?: (code: string, script: string) => void;
-  error?: CallableFunction;
-};
-
 export async function loadApp<T extends ObjectType>(
   app: LoadableApp<T>,
   configuration: FrameworkConfiguration = {},
@@ -407,35 +401,33 @@ export async function loadApp<T extends ObjectType>(
 
   await execHooksChain(toArray(beforeLoad), app, global);
 
-  const { beforeExec, afterExec, error } = importEntryOpts as ExecScriptHooks;
   let resetCurrentScript = () => {};
 
   // get the lifecycle hooks from module exports
   const execScriptOpts = {
     scopedGlobalVariables: speedySandbox ? cachedGlobals : [],
-    beforeExec: (code: string, script: string) => {
+    beforeExec: (_code: string, script: string) => {
       resetCurrentScript();
       resetCurrentScript = patchCurrentScript(createFakeCurrentScript(script));
-      return beforeExec?.(code, script);
     },
-    afterExec: (code: string, script: string) => {
+    afterExec: () => {
       resetCurrentScript();
       resetCurrentScript = () => {};
-      afterExec?.(code, script);
     },
     error: () => {
       resetCurrentScript();
       resetCurrentScript = () => {};
-      error?.();
     },
   } as any;
 
   const scriptExports: any = await execScripts(global, sandbox && !useLooseSandbox, execScriptOpts);
-  const { bootstrap, mount, unmount, update } = await getLifecyclesFromExportsWhenReady(
-    (silent) =>
-      getLifecyclesFromExports(scriptExports, appName, global, sandboxContainer?.instance?.latestSetProp, silent),
-    waitForLifecycleReady,
-  );
+  const { bootstrap, mount, unmount, update } = waitForLifecycleReady
+    ? await getLifecyclesFromExportsWhenReady(
+        (silent) =>
+          getLifecyclesFromExports(scriptExports, appName, global, sandboxContainer?.instance?.latestSetProp, silent),
+        waitForLifecycleReady,
+      )
+    : getLifecyclesFromExports(scriptExports, appName, global, sandboxContainer?.instance?.latestSetProp);
 
   const { onGlobalStateChange, setGlobalState, offGlobalStateChange }: Record<string, CallableFunction> =
     getMicroAppStateActions(appInstanceId);

--- a/src/sandbox/patchers/dynamicAppend/common.ts
+++ b/src/sandbox/patchers/dynamicAppend/common.ts
@@ -5,7 +5,7 @@
 import { execScripts } from 'import-html-entry';
 import { isFunction } from 'lodash';
 import { frameworkConfiguration } from '../../../apis';
-import { qiankunHeadTagName } from '../../../utils';
+import { patchCurrentScript, qiankunHeadTagName } from '../../../utils';
 import { cachedGlobals } from '../../proxySandbox';
 import * as css from '../css';
 
@@ -305,40 +305,22 @@ function getOverwrittenAppendChildOrInsertBefore(opts: {
           const scopedGlobalVariables = speedySandbox ? cachedGlobals : [];
 
           if (src) {
-            let isRedfinedCurrentScript = false;
+            let resetCurrentScript = () => {};
             execScripts(null, [src], proxy, {
               fetch,
               strictGlobal,
               scopedGlobalVariables,
               beforeExec: () => {
-                const isCurrentScriptConfigurable = () => {
-                  const descriptor = Object.getOwnPropertyDescriptor(document, 'currentScript');
-                  return !descriptor || descriptor.configurable;
-                };
-                if (isCurrentScriptConfigurable()) {
-                  Object.defineProperty(document, 'currentScript', {
-                    get(): any {
-                      return element;
-                    },
-                    configurable: true,
-                  });
-                  isRedfinedCurrentScript = true;
-                }
+                resetCurrentScript = patchCurrentScript(element as HTMLScriptElement);
               },
               success: () => {
                 manualInvokeElementOnLoad(element);
-                if (isRedfinedCurrentScript) {
-                  // @ts-ignore
-                  delete document.currentScript;
-                }
+                resetCurrentScript();
                 element = null;
               },
               error: () => {
                 manualInvokeElementOnError(element);
-                if (isRedfinedCurrentScript) {
-                  // @ts-ignore
-                  delete document.currentScript;
-                }
+                resetCurrentScript();
                 element = null;
               },
             });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,6 +139,41 @@ export const isConstDestructAssignmentSupported = memoize(() => {
 
 export const qiankunHeadTagName = 'qiankun-head';
 
+const noop = () => {};
+
+function isCurrentScriptConfigurable() {
+  const descriptor = Object.getOwnPropertyDescriptor(document, 'currentScript');
+  return !descriptor || descriptor.configurable;
+}
+
+export function patchCurrentScript(currentScript: HTMLScriptElement | null) {
+  if (!currentScript || !isCurrentScriptConfigurable()) {
+    return noop;
+  }
+
+  Object.defineProperty(document, 'currentScript', {
+    get(): HTMLScriptElement {
+      return currentScript;
+    },
+    configurable: true,
+  });
+
+  return () => {
+    // @ts-ignore
+    delete document.currentScript;
+  };
+}
+
+export function createFakeCurrentScript(scriptUrl: string) {
+  if (!scriptUrl || scriptUrl.indexOf('<') === 0) {
+    return null;
+  }
+
+  const script = document.createElement('script');
+  script.src = scriptUrl;
+  return script;
+}
+
 export function getDefaultTplWrapper(name: string, sandboxOpts: FrameworkConfiguration['sandbox']) {
   return (tpl: string) => {
     let tplWithSimulatedHead: string;


### PR DESCRIPTION
## Summary

This PR makes qiankun 2 compatible with entry scripts that depend on browser script execution semantics and expose lifecycles asynchronously after the entry script has been evaluated.

It includes two related fixes:

- expose a temporary `document.currentScript` while `import-html-entry` evaluates entry scripts, so runtimes that infer their current chunk from `document.currentScript` can resolve the entry chunk path correctly
- add an opt-in `waitForLifecycleReady` framework option that polls lifecycle exports for a short period after `execScripts`, covering runtimes that load additional chunks before assigning `window[appName] = { bootstrap, mount, unmount }`

## Why

Utoopack/Turbopack style runtimes can execute an entry script that immediately registers the current chunk and then asynchronously loads other chunks where the actual app entry exports are evaluated. Under qiankun 2, entry scripts are executed through `fetch + eval`, so `document.currentScript` is empty. After fixing that, qiankun can still read lifecycles too early because the lifecycle global is assigned only after the runtime finishes loading the follow-up chunks.

The new lifecycle wait is opt-in, so the existing synchronous behavior remains unchanged unless users enable it.

## Usage

```ts
start({
  waitForLifecycleReady: {
    timeout: 5000,
    interval: 16,
  },
});
```

For manual loading:

```ts
loadMicroApp(app, {
  waitForLifecycleReady: {
    timeout: 5000,
    interval: 16,
  },
});
```

## Validation

- `yarn test src/__tests__/loader.test.ts --runInBand`
- `yarn lint:js -- src/loader.ts src/interfaces.ts src/__tests__/loader.test.ts`
- locally verified Umi `examples/qiankun-master` loading `examples/with-utoopack-qiankun-slave`; the route rendered `Utoopack with Qiankun Slave` with no `chunk path empty`, lifecycle, or `import-html-entry` errors