### PR TITLE
ci: deploy docs to Cloudflare Pages; disable Vercel git deploys

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -1,0 +1,49 @@
+name: Deploy Docs to Cloudflare Pages
+
+on:
+  push:
+    branches:
+      - next
+    paths:
+      - "docs/**"
+      - ".github/workflows/cloudflare-pages.yml"
+  workflow_dispatch:
+
+# Avoid overlapping deploys stepping on each other
+concurrency:
+  group: cloudflare-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: "pnpm"
+
+      - run: corepack enable # https://nodejs.org/api/corepack.html
+
+      - run: pnpm install
+
+      - name: Build docs
+        run: pnpm run docs:build # outputs to docs/.vitepress/dist
+
+      # Use npx directly instead of cloudflare/wrangler-action: the action
+      # auto-installs wrangler via `pnpm add`, which fails at a pnpm workspace
+      # root (ERR_PNPM_ADDING_TO_ROOT). npx installs to its own cache instead.
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx -y wrangler@4 pages deploy docs/.vitepress/dist --project-name=qiankun --branch=${{ github.ref_name }}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
## What

Migrate the docs site (`qiankun.umijs.org`) hosting from **Vercel** to **Cloudflare Pages**.

- **Add** `.github/workflows/cloudflare-pages.yml` — builds VitePress docs and deploys `docs/.vitepress/dist` to the `qiankun` Cloudflare Pages project on push to `next` (when `docs/**` changes) or manual `workflow_dispatch`.
  - Uses `npx wrangler` directly rather than `cloudflare/wrangler-action`, because the action auto-installs wrangler via `pnpm add`, which fails at a pnpm workspace root (`ERR_PNPM_ADDING_TO_ROOT`).
- **Add** `vercel.json` with `git.deploymentEnabled: false` to stop Vercel from running (failing) deploys on every PR now that Cloudflare Pages is the deploy target.
- **Keep** `.github/workflows/github-pages.yml` as a disaster-recovery deploy (unchanged).

## Verification

- Cloudflare Pages project `qiankun` created (production branch `next`); first production deploy is live and verified (HTTP 200, `/zh-CN/` 200, unknown path → 404, `server: cloudflare`).
- This workflow was run end-to-end on a branch (preview deploy) and **passed**, confirming the scoped `CLOUDFLARE_API_TOKEN` (only `Account · Cloudflare Pages · Edit`) + `CLOUDFLARE_ACCOUNT_ID` secrets are sufficient.

## Remaining manual steps (outside this PR)

1. Bind custom domain `qiankun.umijs.org` in the Cloudflare Pages dashboard.
2. Cut over DNS: point `qiankun` from Vercel (A `76.223.126.88`) to the Cloudflare Pages target.
3. After the new site is verified on the custom domain, remove the project from Vercel.

> Note: `vercel.json` only takes effect once merged to the branch Vercel builds; it stops Vercel git deploys without deleting the existing (still-serving) production deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113xUYMS3cWzac23HkxLnc6