### PR TITLE
docs: refresh AGENTS.md with v3 ESM-sandbox architecture + add CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,7 @@
 
 **Updated:** 2026-07-06 · **Commit:** dcc42ae4 · **Branch:** next (qiankun 3.0, active dev)
 
-Qiankun is a micro-frontend framework built on [single-spa](https://github.com/single-spa/single-spa).
-v3 rewrites the runtime around **streaming HTML-entry loading**, a **Proxy-membrane JS sandbox**,
-and native **ESM-sandbox** execution. pnpm monorepo, built with `father` (UmiJS).
+Qiankun is a micro-frontend framework built on [single-spa](https://github.com/single-spa/single-spa). v3 rewrites the runtime around **streaming HTML-entry loading**, a **Proxy-membrane JS sandbox**, and native **ESM-sandbox** execution. pnpm monorepo, built with `father` (UmiJS).
 
 > Requires Node `>=20.19`, `pnpm@10.28.2` (see `packageManager`). Never use npm/yarn at the root.
 
@@ -39,22 +37,16 @@ qiankun/
 `loadApp` (`packages/qiankun/src/core/loadApp.ts`) is the orchestrator. Per micro-app it wires:
 
 1. **fetch** — decorated `window.fetch`: `makeFetchCacheable(makeFetchRetryable(makeFetchThrowable(fetch)))`.
-2. **sandbox** — `createSandboxContainer()` builds a Proxy-membrane `window`/`document` view; patchers
-   (dynamicAppend, timers, listeners, history) each return a `free()` cleanup called on unmount.
-3. **loader** — `loadEntry(entry, container, opts)` streams the HTML entry through `writable-dom`,
-   virtualizing `<head>` → `<qiankun-head>` and running each node through a `nodeTransformer`.
+2. **sandbox** — `createSandboxContainer()` builds a Proxy-membrane `window`/`document` view; patchers (dynamicAppend, timers, listeners, history) each return a `free()` cleanup called on unmount.
+3. **loader** — `loadEntry(entry, container, opts)` streams the HTML entry through `writable-dom`, virtualizing `<head>` → `<qiankun-head>` and running each node through a `nodeTransformer`.
 4. **transpilers** (`shared/assets-transpilers`) rewrite each script/link/style node before it hits live DOM.
 
 Two execution paths, chosen per script type:
 
-- **Classic** (`<script entry>`, UMD/global): source is wrapped and run via a **blob URL** scoped to the
-  sandbox membrane. The app's export = `sandbox.latestSetProp` (the last global the entry script set).
-- **ESM** (`<script type="module">`): handled by `EsmSandboxEngine` (`shared/esm-sandbox`). Modules are
-  fetched, lexer-rewritten to route globals through the membrane, given synthetic specifiers via a
-  dynamically injected **import map**, and evaluated in order. The engine also handles dynamic `import()`.
+- **Classic** (`<script entry>`, UMD/global): source is wrapped and run via a **blob URL** scoped to the sandbox membrane. The app's export = `sandbox.latestSetProp` (the last global the entry script set).
+- **ESM** (`<script type="module">`): handled by `EsmSandboxEngine` (`shared/esm-sandbox`). Modules are fetched, lexer-rewritten to route globals through the membrane, given synthetic specifiers via a dynamically injected **import map**, and evaluated in order. The engine also handles dynamic `import()`.
 
-**Style isolation** (`shared/assets-transpilers/style.ts` + `link.ts`) uses CSS `@scope` at runtime;
-external stylesheets become blob-`<link>`s so `@scope` can wrap them. Opt-in via `styleIsolation`.
+**Style isolation** (`shared/assets-transpilers/style.ts` + `link.ts`) uses CSS `@scope` at runtime; external stylesheets become blob-`<link>`s so `@scope` can wrap them. Opt-in via `styleIsolation`.
 
 Internal dependency graph (never invert it):
 
@@ -97,8 +89,7 @@ pnpm run docs:dev            # VitePress docs
 TypeScript is strict + type-checked (`@typescript-eslint/recommended-requiring-type-checking`):
 
 - **No `any`** — `no-explicit-any` auto-fixes to `unknown`. No `as any`, `@ts-ignore`, `@ts-expect-error`.
-- **Inline type imports** — `import { type Foo, bar }`, not `import type { Foo }` on its own line
-  (`consistent-type-imports`/`consistent-type-exports` with `fixStyle: inline-type-imports`).
+- **Inline type imports** — `import { type Foo, bar }`, not `import type { Foo }` on its own line (`consistent-type-imports`/`consistent-type-exports` with `fixStyle: inline-type-imports`).
 - `no-unnecessary-condition` is an error — don't guard values the types prove are always truthy.
 - Unused vars/args must be prefixed `_` (`argsIgnorePattern: ^_`).
 - `array-simple`: `T[]` for simple, `Array<T>` for complex element types.
@@ -121,7 +112,6 @@ Build/release:
 
 ## NOTES
 
-- Firefox doesn't support dynamically injected import maps → ESM-sandbox e2e tests are annotated
-  `test.fail(firefox, …)` (expected failure, not skip). See `e2e/README.md`.
+- Firefox doesn't support dynamically injected import maps → ESM-sandbox e2e tests are annotated `test.fail(firefox, …)` (expected failure, not skip). See `e2e/README.md`.
 - Design decisions live in `docs/rfcs/` (e.g. the ESM-sandbox RFC).
 - v3 roadmap: github.com/umijs/qiankun/discussions/1378.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,119 +1,127 @@
 # QIANKUN PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-01-10 **Commit:** 058166b6 **Branch:** next
+**Updated:** 2026-07-06 · **Commit:** dcc42ae4 · **Branch:** next (qiankun 3.0, active dev)
 
-## OVERVIEW
+Qiankun is a micro-frontend framework built on [single-spa](https://github.com/single-spa/single-spa).
+v3 rewrites the runtime around **streaming HTML-entry loading**, a **Proxy-membrane JS sandbox**,
+and native **ESM-sandbox** execution. pnpm monorepo, built with `father` (UmiJS).
 
-Qiankun is a micro-frontend framework built on single-spa, providing HTML entry, JS sandbox, and style isolation. Monorepo managed by pnpm with `father` build tool.
+> Requires Node `>=20.19`, `pnpm@10.28.2` (see `packageManager`). Never use npm/yarn at the root.
 
 ## STRUCTURE
 
 ```
 qiankun/
 ├── packages/
-│   ├── qiankun/         # Main facade - re-exports from loader/sandbox/shared
-│   ├── sandbox/         # JS isolation via Proxy membrane + Compartment (SEE packages/sandbox/AGENTS.md)
-│   ├── loader/          # Streaming HTML entry loader (SEE packages/loader/AGENTS.md)
-│   ├── shared/          # fetch-utils, asset transpilers, module-resolver (SEE packages/shared/AGENTS.md)
-│   ├── ui-bindings/     # React/Vue <MicroApp> components
-│   ├── bundler-plugin/  # Entry point configuration plugin
-│   └── create-qiankun/  # CLI scaffolding tool
-├── examples/            # Integration examples (NOT in workspace currently)
-└── docs/                # VitePress documentation
+│   ├── qiankun/         # Facade: public APIs (register/loadMicroApp, start, prefetch) + loadApp orchestration
+│   ├── sandbox/         # JS isolation: Proxy membrane + Compartment  → packages/sandbox/AGENTS.md
+│   ├── loader/          # Streaming HTML-entry loader (writable-dom)  → packages/loader/AGENTS.md
+│   ├── shared/          # Transpilers, fetch-utils, module-resolver, ESM-sandbox engine → packages/shared/AGENTS.md
+│   ├── ui-bindings/     # <MicroApp> components: react/ vue/ shared/
+│   ├── bundler-plugin/  # Webpack(4/5) + Vite plugins: mark entry script, fix output library
+│   └── create-qiankun/  # `npm create qiankun` scaffolder (React/Vue, Vite)
+├── e2e/                 # Playwright, runs against BUILT dist → e2e/README.md
+├── examples/            # Runnable integration demos (main + react/vue/purehtml/webpack)
+└── docs/                # VitePress site (docs/rfcs holds design RFCs)
 ```
 
-## WHERE TO LOOK
+## PROGRESSIVE DISCLOSURE — read the scoped doc before editing a package
 
-| Task | Location | Notes |
-| --- | --- | --- |
-| Core APIs (registerMicroApps, loadMicroApp) | `packages/qiankun/src/apis/` | Thin wrappers around loader/sandbox |
-| App loading lifecycle | `packages/qiankun/src/core/loadApp.ts` | Orchestrates sandbox+loader+hooks |
-| JS sandbox implementation | `packages/sandbox/src/core/` | Membrane, Compartment, StandardSandbox |
-| HTML streaming loader | `packages/loader/src/index.ts` | Uses writable-dom for streaming |
-| Script/link transpilation | `packages/shared/src/assets-transpilers/` | Blob URL sandboxing |
-| Fetch enhancements | `packages/shared/src/fetch-utils/` | Cache, retry, error handling |
-| Dependency sharing | `packages/shared/src/module-resolver/` | Semver-based matching |
-| React/Vue bindings | `packages/ui-bindings/{react,vue}/` | `<MicroApp>` component |
+| Working in… | Read first |
+| --- | --- |
+| `packages/sandbox/**` | [`packages/sandbox/AGENTS.md`](packages/sandbox/AGENTS.md) — membrane, compartment, patchers, ESM globals |
+| `packages/loader/**` | [`packages/loader/AGENTS.md`](packages/loader/AGENTS.md) — streaming pipeline, head virtualization |
+| `packages/shared/**` | [`packages/shared/AGENTS.md`](packages/shared/AGENTS.md) — transpilers, fetch decorators, **esm-sandbox** |
+| `e2e/**` | [`e2e/README.md`](e2e/README.md) — Playwright layout, fixtures, anti-flake rules |
 
-## CODE MAP
+## ARCHITECTURE (big picture)
 
-### Package Dependencies (internal)
+`loadApp` (`packages/qiankun/src/core/loadApp.ts`) is the orchestrator. Per micro-app it wires:
+
+1. **fetch** — decorated `window.fetch`: `makeFetchCacheable(makeFetchRetryable(makeFetchThrowable(fetch)))`.
+2. **sandbox** — `createSandboxContainer()` builds a Proxy-membrane `window`/`document` view; patchers
+   (dynamicAppend, timers, listeners, history) each return a `free()` cleanup called on unmount.
+3. **loader** — `loadEntry(entry, container, opts)` streams the HTML entry through `writable-dom`,
+   virtualizing `<head>` → `<qiankun-head>` and running each node through a `nodeTransformer`.
+4. **transpilers** (`shared/assets-transpilers`) rewrite each script/link/style node before it hits live DOM.
+
+Two execution paths, chosen per script type:
+
+- **Classic** (`<script entry>`, UMD/global): source is wrapped and run via a **blob URL** scoped to the
+  sandbox membrane. The app's export = `sandbox.latestSetProp` (the last global the entry script set).
+- **ESM** (`<script type="module">`): handled by `EsmSandboxEngine` (`shared/esm-sandbox`). Modules are
+  fetched, lexer-rewritten to route globals through the membrane, given synthetic specifiers via a
+  dynamically injected **import map**, and evaluated in order. The engine also handles dynamic `import()`.
+
+**Style isolation** (`shared/assets-transpilers/style.ts` + `link.ts`) uses CSS `@scope` at runtime;
+external stylesheets become blob-`<link>`s so `@scope` can wrap them. Opt-in via `styleIsolation`.
+
+Internal dependency graph (never invert it):
 
 ```
-qiankun (facade)
-├── @qiankunjs/loader
-│   ├── @qiankunjs/sandbox
-│   └── @qiankunjs/shared
-├── @qiankunjs/sandbox
-│   └── @qiankunjs/shared
-└── @qiankunjs/shared (base utilities)
+qiankun → loader → sandbox → shared
+                   sandbox → shared
+ui-bindings/{react,vue} → ui-bindings/shared → qiankun
 ```
-
-### Key Entry Points
-
-| Package            | Entry          | Primary Exports                                     |
-| ------------------ | -------------- | --------------------------------------------------- |
-| qiankun            | `src/index.ts` | `registerMicroApps`, `start`, `loadMicroApp`        |
-| @qiankunjs/sandbox | `src/index.ts` | `createSandboxContainer`, `StandardSandbox`         |
-| @qiankunjs/loader  | `src/index.ts` | `loadEntry`                                         |
-| @qiankunjs/shared  | `src/index.ts` | `transpileScript`, `makeFetchCacheable`, `Deferred` |
-
-## CONVENTIONS
-
-### TypeScript (STRICT - enforced by eslint)
-
-- `@typescript-eslint/no-explicit-any`: ERROR - use `unknown` instead
-- `@typescript-eslint/consistent-type-imports`: inline-type-imports required
-- `@typescript-eslint/no-unnecessary-condition`: ERROR
-- Path aliases: `@qiankunjs/*` → `packages/*/src`
-
-### Code Style
-
-- No `as any`, `@ts-ignore`, `@ts-expect-error`
-- Unused vars: prefix with `_` (e.g., `_unused`)
-- Type exports: use `export type { X }` inline syntax
-
-### Build
-
-- Tool: `father` (UmiJS ecosystem)
-- Output: dual ESM + CJS in `dist/`
-- No `exports` field in package.json (uses `main`/`module`/`types`)
-
-## ANTI-PATTERNS (THIS PROJECT)
-
-- **NEVER** add more than 1 `entry` attribute script per HTML entry
-- **NEVER** use `!important` in CSS unless absolutely necessary (breaks isolation)
-- **ALWAYS** unmount micro-apps when finished (`loadMicroApp` returns unmount handle)
-- **AVOID** global variables in micro-apps - sandbox tracks `latestSetProp` for exports
-
-### Technical Debt (from codebase comments)
-
-- `FIXME` in `loadApp.ts`: async execution order coordination
-- `FIXME` in sandbox: System.js scope escape via indirect eval
-- `TODO`: Snapshot sandbox and GC not yet implemented
 
 ## COMMANDS
 
 ```bash
-pnpm install              # Install all workspace deps
-pnpm run build            # Build all packages (father build)
-pnpm run test             # Run vitest across workspace
-pnpm run eslint           # Lint packages/
-pnpm run ci               # Full CI: build + eslint + prettier:check
+pnpm install                 # install all workspace deps
 
-# Development
-pnpm run start:example    # Build + run example apps
-pnpm run docs:dev         # VitePress dev server
+# build (father → dual ESM+CJS in each package's dist/)
+pnpm run build               # build everything (packages + examples)
+pnpm run build:packages      # build only packages/** (prereq for e2e & examples)
 
-# Release (changesets)
-pnpm run prerelease:alpha # Enter alpha, version bump
-pnpm run release:alpha    # Build, publish, exit alpha
+# unit tests — vitest + happy-dom, aliased to src (NO build needed, see vitest.config.ts)
+pnpm run test                            # all packages
+pnpm --filter @qiankunjs/shared run test # one package
+pnpm --filter @qiankunjs/sandbox exec vitest run path/to.test.ts   # single file
+pnpm --filter @qiankunjs/shared  exec vitest run -t "test name"    # single test by name
+
+# e2e — Playwright against BUILT dist (see e2e/README.md)
+pnpm run test:e2e            # build all + run chromium suite
+
+# lint / format / full CI gate
+pnpm run eslint              # eslint packages/
+pnpm run prettier:check      # prettier -c .
+pnpm run ci                  # build + eslint + prettier:check (what CI runs)
+
+# dev
+pnpm run start:example       # build packages + run all example apps in parallel
+pnpm run docs:dev            # VitePress docs
 ```
+
+## CONVENTIONS (enforced by eslint — `pnpm run eslint` will reject violations)
+
+TypeScript is strict + type-checked (`@typescript-eslint/recommended-requiring-type-checking`):
+
+- **No `any`** — `no-explicit-any` auto-fixes to `unknown`. No `as any`, `@ts-ignore`, `@ts-expect-error`.
+- **Inline type imports** — `import { type Foo, bar }`, not `import type { Foo }` on its own line
+  (`consistent-type-imports`/`consistent-type-exports` with `fixStyle: inline-type-imports`).
+- `no-unnecessary-condition` is an error — don't guard values the types prove are always truthy.
+- Unused vars/args must be prefixed `_` (`argsIgnorePattern: ^_`).
+- `array-simple`: `T[]` for simple, `Array<T>` for complex element types.
+- JS-wide: `no-else-return` (no `else` after `return`), `object-shorthand`.
+- Path alias `@qiankunjs/*` → `packages/*/src` (tsconfig + vitest); imports resolve to **source**, not dist.
+
+Build/release:
+
+- `father` build, dual ESM+CJS; packages use `main`/`module`/`types` (no `exports` field).
+- Versioning via **changesets** — add a changeset (`.changeset/`) for any user-facing change.
+- Conventional commits enforced by commitlint (`feat:`, `fix:`, `feat(esm-sandbox):`, …).
+
+## ANTI-PATTERNS (this project)
+
+- **NEVER** put more than one `entry` script in an HTML entry — the loader throws `QiankunError`.
+- **ALWAYS** unmount micro-apps; `loadMicroApp`/patchers return handles/`free()` — leaks break remount & multi-instance.
+- In sandbox code, **never touch the real `window`/`document.head`** — go through the proxied view.
+- Don't invert the package dependency graph above (e.g. `shared` must not import `sandbox`).
+- e2e: never `waitForTimeout`; use web-first assertions; all ports come from `e2e/ports.ts`.
 
 ## NOTES
 
-- **v3.0 Active Development**: Check roadmap at github.com/umijs/qiankun/discussions/1378
-- **Streaming Architecture**: v3 uses `writable-dom` for incremental HTML parsing
-- **Head Virtualization**: `<head>` → `<qiankun-head>` for isolation
-- **Blob URL Execution**: Scripts wrapped and executed via `URL.createObjectURL`
-- **Test Environment**: Vitest + happy-dom; edge-runtime for fetch tests
+- Firefox doesn't support dynamically injected import maps → ESM-sandbox e2e tests are annotated
+  `test.fail(firefox, …)` (expected failure, not skip). See `e2e/README.md`.
+- Design decisions live in `docs/rfcs/` (e.g. the ESM-sandbox RFC).
+- v3 roadmap: github.com/umijs/qiankun/discussions/1378.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+All project guidance lives in `AGENTS.md` (imported below). It links out to package-scoped
+`packages/*/AGENTS.md` files for deep-dives — read those on demand when editing a given package.
+
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-All project guidance lives in `AGENTS.md` (imported below). It links out to package-scoped
-`packages/*/AGENTS.md` files for deep-dives — read those on demand when editing a given package.
+All project guidance lives in `AGENTS.md` (imported below). It links out to package-scoped `packages/*/AGENTS.md` files for deep-dives — read those on demand when editing a given package.
 
 @AGENTS.md

--- a/packages/loader/AGENTS.md
+++ b/packages/loader/AGENTS.md
@@ -40,17 +40,16 @@ loader/
 ### Script classification (`index.ts`)
 
 ```typescript
-isExternalScript // has src or data-src
-isEntryScript    // external + [entry]  → resolves the load promise (app's main export point)
-isDeferScript    // external + [defer]  → ordered via shared prepareDeferredQueue
+isExternalScript; // has src or data-src
+isEntryScript; // external + [entry]  → resolves the load promise (app's main export point)
+isDeferScript; // external + [defer]  → ordered via shared prepareDeferredQueue
 ```
 
 - Exactly **one** `entry` script is allowed per HTML entry; a second one throws `QiankunError`.
 
 ### Detached parsing
 
-Nodes are parsed/transformed in a detached document first, then moved to live DOM — this prevents
-premature script execution before the transpiler has rewritten the node.
+Nodes are parsed/transformed in a detached document first, then moved to live DOM — this prevents premature script execution before the transpiler has rewritten the node.
 
 ## ANTI-PATTERNS
 

--- a/packages/loader/AGENTS.md
+++ b/packages/loader/AGENTS.md
@@ -1,71 +1,65 @@
 # @qiankunjs/loader
 
-Streaming HTML entry loader using writable-dom.
+Streaming HTML-entry loader built on a forked `writable-dom`. Depends on `@qiankunjs/sandbox` + `@qiankunjs/shared`.
 
 ## STRUCTURE
 
 ```
 loader/
-├── index.ts              # loadEntry() - main API
-├── TagTransformStream.ts # <head> → <qiankun-head> replacement
-├── writable-dom/         # Forked streaming DOM engine
-│   └── index.ts          # WritableDOMStream implementation
-└── parser.ts             # Static HTML parsing for prefetch
+├── index.ts              # loadEntry() — main API
+├── TagTransformStream.ts # <head> → <qiankun-head> string-level replacement
+├── writable-dom/         # forked streaming DOM engine (incremental parse + blocking scripts)
+│   └── index.ts
+└── parser.ts             # static HTML parsing for prefetch
 ```
 
 ## WHERE TO LOOK
 
-| Task                | File                    | Notes                                  |
-| ------------------- | ----------------------- | -------------------------------------- |
-| Load micro-app      | `index.ts`              | `loadEntry(url, container, opts)`      |
-| Head virtualization | `TagTransformStream.ts` | String-level tag replacement           |
-| Streaming DOM       | `writable-dom/index.ts` | Incremental parsing + blocking scripts |
+| Task | File | Notes |
+| --- | --- | --- |
+| Load micro-app | `index.ts` | `loadEntry(entry, container, opts)`; `opts` carries `sandbox` and/or `esmEngine` |
+| Head virtualization | `TagTransformStream.ts` | rewrites `<head>` tags at the string level before DOM insertion |
+| Streaming DOM | `writable-dom/index.ts` | incremental parsing, blocks on sync scripts/styles, preloads the rest |
 
 ## LOADING PIPELINE
 
 ```
-1. fetch(entry)
-   ↓
-2. TextDecoderStream (bytes → string)
-   ↓
-3. TagTransformStream (<head> → <qiankun-head>)
-   ↓
-4. WritableDOMStream (stream → live DOM)
-   ├─ nodeTransformer called per node
-   ├─ Blocks on sync scripts/styles
-   └─ Preloads other assets while blocked
-   ↓
-5. Resolve with sandbox.latestSetProp (app exports)
+1. fetch(entry)                              (decorated fetch: cacheable/retryable/throwable)
+2. TextDecoderStream                         bytes → string
+3. TagTransformStream                        <head> → <qiankun-head>
+4. WritableDOMStream                         stream → live DOM
+   ├─ nodeTransformer(node) per node         → shared/assets-transpilers rewrites script/link/style
+   ├─ classic <script entry> → blob-URL execution in the sandbox membrane
+   ├─ <script type="module"> → handed to opts.esmEngine (EsmSandboxEngine)
+   └─ blocks on sync scripts; preloads other assets while blocked
+5. resolve app export                        classic: sandbox.latestSetProp · esm: engine lifecycle namespace
 ```
 
 ## KEY PATTERNS
 
-### Entry Script Detection
+### Script classification (`index.ts`)
 
 ```typescript
-// Script with `entry` attribute = app's main export point
-<script src="main.js" entry></script>
-// Loader resolves promise when entry script loads
+isExternalScript // has src or data-src
+isEntryScript    // external + [entry]  → resolves the load promise (app's main export point)
+isDeferScript    // external + [defer]  → ordered via shared prepareDeferredQueue
 ```
 
-### Defer Script Ordering
+- Exactly **one** `entry` script is allowed per HTML entry; a second one throws `QiankunError`.
 
-- Deferred queue ensures correct execution order
-- `prepareDeferredQueue` from @qiankunjs/shared
+### Detached parsing
 
-### Detached Parsing
-
-- HTML parsed in detached document first
-- Nodes transformed before moving to live DOM
-- Prevents premature script execution
+Nodes are parsed/transformed in a detached document first, then moved to live DOM — this prevents
+premature script execution before the transpiler has rewritten the node.
 
 ## ANTI-PATTERNS
 
-- **NEVER** include >1 `entry` script per HTML entry (throws QiankunError)
-- **FIXME**: Non-standard HTML chunks lacking `<head>` tag
+- **NEVER** include more than one `entry` script per HTML entry (throws `QiankunError`).
+- **FIXME** (in code): non-standard HTML chunks that lack a `<head>` tag.
 
-## EXPORTS
+## EXPORTS (`src/index.ts`)
 
 ```typescript
 export { loadEntry, type LoaderOpts } from './index';
+// LoaderOpts = { fetch, sandbox?, esmEngine?, nodeTransformer?, streamTransformer? } & BaseTranspilerOpts
 ```

--- a/packages/sandbox/AGENTS.md
+++ b/packages/sandbox/AGENTS.md
@@ -1,67 +1,71 @@
 # @qiankunjs/sandbox
 
-JS isolation engine using Proxy-based Membrane + Compartment execution model.
+JS isolation engine: Proxy-based **Membrane** + **Compartment** execution model. Also exposes the
+globals contract the ESM-sandbox engine (in `@qiankunjs/shared`) relies on. Depends only on `@qiankunjs/shared`.
 
 ## STRUCTURE
 
 ```
 sandbox/
 ├── core/
-│   ├── sandbox/          # StandardSandbox, createSandboxContainer
-│   ├── membrane/         # Proxy wrapper for global isolation
-│   ├── compartment/      # Code evaluation with `with(this)` binding
-│   └── globals.ts        # Global property definitions
+│   ├── sandbox/          # createSandboxContainer() + StandardSandbox (mount/unmount, latestSetProp)
+│   ├── membrane/         # Proxy wrapper for global (window/document) isolation
+│   ├── compartment/      # Code evaluation with `with(this)` scope binding + globalProps
+│   ├── globals.ts        # global property definitions
+│   └── esm-globals.ts    # esmDestructurableGlobals — globals the ESM engine may destructure/rebind
 ├── patchers/
-│   ├── dynamicAppend/    # DOM appendChild/insertBefore interception
-│   ├── windowListener.ts # Event listener tracking
-│   ├── interval.ts       # Timer tracking
+│   ├── dynamicAppend/    # appendChild/insertBefore interception → redirect to app container
+│   ├── windowListener.ts # event listener tracking
+│   ├── interval.ts       # timer tracking
 │   └── historyListener.ts
-└── consts.ts             # qiankunHeadTagName, etc.
+└── consts.ts             # qiankunHeadTagName / qiankunBodyTagName, nativeGlobal, nativeDocument
 ```
 
 ## WHERE TO LOOK
 
 | Task | File | Notes |
 | --- | --- | --- |
-| Create sandbox | `core/sandbox/index.ts` | `createSandboxContainer()` returns mount/unmount |
-| Proxy logic | `core/membrane/index.ts` | Write → local target, Read → target → endowments → host |
-| Code execution | `core/compartment/index.ts` | `with(this)` scope binding |
-| DOM interception | `patchers/dynamicAppend/forStandardSandbox.ts` | Redirects to app container |
-| Side effect cleanup | `patchers/*.ts` | Each returns `free()` function |
+| Create sandbox | `core/sandbox/index.ts` | `createSandboxContainer()` returns mount/unmount + membrane views |
+| Proxy logic | `core/membrane/index.ts` | Write → local target; Read → local → endowments → host window |
+| Code execution | `core/compartment/index.ts` | `with(this)` scope binding for classic (blob-URL) scripts |
+| DOM interception | `patchers/dynamicAppend/forStandardSandbox.ts` | Redirects dynamic script/style/link to app container |
+| Side-effect cleanup | `patchers/*.ts` | Each patcher returns a `free()` called on unmount |
+| ESM globals contract | `core/esm-globals.ts` | Consumed by `shared/esm-sandbox` engine, passed as `globalsBaseSet` |
 
 ## KEY PATTERNS
 
 ### Membrane (Proxy)
 
-- **Writes**: Trapped and stored in local `target` object
-- **Reads**: Check local → endowments → fallback to host window
-- **Native rebinding**: `fetch`, `console` rebound to avoid "Illegal invocation"
+- **Writes** are trapped and stored on a local `target` object (the sandbox's own globals).
+- **Reads** check local target → endowments → fall back to the real host window.
+- **Native rebinding**: `fetch`, `console`, etc. are rebound to the real receiver to avoid "Illegal invocation".
+- `latestSetProp` records the last global the entry script assigned — that's how the loader recovers a
+  classic app's exported lifecycles when no explicit export exists.
 
-### Patcher/Free Pattern
+### Patcher / free pattern
 
 ```typescript
-// Every patcher returns cleanup function
-const free = patchWindowListener(sandbox);
-// On unmount:
-free(); // Removes all listeners added by micro-app
+const free = patchWindowListener(sandbox); // on mount
+// ...
+free(); // on unmount — removes every listener/timer the micro-app added
 ```
 
-### WeakMap Metadata
+### WeakMap metadata
 
-- `sandboxConfigWeakMap`: Sandbox config per instance
-- `elementAttachSandboxConfigMap`: Tracks which app owns which DOM node
+- `sandboxConfigWeakMap` — per-instance sandbox config.
+- `elementAttachSandboxConfigMap` — which app owns which dynamically-appended DOM node.
 
 ## ANTI-PATTERNS
 
-- **NEVER** access real `window.document.head` directly - use proxied version
-- **FIXME**: Indirect `eval` in membrane causes System.js scope escape
-- **FIXME**: Global variable for runtime container may miss monkey-patched logic
+- **NEVER** access the real `window` / `document.head` directly — always the proxied view.
+- **FIXME** (in code): indirect `eval` in the membrane can let System.js escape sandbox scope.
+- **FIXME**: the runtime-container global may miss monkey-patched append logic.
 
-## EXPORTS
+## EXPORTS (`src/index.ts`)
 
 ```typescript
-export { createSandboxContainer } from './core/sandbox';
-export { StandardSandbox } from './core/sandbox/StandardSandbox';
-export { Compartment } from './core/compartment';
-export { qiankunHeadTagName } from './consts';
+export * from './core/sandbox';       // createSandboxContainer, type Sandbox, StandardSandbox
+export * from './core/compartment';   // Compartment
+export * from './consts';             // qiankunHeadTagName, qiankunBodyTagName, nativeGlobal, nativeDocument
+export { esmDestructurableGlobals } from './core/esm-globals';
 ```

--- a/packages/sandbox/AGENTS.md
+++ b/packages/sandbox/AGENTS.md
@@ -1,7 +1,6 @@
 # @qiankunjs/sandbox
 
-JS isolation engine: Proxy-based **Membrane** + **Compartment** execution model. Also exposes the
-globals contract the ESM-sandbox engine (in `@qiankunjs/shared`) relies on. Depends only on `@qiankunjs/shared`.
+JS isolation engine: Proxy-based **Membrane** + **Compartment** execution model. Also exposes the globals contract the ESM-sandbox engine (in `@qiankunjs/shared`) relies on. Depends only on `@qiankunjs/shared`.
 
 ## STRUCTURE
 
@@ -39,8 +38,7 @@ sandbox/
 - **Writes** are trapped and stored on a local `target` object (the sandbox's own globals).
 - **Reads** check local target → endowments → fall back to the real host window.
 - **Native rebinding**: `fetch`, `console`, etc. are rebound to the real receiver to avoid "Illegal invocation".
-- `latestSetProp` records the last global the entry script assigned — that's how the loader recovers a
-  classic app's exported lifecycles when no explicit export exists.
+- `latestSetProp` records the last global the entry script assigned — that's how the loader recovers a classic app's exported lifecycles when no explicit export exists.
 
 ### Patcher / free pattern
 
@@ -64,8 +62,8 @@ free(); // on unmount — removes every listener/timer the micro-app added
 ## EXPORTS (`src/index.ts`)
 
 ```typescript
-export * from './core/sandbox';       // createSandboxContainer, type Sandbox, StandardSandbox
-export * from './core/compartment';   // Compartment
-export * from './consts';             // qiankunHeadTagName, qiankunBodyTagName, nativeGlobal, nativeDocument
+export * from './core/sandbox'; // createSandboxContainer, type Sandbox, StandardSandbox
+export * from './core/compartment'; // Compartment
+export * from './consts'; // qiankunHeadTagName, qiankunBodyTagName, nativeGlobal, nativeDocument
 export { esmDestructurableGlobals } from './core/esm-globals';
 ```

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -1,74 +1,88 @@
 # @qiankunjs/shared
 
-Internal utilities for fetch, asset transpilation, and module resolution.
+Base utilities shared by `loader`/`sandbox`/`qiankun`: asset transpilers, fetch decorators, module
+resolution, error reporting, and the **ESM-sandbox engine**. No internal `@qiankunjs/*` dependencies —
+keep it at the bottom of the graph (it must never import `sandbox` or `loader`).
 
 ## STRUCTURE
 
 ```
 shared/
-├── assets-transpilers/   # Script/link DOM node transformation
-│   ├── script.ts         # Blob URL wrapping, sandbox execution
-│   └── link.ts           # Preload optimization, URL rewriting
-├── fetch-utils/          # Enhanced fetch wrappers
-│   ├── makeFetchCacheable.ts   # LRU cache (50 entries)
-│   ├── makeFetchRetryable.ts   # Automatic retries
-│   └── makeFetchThrowable.ts   # Non-2xx throws error
-├── module-resolver/      # Shared dependency resolution
-├── reporter/             # QiankunError, logger
-├── deferred-queue/       # Async task sequencing
-└── utils.ts              # Deferred, resolveUrl, etc.
+├── assets-transpilers/   # transform script/link/style DOM nodes for the micro-frontend runtime
+│   ├── index.ts          # transpileAssets(node, baseURI, opts) — dispatch by tagName
+│   ├── script.ts         # classic scripts → blob-URL wrapping, sandbox scope
+│   ├── link.ts           # external stylesheets → blob-<link> (enables @scope); preload/URL rewriting; cache
+│   └── style.ts          # inline <style> → CSS @scope rewriting (runtime style isolation)
+├── esm-sandbox/          # per-instance native-ESM execution engine (see below)
+├── fetch-utils/          # higher-order fetch decorators
+│   ├── makeFetchCacheable.ts   # mini LRU, clones responses, prunes failures
+│   ├── makeFetchRetryable.ts   # automatic retries
+│   └── makeFetchThrowable.ts   # non-2xx → throw
+├── module-resolver/      # shared-dependency canonicalization (semver via <script type="dependencymap">)
+├── reporter/             # QiankunError + logger (warn/…)
+├── deferred-queue/       # async task sequencing (defer-script ordering)
+├── common.ts / utils.ts  # Deferred, defineProperty, hasOwnProperty, keys, resolveUrl, …
+└── typings.d.ts
 ```
+
+## ESM-SANDBOX (`esm-sandbox/`, the largest subsystem here)
+
+`EsmSandboxEngine` runs a micro-app's `<script type="module">` graph inside the sandbox membrane
+without a bundler. See the RFC in `docs/rfcs/`. Pipeline: fetch modules in parallel (memoized) →
+lexer-scan imports/globals → rewrite source to route referenced globals through the membrane and
+give each module a synthetic specifier → inject an **import map** so the browser resolves those
+specifiers → evaluate in dependency order → keep dunder-globals (`__qk_track`) live on later global writes.
+
+| File | Responsibility |
+| --- | --- |
+| `engine.ts` | `EsmSandboxEngine` — module-graph orchestration, redeclaration probing, in-order eval, dynamic `import()` |
+| `lexer.ts` | `prepareEsmLexer` — wraps es-module-lexer (async init) |
+| `rewrite.ts` | `rewriteModule`, `buildSyntheticSpecifier`, `esmInternalPrefix`, `runtimeModuleSubpath` |
+| `import-bindings.ts` | import statement binding analysis |
+| `identifier-scan.ts` | `scanReferencedGlobals`, `isLiveBindableDunderName` — which globals a module touches |
+| `import-map-registry.ts` | `injectImportMapEntries`, `resetImportMapRegistry` — the dynamic import map |
+| `realm-registry.ts` | `registerEsmRealm`/`unregisterEsmRealm`, `EsmRealm`, `RealmHandle` — per-instance realm lookup |
+| `vite-client-stub.ts` | `isViteClientUrl`, `viteClientStubSource` — stubs Vite dev-client HMR |
+| `source-map.ts` | rewritten-module source-map fixups |
+
+> ESM sandbox depends on **dynamically injected import maps** → unsupported on Firefox (see `e2e/README.md`).
 
 ## WHERE TO LOOK
 
-| Task               | File                                | Notes                                               |
-| ------------------ | ----------------------------------- | --------------------------------------------------- |
-| Script sandboxing  | `assets-transpilers/script.ts`      | Creates Blob URL with sandbox scope                 |
-| Link preload fix   | `assets-transpilers/link.ts`        | Changes `as="script"` to `as="fetch"` for sandbox   |
-| Fetch with cache   | `fetch-utils/makeFetchCacheable.ts` | Clones responses, prunes failed                     |
-| Dependency sharing | `module-resolver/index.ts`          | Semver matching via `<script type="dependencymap">` |
-| Promise utilities  | `utils.ts`                          | `Deferred` class for async control flow             |
+| Task | File | Notes |
+| --- | --- | --- |
+| Transpile any asset node | `assets-transpilers/index.ts` | `transpileAssets()` — the single dispatch entry |
+| Classic script sandboxing | `assets-transpilers/script.ts` | blob-URL wrap + sandbox scope |
+| Style isolation | `assets-transpilers/style.ts` + `link.ts` | CSS `@scope` rewrite; external CSS → blob-`<link>` |
+| Fetch enhancements | `fetch-utils/*` | decorator chain (compose with `make*` HOFs) |
+| Shared dependency reuse | `module-resolver/index.ts` | `moduleResolver(url, container, head)` semver match |
+| ESM module execution | `esm-sandbox/engine.ts` | `EsmSandboxEngine` (see section above) |
+| Promise/util helpers | `utils.ts` | `Deferred`, `keys`, `defineProperty`, `hasOwnProperty` |
 
 ## KEY PATTERNS
 
-### Higher-Order Fetch
+### Higher-order fetch (decorator composition)
 
 ```typescript
-// Decorator pattern - wrap fetch with enhancements
 const enhancedFetch = makeFetchCacheable(makeFetchRetryable(makeFetchThrowable(fetch)));
 ```
 
-### Deferred Promise
+### Deferred promise
 
 ```typescript
-const deferred = new Deferred<void>();
-// Later:
-deferred.resolve();
-await deferred.promise;
+const d = new Deferred<void>();
+d.resolve();
+await d.promise;
 ```
 
-### Blob URL Execution
+### DOM as metadata store
 
-```typescript
-// Scripts wrapped and executed via Blob for sandbox isolation
-const blob = new Blob([wrappedCode], { type: 'text/javascript' });
-script.src = URL.createObjectURL(blob);
-```
-
-### DOM as Metadata Store
-
-- `data-src`: Original source URL
-- `data-consumed`: Marks processed elements
+- `data-src` — original source URL of a transpiled node.
+- `data-consumed` — marks an already-processed element.
 
 ## EXPORTS
 
-```typescript
-// Transpilers
-export { transpileScript, transpileLink } from './assets-transpilers';
-// Fetch
-export { makeFetchCacheable, makeFetchRetryable, makeFetchThrowable } from './fetch-utils';
-// Module resolution
-export { createModuleResolver } from './module-resolver';
-// Utilities
-export { Deferred, QiankunError, prepareDeferredQueue } from './utils';
-```
+`src/index.ts` re-exports everything: `./assets-transpilers`, `./utils`, `./common`,
+`./module-resolver`, `./reporter`, `./esm-sandbox`, the three `fetch-utils/make*`, and `./deferred-queue`.
+Notable named exports: `transpileAssets`, `EsmSandboxEngine`, `moduleResolver`, `makeFetchCacheable`,
+`makeFetchRetryable`, `makeFetchThrowable`, `Deferred`, `QiankunError`, `warn`.

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -1,8 +1,6 @@
 # @qiankunjs/shared
 
-Base utilities shared by `loader`/`sandbox`/`qiankun`: asset transpilers, fetch decorators, module
-resolution, error reporting, and the **ESM-sandbox engine**. No internal `@qiankunjs/*` dependencies —
-keep it at the bottom of the graph (it must never import `sandbox` or `loader`).
+Base utilities shared by `loader`/`sandbox`/`qiankun`: asset transpilers, fetch decorators, module resolution, error reporting, and the **ESM-sandbox engine**. No internal `@qiankunjs/*` dependencies — keep it at the bottom of the graph (it must never import `sandbox` or `loader`).
 
 ## STRUCTURE
 
@@ -27,11 +25,7 @@ shared/
 
 ## ESM-SANDBOX (`esm-sandbox/`, the largest subsystem here)
 
-`EsmSandboxEngine` runs a micro-app's `<script type="module">` graph inside the sandbox membrane
-without a bundler. See the RFC in `docs/rfcs/`. Pipeline: fetch modules in parallel (memoized) →
-lexer-scan imports/globals → rewrite source to route referenced globals through the membrane and
-give each module a synthetic specifier → inject an **import map** so the browser resolves those
-specifiers → evaluate in dependency order → keep dunder-globals (`__qk_track`) live on later global writes.
+`EsmSandboxEngine` runs a micro-app's `<script type="module">` graph inside the sandbox membrane without a bundler. See the RFC in `docs/rfcs/`. Pipeline: fetch modules in parallel (memoized) → lexer-scan imports/globals → rewrite source to route referenced globals through the membrane and give each module a synthetic specifier → inject an **import map** so the browser resolves those specifiers → evaluate in dependency order → keep dunder-globals (`__qk_track`) live on later global writes.
 
 | File | Responsibility |
 | --- | --- |
@@ -82,7 +76,4 @@ await d.promise;
 
 ## EXPORTS
 
-`src/index.ts` re-exports everything: `./assets-transpilers`, `./utils`, `./common`,
-`./module-resolver`, `./reporter`, `./esm-sandbox`, the three `fetch-utils/make*`, and `./deferred-queue`.
-Notable named exports: `transpileAssets`, `EsmSandboxEngine`, `moduleResolver`, `makeFetchCacheable`,
-`makeFetchRetryable`, `makeFetchThrowable`, `Deferred`, `QiankunError`, `warn`.
+`src/index.ts` re-exports everything: `./assets-transpilers`, `./utils`, `./common`, `./module-resolver`, `./reporter`, `./esm-sandbox`, the three `fetch-utils/make*`, and `./deferred-queue`. Notable named exports: `transpileAssets`, `EsmSandboxEngine`, `moduleResolver`, `makeFetchCacheable`, `makeFetchRetryable`, `makeFetchThrowable`, `Deferred`, `QiankunError`, `warn`.


### PR DESCRIPTION
## Summary

Comprehensive refresh of project guidance documentation to reflect qiankun 3.0 architecture:

- **New CLAUDE.md**: lightweight entry point that imports AGENTS.md via `@import`, implementing progressive disclosure pattern
- **Root AGENTS.md** (commit dcc42ae4): updated architecture, ESM-sandbox engine deep-dive, Playwright e2e, bundler-plugin/create-qiankun, commands, conventions
- **Scoped AGENTS.md** (sandbox/loader/shared): accurate exports, ESM globals contract, esm-sandbox subsystem (lexer/rewrite/import-map/realm-registry), deprecated patterns

## Progressive Disclosure

The hierarchy avoids bloating context:

1. **CLAUDE.md** → imports AGENTS.md
2. **AGENTS.md** (root) → links to `packages/{sandbox,loader,shared}/AGENTS.md` for deep-dives, no `@import` (read on demand)
3. **scoped docs** → detailed subsystem knowledge

## Key Updates

- **Architecture**: dual execution paths (classic blob-URL vs. ESM-sandbox engine), Proxy-membrane sandbox, streaming HTML-entry loader
- **ESM-sandbox**: 10 files (engine/lexer/rewrite/import-bindings/identifier-scan/import-map-registry/realm-registry/vite-client-stub/source-map)
- **Style isolation**: @scope + blob-link runtime rewriting
- **Playwright e2e**: cross-origin, built-artifact verification, anti-flake rules
- **Commands**: pnpm run build:packages, test:e2e, eslint, prettier, ci
- **Conventions**: strict TS enforcement, inline type-imports, no-any (auto-fix to unknown), etc.

No breaking changes; documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0169dar49Ai5sbWfrukGte8r