### PR TITLE
fix(loader): stream HTML chunks incrementally with benchmark coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ e2e/playwright-report/
 e2e/blob-report/
 
 # local benchmark artifacts
+benchmark/artifacts/
 benchmark/results/
 
 # typescript incremental build info

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ e2e/test-results/
 e2e/playwright-report/
 e2e/blob-report/
 
+# local benchmark artifacts
+benchmark/results/
+
 # typescript incremental build info
 *.tsbuildinfo

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -14,13 +14,28 @@ pnpm benchmark:check
 pnpm benchmark:smoke
 ```
 
+To compare a performance change against an interleaved baseline, snapshot the fully bundled host before editing package code, then run the comparison after the change:
+
+```bash
+# On the clean baseline revision. Fails instead of overwriting an existing snapshot.
+pnpm benchmark:baseline
+
+# After making and building the candidate change. Runs 100 paired samples per revision.
+pnpm benchmark:compare
+
+# Five paired samples for plumbing only; the improvement gate is disabled.
+pnpm benchmark:compare:check
+```
+
+The baseline snapshot contains the complete Vite host bundle, so its qiankun, loader, sandbox, and shared dependency graph cannot mix with candidate packages. Revision samples use different host origins, fresh BrowserContexts, a balanced alternating order, and the same streamed fixture. A formal comparison passes only when every sample is valid and the paired bootstrap 95% confidence interval is entirely below 0%.
+
 Install the pinned Chromium revision once if Playwright reports that it is missing:
 
 ```bash
 pnpm --filter @qiankunjs/benchmark exec playwright install chromium
 ```
 
-Local artifacts are written to `benchmark/results/<timestamp>-<commit>/` and are gitignored.
+Local snapshots are written to `benchmark/artifacts/`; run results are written to `benchmark/results/<timestamp>-<commit>/`. Both are gitignored.
 
 ## Matrix
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,58 @@
+# qiankun benchmark
+
+This workspace compares the cold-load path of the locally built qiankun package with a pinned Wujie release. It is intentionally separate from `e2e/`: Playwright Library only drives the browser boundaries, while all timing and core-element detection run inside the page.
+
+## Commands
+
+Run from the repository root:
+
+```bash
+# Five samples per product cell. Validates plumbing only; not performance data.
+pnpm benchmark:check
+
+# Five warmups, 100 valid attempts per product cell, and 50 samples per A/A arm.
+pnpm benchmark:smoke
+```
+
+Install the pinned Chromium revision once if Playwright reports that it is missing:
+
+```bash
+pnpm --filter @qiankunjs/benchmark exec playwright install chromium
+```
+
+Local artifacts are written to `benchmark/results/<timestamp>-<commit>/` and are gitignored.
+
+## Matrix
+
+The matrix is explicit rather than a cartesian product:
+
+1. qiankun without sandbox or style isolation
+2. qiankun with sandbox only
+3. qiankun with sandbox and style isolation
+4. Wujie with its intrinsic iframe and Shadow DOM isolation
+5. qiankun with full isolation and a three-chunk HTML response
+6. Wujie with the same three-chunk HTML response
+
+Wujie does not expose switches that disable its JavaScript or CSS isolation. Its off-cases are therefore marked N/A instead of being compared against a semantically different configuration.
+
+## Measurement contract
+
+- `t0`: immediately before `loadMicroApp` or `startApp` is called in the host page.
+- `t1`: the core marker exists, has non-zero geometry, is visible, has the expected CSS sentinel, and survives two `requestAnimationFrame` callbacks.
+- The framework must still finish mounting successfully; settlement is awaited outside the measured duration.
+- Buffered and streamed entry responses contain identical bytes. Streamed HTML is emitted at 0/50/100 ms by default.
+- The browser process is reused, but every attempt receives a fresh BrowserContext and page.
+- No trace, video, screenshot, HAR, route interception, retry, or parallel execution is enabled.
+- Raw warmup and measured samples are retained; none are silently replaced or filtered as outliers.
+
+The primary statistic is the paired median relative delta with a 10,000-resample bootstrap 95% confidence interval. Median, mean, p75, p95, MAD, standard deviation, and CV are also retained. Positive comparison deltas mean the candidate is slower than the reference.
+
+## A/A calibration
+
+Before the product matrix, two aliases of the exact same fully isolated qiankun variant are interleaved. The formal run requires:
+
+- absolute paired median delta no greater than 3%;
+- the bootstrap 95% interval includes 0%;
+- interval width no greater than 10 percentage points.
+
+The benchmark is manual in phase one and is not part of the regular PR CI gate.

--- a/benchmark/fixtures/host/qiankun.html
+++ b/benchmark/fixtures/host/qiankun.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>qiankun benchmark host</title>
+    <link rel="stylesheet" href="/src/host.css" />
+  </head>
+  <body>
+    <div id="micro-app-container"></div>
+    <script type="module" src="/src/qiankun.ts"></script>
+  </body>
+</html>

--- a/benchmark/fixtures/host/src/benchmark.ts
+++ b/benchmark/fixtures/host/src/benchmark.ts
@@ -1,0 +1,89 @@
+export interface BenchmarkOptions {
+  entry: string;
+  frameworkOptions: Record<string, unknown>;
+  timeoutMs: number;
+}
+
+export interface BenchmarkMeasurement {
+  duration: number;
+  settled: boolean;
+  t0: number;
+  t1: number;
+}
+
+type StartMicroApp = (options: BenchmarkOptions) => Promise<void>;
+
+function findCoreElement(): HTMLElement | null {
+  const direct = document.querySelector<HTMLElement>('#benchmark-core');
+  if (direct) return direct;
+  const wujieApp = document.querySelector('wujie-app');
+  return wujieApp?.shadowRoot?.querySelector<HTMLElement>('#benchmark-core') ?? null;
+}
+
+function isPaintable(element: HTMLElement): boolean {
+  const rect = element.getBoundingClientRect();
+  const style = getComputedStyle(element);
+  return (
+    rect.width > 0 &&
+    rect.height > 0 &&
+    style.display !== 'none' &&
+    style.visibility !== 'hidden' &&
+    style.opacity !== '0' &&
+    style.getPropertyValue('--benchmark-style-ready').trim() === '1'
+  );
+}
+
+function waitForPaint(t0: number, timeoutMs: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timeout = window.setTimeout(() => reject(new Error('core element paint timed out')), timeoutMs);
+
+    const check = () => {
+      const core = findCoreElement();
+      if (!core || !isPaintable(core)) {
+        requestAnimationFrame(check);
+        return;
+      }
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          const paintedCore = findCoreElement();
+          if (!paintedCore || !isPaintable(paintedCore)) {
+            requestAnimationFrame(check);
+            return;
+          }
+          window.clearTimeout(timeout);
+          resolve(performance.now() - t0);
+        });
+      });
+    };
+
+    requestAnimationFrame(check);
+  });
+}
+
+export function installBenchmark(startMicroApp: StartMicroApp): void {
+  window.__BENCHMARK__ = {
+    async run(options) {
+      const container = document.querySelector<HTMLElement>('#micro-app-container');
+      if (!container) throw new Error('micro app container is missing');
+      container.replaceChildren();
+
+      const t0 = performance.now();
+      const paintPromise = waitForPaint(t0, options.timeoutMs);
+      const settlePromise = startMicroApp(options);
+      const [duration] = await Promise.all([paintPromise, settlePromise]);
+      const mountedCore = findCoreElement();
+      if (mountedCore?.dataset.mounted !== 'true') {
+        throw new Error('micro app settled without mounting its core element');
+      }
+      return { duration, settled: true, t0, t1: t0 + duration };
+    },
+  };
+}
+
+declare global {
+  interface Window {
+    __BENCHMARK__: {
+      run(options: BenchmarkOptions): Promise<BenchmarkMeasurement>;
+    };
+  }
+}

--- a/benchmark/fixtures/host/src/host.css
+++ b/benchmark/fixtures/host/src/host.css
@@ -1,0 +1,11 @@
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+#micro-app-container {
+  display: block;
+  min-height: 480px;
+  width: 960px;
+}

--- a/benchmark/fixtures/host/src/qiankun.ts
+++ b/benchmark/fixtures/host/src/qiankun.ts
@@ -1,0 +1,17 @@
+import { type AppConfiguration, loadMicroApp } from 'qiankun';
+
+import { installBenchmark } from './benchmark';
+
+installBenchmark(async ({ entry, frameworkOptions }) => {
+  const container = document.querySelector<HTMLElement>('#micro-app-container');
+  if (!container) throw new Error('micro app container is missing');
+  const app = loadMicroApp(
+    {
+      container,
+      entry,
+      name: 'benchmark-app',
+    },
+    frameworkOptions as AppConfiguration,
+  );
+  await app.mountPromise;
+});

--- a/benchmark/fixtures/host/src/wujie.ts
+++ b/benchmark/fixtures/host/src/wujie.ts
@@ -1,0 +1,13 @@
+import { startApp } from 'wujie';
+
+import { installBenchmark } from './benchmark';
+
+installBenchmark(async ({ entry, frameworkOptions }) => {
+  await startApp({
+    ...frameworkOptions,
+    el: '#micro-app-container',
+    loading: document.createElement('span'),
+    name: 'benchmark-app',
+    url: entry,
+  });
+});

--- a/benchmark/fixtures/host/vite.config.ts
+++ b/benchmark/fixtures/host/vite.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    emptyOutDir: true,
+    minify: false,
+    outDir: 'dist',
+    rollupOptions: {
+      input: {
+        qiankun: fileURLToPath(new URL('qiankun.html', import.meta.url)),
+        wujie: fileURLToPath(new URL('wujie.html', import.meta.url)),
+      },
+    },
+    sourcemap: false,
+  },
+});

--- a/benchmark/fixtures/host/wujie.html
+++ b/benchmark/fixtures/host/wujie.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wujie benchmark host</title>
+    <link rel="stylesheet" href="/src/host.css" />
+  </head>
+  <body>
+    <div id="micro-app-container"></div>
+    <script type="module" src="/src/wujie.ts"></script>
+  </body>
+</html>

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -5,10 +5,13 @@
   "type": "module",
   "scripts": {
     "build:fixture": "vite build fixtures/host",
-    "check": "pnpm run test:unit && pnpm run build:fixture && node --test tests/browser.integration.test.mjs",
+    "check": "pnpm run test:unit && pnpm run typecheck && pnpm run build:fixture && node --test tests/browser.integration.test.mjs",
+    "compare": "pnpm run build:fixture && node runner.mjs --mode=revision --baseline-dir=artifacts/baseline --samples=100 --warmup=5 --calibration-samples=50",
+    "compare:check": "pnpm run build:fixture && node runner.mjs --mode=revision --baseline-dir=artifacts/baseline --samples=5 --warmup=2 --calibration-samples=5 --calibration-gate=false --comparison-gate=false",
     "run:check": "pnpm run build:fixture && node runner.mjs --samples=5 --warmup=2 --calibration-samples=5 --calibration-gate=false",
+    "snapshot:baseline": "pnpm run build:fixture && node snapshot.mjs --name=baseline",
     "smoke": "pnpm run build:fixture && node runner.mjs --samples=100 --warmup=5 --calibration-samples=50",
-    "test:unit": "node --test tests/browser.test.mjs tests/collect.test.mjs tests/options.test.mjs tests/report.test.mjs tests/scenarios.test.mjs tests/schedule.test.mjs tests/server.test.mjs tests/stats.test.mjs",
+    "test:unit": "node --test tests/browser.test.mjs tests/collect.test.mjs tests/options.test.mjs tests/report.test.mjs tests/revisions.test.mjs tests/scenarios.test.mjs tests/schedule.test.mjs tests/server.test.mjs tests/snapshot.test.mjs tests/stats.test.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@qiankunjs/benchmark",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "build:fixture": "vite build fixtures/host",
+    "check": "pnpm run test:unit && pnpm run build:fixture && node --test tests/browser.integration.test.mjs",
+    "run:check": "pnpm run build:fixture && node runner.mjs --samples=5 --warmup=2 --calibration-samples=5 --calibration-gate=false",
+    "smoke": "pnpm run build:fixture && node runner.mjs --samples=100 --warmup=5 --calibration-samples=50",
+    "test:unit": "node --test tests/browser.test.mjs tests/collect.test.mjs tests/options.test.mjs tests/report.test.mjs tests/scenarios.test.mjs tests/schedule.test.mjs tests/server.test.mjs tests/stats.test.mjs",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "qiankun": "workspace:*",
+    "wujie": "2.1.0"
+  },
+  "devDependencies": {
+    "playwright": "1.61.1",
+    "typescript": "5.9.3",
+    "vite": "5.4.21"
+  }
+}

--- a/benchmark/runner.mjs
+++ b/benchmark/runner.mjs
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 
@@ -11,10 +11,19 @@ import { runBrowserSample } from './src/browser.mjs';
 import { collectSamples } from './src/collect.mjs';
 import { parseRunnerOptions } from './src/options.mjs';
 import { buildReport, renderSummaryMarkdown } from './src/report.mjs';
+import { evaluateRevisionComparison, resolveVariantHostOrigin } from './src/revisions.mjs';
 import { createFixtureServer } from './src/server.mjs';
+import { readBaselineSnapshot } from './src/snapshot.mjs';
 import { createStaticServer } from './src/static-server.mjs';
 import { evaluateCalibration } from './src/stats.mjs';
-import { CALIBRATION_VARIANTS, PRODUCT_COMPARISONS, PRODUCT_VARIANTS } from './scenarios.mjs';
+import {
+  CALIBRATION_VARIANTS,
+  PRODUCT_COMPARISONS,
+  PRODUCT_VARIANTS,
+  REVISION_CALIBRATION_VARIANTS,
+  REVISION_COMPARISONS,
+  REVISION_VARIANTS,
+} from './scenarios.mjs';
 
 const execFileAsync = promisify(execFile);
 const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
@@ -24,18 +33,38 @@ async function readJson(path) {
   return JSON.parse(await readFile(path, 'utf8'));
 }
 
-async function getCommit() {
-  const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repositoryRoot });
-  return stdout.trim();
+async function getGitState() {
+  const [commitResult, statusResult] = await Promise.all([
+    execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repositoryRoot }),
+    execFileAsync('git', ['status', '--porcelain'], { cwd: repositoryRoot }),
+  ]);
+  return { commit: commitResult.stdout.trim(), dirty: statusResult.stdout.trim().length > 0 };
 }
 
-function materializeCalibrationVariants() {
-  const productById = new Map(PRODUCT_VARIANTS.map((variant) => [variant.id, variant]));
-  return CALIBRATION_VARIANTS.map((alias) => {
+function materializeCalibrationVariants(productVariants, aliases) {
+  const productById = new Map(productVariants.map((variant) => [variant.id, variant]));
+  return aliases.map((alias) => {
     const source = productById.get(alias.sourceVariant);
     if (!source) throw new Error(`unknown calibration source: ${alias.sourceVariant}`);
     return { ...source, id: alias.id, label: alias.label };
   });
+}
+
+function createRunDefinition(mode) {
+  if (mode === 'revision') {
+    return {
+      calibrationAliases: REVISION_CALIBRATION_VARIANTS,
+      comparisons: REVISION_COMPARISONS,
+      productTitle: 'Revision comparison',
+      variants: REVISION_VARIANTS,
+    };
+  }
+  return {
+    calibrationAliases: CALIBRATION_VARIANTS,
+    comparisons: PRODUCT_COMPARISONS,
+    productTitle: 'Product matrix',
+    variants: PRODUCT_VARIANTS,
+  };
 }
 
 function ensureAllValid(samples, phase) {
@@ -45,7 +74,7 @@ function ensureAllValid(samples, phase) {
   }
 }
 
-async function collectPhase({ browser, fixtureOrigin, hostOrigin, phase, rounds, seed, timeoutMs, variants }) {
+async function collectPhase({ browser, fixtureOrigin, hostOrigins, phase, rounds, seed, timeoutMs, variants }) {
   let completed = 0;
   const total = rounds * variants.length;
   return collectSamples({
@@ -58,7 +87,7 @@ async function collectPhase({ browser, fixtureOrigin, hostOrigin, phase, rounds,
         const measurement = await runBrowserSample({
           browser,
           fixtureOrigin,
-          hostOrigin,
+          hostOrigin: resolveVariantHostOrigin(variant, hostOrigins),
           timeoutMs,
           variant,
         });
@@ -74,12 +103,20 @@ async function collectPhase({ browser, fixtureOrigin, hostOrigin, phase, rounds,
   });
 }
 
-function renderRunSummary({ calibrationEvaluation, calibrationReport, fatalError, metadata, productReport }) {
+function renderRunSummary({
+  calibrationEvaluation,
+  calibrationReport,
+  fatalError,
+  metadata,
+  productReport,
+  productTitle,
+  revisionEvaluation,
+}) {
   const lines = [
-    '# qiankun vs Wujie benchmark',
+    metadata.options.mode === 'revision' ? '# qiankun revision benchmark' : '# qiankun vs Wujie benchmark',
     '',
     `- Run: ${metadata.runId}`,
-    `- Commit: ${metadata.commit}`,
+    `${metadata.options.mode === 'revision' ? '- Candidate commit' : '- Commit'}: ${metadata.commit}${metadata.dirty ? ' (dirty)' : ''}`,
     `- Chromium: ${metadata.browserVersion}`,
     `- Samples: ${metadata.options.samples} per product cell`,
     `- Warmup: ${metadata.options.warmup} per cell`,
@@ -88,6 +125,15 @@ function renderRunSummary({ calibrationEvaluation, calibrationReport, fatalError
     '> Positive comparison deltas mean the candidate is slower than the reference.',
     '',
   ];
+
+  if (metadata.baseline) {
+    lines.splice(
+      4,
+      0,
+      `- Baseline commit: ${metadata.baseline.git.commit}${metadata.baseline.git.dirty ? ' (dirty)' : ''}`,
+      `- Baseline bundle: ${metadata.baseline.bundleHash}`,
+    );
+  }
 
   if (fatalError) lines.push('## Fatal error', '', `\`${fatalError}\``, '');
   if (calibrationReport) {
@@ -103,7 +149,16 @@ function renderRunSummary({ calibrationEvaluation, calibrationReport, fatalError
     }
   }
   if (productReport) {
-    lines.push(renderSummaryMarkdown(productReport, { headingLevel: 2, title: 'Product matrix' }));
+    lines.push(renderSummaryMarkdown(productReport, { headingLevel: 2, title: productTitle }));
+  }
+  if (revisionEvaluation) {
+    lines.push(
+      `Improvement diagnostic: **${revisionEvaluation.passed ? 'passed' : 'failed'}**`,
+      `Improvement gate: **${metadata.options.comparisonGate ? 'enforced' : 'disabled for plumbing check'}**`,
+      '',
+    );
+    revisionEvaluation.failures.forEach((failure) => lines.push(`- ${failure}`));
+    if (revisionEvaluation.failures.length > 0) lines.push('');
   }
   return lines.join('\n');
 }
@@ -111,12 +166,21 @@ function renderRunSummary({ calibrationEvaluation, calibrationReport, fatalError
 async function main() {
   const options = parseRunnerOptions(process.argv.slice(2));
   const startedAt = new Date();
-  const commit = await getCommit();
+  const git = await getGitState();
+  const { commit } = git;
   const runId = `${startedAt.toISOString().replace(/[:.]/gu, '-')}-${commit.slice(0, 8)}`;
   const resultDirectory = join(benchmarkRoot, 'results', runId);
-  const host = createStaticServer({ port: 7600, root: join(benchmarkRoot, 'fixtures/host/dist') });
+  const runDefinition = createRunDefinition(options.mode);
+  const hostServers = {
+    candidate: createStaticServer({ port: 7600, root: join(benchmarkRoot, 'fixtures/host/dist') }),
+  };
+  const baselineDirectory = options.baselineDir ? resolve(benchmarkRoot, options.baselineDir) : null;
+  if (baselineDirectory) {
+    hostServers.baseline = createStaticServer({ port: 7602, root: join(baselineDirectory, 'host') });
+  }
   const fixture = createFixtureServer({ chunkIntervalMs: options.chunkIntervalMs, port: 7601 });
-  const calibrationVariants = materializeCalibrationVariants();
+  const calibrationVariants = materializeCalibrationVariants(runDefinition.variants, runDefinition.calibrationAliases);
+  let baselineMetadata;
   let browser;
   let calibrationEvaluation;
   let calibrationReport;
@@ -125,16 +189,19 @@ async function main() {
   let productReport;
   let productSamples = [];
   let productWarmupSamples = [];
+  let revisionEvaluation;
   let fatalError;
 
   try {
-    await Promise.all([host.start(), fixture.start()]);
+    if (baselineDirectory) baselineMetadata = await readBaselineSnapshot(baselineDirectory);
+    await Promise.all([...Object.values(hostServers).map((host) => host.start()), fixture.start()]);
+    const hostOrigins = Object.fromEntries(Object.entries(hostServers).map(([role, host]) => [role, host.origin]));
     browser = await chromium.launch({ headless: true });
 
     calibrationWarmupSamples = await collectPhase({
       browser,
       fixtureOrigin: fixture.origin,
-      hostOrigin: host.origin,
+      hostOrigins,
       phase: 'calibration-warmup',
       rounds: options.warmup,
       seed: options.seed - 2,
@@ -146,7 +213,7 @@ async function main() {
     calibrationSamples = await collectPhase({
       browser,
       fixtureOrigin: fixture.origin,
-      hostOrigin: host.origin,
+      hostOrigins,
       phase: 'calibration',
       rounds: options.calibrationSamples,
       seed: options.seed - 1,
@@ -173,36 +240,39 @@ async function main() {
       productWarmupSamples = await collectPhase({
         browser,
         fixtureOrigin: fixture.origin,
-        hostOrigin: host.origin,
+        hostOrigins,
         phase: 'product-warmup',
         rounds: options.warmup,
         seed: options.seed + 1,
         timeoutMs: options.timeoutMs,
-        variants: PRODUCT_VARIANTS,
+        variants: runDefinition.variants,
       });
       ensureAllValid(productWarmupSamples, 'product warmup');
 
       productSamples = await collectPhase({
         browser,
         fixtureOrigin: fixture.origin,
-        hostOrigin: host.origin,
+        hostOrigins,
         phase: 'product',
         rounds: options.samples,
         seed: options.seed,
         timeoutMs: options.timeoutMs,
-        variants: PRODUCT_VARIANTS,
+        variants: runDefinition.variants,
       });
       productReport = buildReport({
-        comparisons: PRODUCT_COMPARISONS,
+        comparisons: runDefinition.comparisons,
         samples: productSamples,
         seed: options.seed,
-        variants: PRODUCT_VARIANTS,
+        variants: runDefinition.variants,
       });
+      if (options.mode === 'revision') {
+        revisionEvaluation = evaluateRevisionComparison(productReport.comparisons['candidate-vs-baseline']);
+      }
     }
   } catch (error) {
     fatalError = error instanceof Error ? (error.stack ?? error.message) : String(error);
   } finally {
-    const cleanupTasks = [host.close(), fixture.close()];
+    const cleanupTasks = [...Object.values(hostServers).map((host) => host.close()), fixture.close()];
     if (browser) cleanupTasks.push(browser.close());
     const cleanupResults = await Promise.allSettled(cleanupTasks);
     const cleanupFailures = cleanupResults
@@ -217,17 +287,19 @@ async function main() {
   const qiankunPackage = await readJson(join(repositoryRoot, 'packages/qiankun/package.json'));
   const metadata = {
     arch: os.arch(),
+    baseline: baselineMetadata,
     browserVersion: browser?.version() ?? 'unavailable',
     commit,
     cpu: os.cpus()[0]?.model ?? 'unknown',
     cpuCount: os.cpus().length,
+    dirty: git.dirty,
     nodeVersion: process.version,
     options,
     platform: os.platform(),
     platformRelease: os.release(),
     qiankunVersion: qiankunPackage.version,
     runId,
-    schemaVersion: 1,
+    schemaVersion: 2,
     startedAt: startedAt.toISOString(),
     wujieVersion: benchmarkPackage.dependencies.wujie,
   };
@@ -235,8 +307,9 @@ async function main() {
   const passed =
     !fatalError &&
     (!options.calibrationGate || calibrationEvaluation?.passed === true) &&
+    (options.mode !== 'revision' || !options.comparisonGate || revisionEvaluation?.passed === true) &&
     !hasInvalidProductSample &&
-    productSamples.length === options.samples * PRODUCT_VARIANTS.length;
+    productSamples.length === options.samples * runDefinition.variants.length;
   const result = {
     calibration: {
       evaluation: calibrationEvaluation,
@@ -248,6 +321,7 @@ async function main() {
     metadata,
     passed,
     product: { report: productReport, samples: productSamples, warmupSamples: productWarmupSamples },
+    revision: { evaluation: revisionEvaluation },
   };
   const summary = renderRunSummary({
     calibrationEvaluation,
@@ -255,6 +329,8 @@ async function main() {
     fatalError,
     metadata,
     productReport,
+    productTitle: runDefinition.productTitle,
+    revisionEvaluation,
   });
 
   await mkdir(resultDirectory, { recursive: true });

--- a/benchmark/runner.mjs
+++ b/benchmark/runner.mjs
@@ -1,0 +1,270 @@
+import { execFile } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+import { chromium } from 'playwright';
+
+import { runBrowserSample } from './src/browser.mjs';
+import { collectSamples } from './src/collect.mjs';
+import { parseRunnerOptions } from './src/options.mjs';
+import { buildReport, renderSummaryMarkdown } from './src/report.mjs';
+import { createFixtureServer } from './src/server.mjs';
+import { createStaticServer } from './src/static-server.mjs';
+import { evaluateCalibration } from './src/stats.mjs';
+import { CALIBRATION_VARIANTS, PRODUCT_COMPARISONS, PRODUCT_VARIANTS } from './scenarios.mjs';
+
+const execFileAsync = promisify(execFile);
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = dirname(benchmarkRoot);
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+async function getCommit() {
+  const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repositoryRoot });
+  return stdout.trim();
+}
+
+function materializeCalibrationVariants() {
+  const productById = new Map(PRODUCT_VARIANTS.map((variant) => [variant.id, variant]));
+  return CALIBRATION_VARIANTS.map((alias) => {
+    const source = productById.get(alias.sourceVariant);
+    if (!source) throw new Error(`unknown calibration source: ${alias.sourceVariant}`);
+    return { ...source, id: alias.id, label: alias.label };
+  });
+}
+
+function ensureAllValid(samples, phase) {
+  const invalid = samples.filter((sample) => !sample.valid);
+  if (invalid.length > 0) {
+    throw new Error(`${phase} produced ${invalid.length} invalid sample(s): ${invalid[0].error}`);
+  }
+}
+
+async function collectPhase({ browser, fixtureOrigin, hostOrigin, phase, rounds, seed, timeoutMs, variants }) {
+  let completed = 0;
+  const total = rounds * variants.length;
+  return collectSamples({
+    rounds,
+    seed,
+    variants,
+    sample: async (variant) => {
+      completed += 1;
+      try {
+        const measurement = await runBrowserSample({
+          browser,
+          fixtureOrigin,
+          hostOrigin,
+          timeoutMs,
+          variant,
+        });
+        console.log(`[benchmark] ${phase} ${completed}/${total} ${variant.id} ${measurement.duration.toFixed(2)}ms`);
+        return { ...measurement, phase, timestamp: new Date().toISOString() };
+      } catch (error) {
+        console.error(
+          `[benchmark] ${phase} ${completed}/${total} ${variant.id} failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        throw error;
+      }
+    },
+  });
+}
+
+function renderRunSummary({ calibrationEvaluation, calibrationReport, fatalError, metadata, productReport }) {
+  const lines = [
+    '# qiankun vs Wujie benchmark',
+    '',
+    `- Run: ${metadata.runId}`,
+    `- Commit: ${metadata.commit}`,
+    `- Chromium: ${metadata.browserVersion}`,
+    `- Samples: ${metadata.options.samples} per product cell`,
+    `- Warmup: ${metadata.options.warmup} per cell`,
+    `- Seed: ${metadata.options.seed}`,
+    '',
+    '> Positive comparison deltas mean the candidate is slower than the reference.',
+    '',
+  ];
+
+  if (fatalError) lines.push('## Fatal error', '', `\`${fatalError}\``, '');
+  if (calibrationReport) {
+    lines.push(
+      renderSummaryMarkdown(calibrationReport, { headingLevel: 2, title: 'A/A calibration' }),
+      `Calibration diagnostic: **${calibrationEvaluation?.passed ? 'passed' : 'failed'}**`,
+      `Calibration gate: **${metadata.options.calibrationGate ? 'enforced' : 'disabled for plumbing check'}**`,
+      '',
+    );
+    if (calibrationEvaluation && !calibrationEvaluation.passed) {
+      calibrationEvaluation.failures.forEach((failure) => lines.push(`- ${failure}`));
+      lines.push('');
+    }
+  }
+  if (productReport) {
+    lines.push(renderSummaryMarkdown(productReport, { headingLevel: 2, title: 'Product matrix' }));
+  }
+  return lines.join('\n');
+}
+
+async function main() {
+  const options = parseRunnerOptions(process.argv.slice(2));
+  const startedAt = new Date();
+  const commit = await getCommit();
+  const runId = `${startedAt.toISOString().replace(/[:.]/gu, '-')}-${commit.slice(0, 8)}`;
+  const resultDirectory = join(benchmarkRoot, 'results', runId);
+  const host = createStaticServer({ port: 7600, root: join(benchmarkRoot, 'fixtures/host/dist') });
+  const fixture = createFixtureServer({ chunkIntervalMs: options.chunkIntervalMs, port: 7601 });
+  const calibrationVariants = materializeCalibrationVariants();
+  let browser;
+  let calibrationEvaluation;
+  let calibrationReport;
+  let calibrationSamples = [];
+  let calibrationWarmupSamples = [];
+  let productReport;
+  let productSamples = [];
+  let productWarmupSamples = [];
+  let fatalError;
+
+  try {
+    await Promise.all([host.start(), fixture.start()]);
+    browser = await chromium.launch({ headless: true });
+
+    calibrationWarmupSamples = await collectPhase({
+      browser,
+      fixtureOrigin: fixture.origin,
+      hostOrigin: host.origin,
+      phase: 'calibration-warmup',
+      rounds: options.warmup,
+      seed: options.seed - 2,
+      timeoutMs: options.timeoutMs,
+      variants: calibrationVariants,
+    });
+    ensureAllValid(calibrationWarmupSamples, 'calibration warmup');
+
+    calibrationSamples = await collectPhase({
+      browser,
+      fixtureOrigin: fixture.origin,
+      hostOrigin: host.origin,
+      phase: 'calibration',
+      rounds: options.calibrationSamples,
+      seed: options.seed - 1,
+      timeoutMs: options.timeoutMs,
+      variants: calibrationVariants,
+    });
+    ensureAllValid(calibrationSamples, 'calibration');
+    calibrationReport = buildReport({
+      comparisons: [
+        {
+          candidate: 'calibration-b',
+          id: 'aa-calibration',
+          label: 'A/A identical qiankun variants',
+          reference: 'calibration-a',
+        },
+      ],
+      samples: calibrationSamples,
+      seed: options.seed,
+      variants: calibrationVariants,
+    });
+    calibrationEvaluation = evaluateCalibration(calibrationReport.comparisons['aa-calibration']);
+
+    if (!options.calibrationGate || calibrationEvaluation.passed) {
+      productWarmupSamples = await collectPhase({
+        browser,
+        fixtureOrigin: fixture.origin,
+        hostOrigin: host.origin,
+        phase: 'product-warmup',
+        rounds: options.warmup,
+        seed: options.seed + 1,
+        timeoutMs: options.timeoutMs,
+        variants: PRODUCT_VARIANTS,
+      });
+      ensureAllValid(productWarmupSamples, 'product warmup');
+
+      productSamples = await collectPhase({
+        browser,
+        fixtureOrigin: fixture.origin,
+        hostOrigin: host.origin,
+        phase: 'product',
+        rounds: options.samples,
+        seed: options.seed,
+        timeoutMs: options.timeoutMs,
+        variants: PRODUCT_VARIANTS,
+      });
+      productReport = buildReport({
+        comparisons: PRODUCT_COMPARISONS,
+        samples: productSamples,
+        seed: options.seed,
+        variants: PRODUCT_VARIANTS,
+      });
+    }
+  } catch (error) {
+    fatalError = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  } finally {
+    const cleanupTasks = [host.close(), fixture.close()];
+    if (browser) cleanupTasks.push(browser.close());
+    const cleanupResults = await Promise.allSettled(cleanupTasks);
+    const cleanupFailures = cleanupResults
+      .filter((result) => result.status === 'rejected')
+      .map((result) => (result.reason instanceof Error ? result.reason.message : String(result.reason)));
+    if (!fatalError && cleanupFailures.length > 0) {
+      fatalError = `benchmark cleanup failed: ${cleanupFailures.join('; ')}`;
+    }
+  }
+
+  const benchmarkPackage = await readJson(join(benchmarkRoot, 'package.json'));
+  const qiankunPackage = await readJson(join(repositoryRoot, 'packages/qiankun/package.json'));
+  const metadata = {
+    arch: os.arch(),
+    browserVersion: browser?.version() ?? 'unavailable',
+    commit,
+    cpu: os.cpus()[0]?.model ?? 'unknown',
+    cpuCount: os.cpus().length,
+    nodeVersion: process.version,
+    options,
+    platform: os.platform(),
+    platformRelease: os.release(),
+    qiankunVersion: qiankunPackage.version,
+    runId,
+    schemaVersion: 1,
+    startedAt: startedAt.toISOString(),
+    wujieVersion: benchmarkPackage.dependencies.wujie,
+  };
+  const hasInvalidProductSample = productSamples.some((sample) => !sample.valid);
+  const passed =
+    !fatalError &&
+    (!options.calibrationGate || calibrationEvaluation?.passed === true) &&
+    !hasInvalidProductSample &&
+    productSamples.length === options.samples * PRODUCT_VARIANTS.length;
+  const result = {
+    calibration: {
+      evaluation: calibrationEvaluation,
+      report: calibrationReport,
+      samples: calibrationSamples,
+      warmupSamples: calibrationWarmupSamples,
+    },
+    fatalError,
+    metadata,
+    passed,
+    product: { report: productReport, samples: productSamples, warmupSamples: productWarmupSamples },
+  };
+  const summary = renderRunSummary({
+    calibrationEvaluation,
+    calibrationReport,
+    fatalError,
+    metadata,
+    productReport,
+  });
+
+  await mkdir(resultDirectory, { recursive: true });
+  await Promise.all([
+    writeFile(join(resultDirectory, 'result.json'), `${JSON.stringify(result, null, 2)}\n`),
+    writeFile(join(resultDirectory, 'summary.md'), summary),
+  ]);
+  console.log(summary);
+  console.log(`[benchmark] artifacts: ${resultDirectory}`);
+  if (!passed) process.exitCode = 1;
+}
+
+await main();

--- a/benchmark/scenarios.mjs
+++ b/benchmark/scenarios.mjs
@@ -1,0 +1,83 @@
+const WUJIE_OPTIONS = {
+  alive: false,
+  degrade: false,
+  fiber: false,
+  sync: false,
+};
+
+export const PRODUCT_VARIANTS = [
+  {
+    delivery: 'buffered',
+    framework: 'qiankun',
+    frameworkOptions: { sandbox: false, styleIsolation: false },
+    id: 'qk-no-isolation',
+    label: 'qiankun · no isolation',
+  },
+  {
+    delivery: 'buffered',
+    framework: 'qiankun',
+    frameworkOptions: { sandbox: true, styleIsolation: false },
+    id: 'qk-sandbox',
+    label: 'qiankun · sandbox',
+  },
+  {
+    delivery: 'buffered',
+    framework: 'qiankun',
+    frameworkOptions: { sandbox: true, styleIsolation: true },
+    id: 'qk-full-isolation',
+    label: 'qiankun · sandbox + style isolation',
+  },
+  {
+    delivery: 'buffered',
+    framework: 'wujie',
+    frameworkOptions: WUJIE_OPTIONS,
+    id: 'wujie-isolated',
+    label: 'Wujie · iframe + Shadow DOM',
+  },
+  {
+    delivery: 'streamed',
+    framework: 'qiankun',
+    frameworkOptions: { sandbox: true, styleIsolation: true },
+    id: 'qk-streamed',
+    label: 'qiankun · streamed',
+  },
+  {
+    delivery: 'streamed',
+    framework: 'wujie',
+    frameworkOptions: WUJIE_OPTIONS,
+    id: 'wujie-streamed',
+    label: 'Wujie · streamed response',
+  },
+];
+
+export const CALIBRATION_VARIANTS = [
+  { id: 'calibration-a', label: 'A/A · A', sourceVariant: 'qk-full-isolation' },
+  { id: 'calibration-b', label: 'A/A · B', sourceVariant: 'qk-full-isolation' },
+];
+
+export const PRODUCT_COMPARISONS = [
+  {
+    candidate: 'qk-sandbox',
+    id: 'sandbox-cost',
+    label: 'qiankun sandbox cost',
+    reference: 'qk-no-isolation',
+  },
+  {
+    candidate: 'qk-full-isolation',
+    id: 'style-isolation-cost',
+    label: 'qiankun style isolation cost',
+    reference: 'qk-sandbox',
+  },
+  {
+    candidate: 'wujie-isolated',
+    id: 'isolated-framework',
+    label: 'Wujie vs qiankun under isolation',
+    reference: 'qk-full-isolation',
+  },
+  {
+    candidate: 'wujie-streamed',
+    id: 'streaming-framework',
+    label: 'Wujie vs qiankun with streamed HTML',
+    reference: 'qk-streamed',
+  },
+];

--- a/benchmark/scenarios.mjs
+++ b/benchmark/scenarios.mjs
@@ -81,3 +81,38 @@ export const PRODUCT_COMPARISONS = [
     reference: 'qk-streamed',
   },
 ];
+
+const REVISION_FRAMEWORK_OPTIONS = { sandbox: true, styleIsolation: true };
+
+export const REVISION_VARIANTS = [
+  {
+    delivery: 'streamed',
+    framework: 'qiankun',
+    frameworkOptions: REVISION_FRAMEWORK_OPTIONS,
+    hostRole: 'baseline',
+    id: 'revision-baseline',
+    label: 'baseline · qiankun streamed',
+  },
+  {
+    delivery: 'streamed',
+    framework: 'qiankun',
+    frameworkOptions: REVISION_FRAMEWORK_OPTIONS,
+    hostRole: 'candidate',
+    id: 'revision-candidate',
+    label: 'candidate · qiankun streamed',
+  },
+];
+
+export const REVISION_CALIBRATION_VARIANTS = [
+  { id: 'calibration-a', label: 'A/A · A', sourceVariant: 'revision-candidate' },
+  { id: 'calibration-b', label: 'A/A · B', sourceVariant: 'revision-candidate' },
+];
+
+export const REVISION_COMPARISONS = [
+  {
+    candidate: 'revision-candidate',
+    id: 'candidate-vs-baseline',
+    label: 'candidate vs baseline',
+    reference: 'revision-baseline',
+  },
+];

--- a/benchmark/snapshot.mjs
+++ b/benchmark/snapshot.mjs
@@ -1,0 +1,39 @@
+import { execFile } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+import { assertCleanBaselineGitState, createBaselineSnapshot } from './src/snapshot.mjs';
+
+const execFileAsync = promisify(execFile);
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = dirname(benchmarkRoot);
+
+function parseName(args) {
+  if (args.length !== 1) throw new Error('usage: node snapshot.mjs --name=<snapshot-name>');
+  const match = /^--name=([\w.-]+)$/u.exec(args[0]);
+  if (!match) throw new Error('snapshot name may only contain letters, numbers, dots, underscores, and dashes');
+  return match[1];
+}
+
+async function getGitState() {
+  const [commitResult, statusResult] = await Promise.all([
+    execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repositoryRoot }),
+    execFileAsync('git', ['status', '--porcelain'], { cwd: repositoryRoot }),
+  ]);
+  return { commit: commitResult.stdout.trim(), dirty: statusResult.stdout.trim().length > 0 };
+}
+
+const name = parseName(process.argv.slice(2));
+const targetDirectory = join(benchmarkRoot, 'artifacts', name);
+const git = await getGitState();
+assertCleanBaselineGitState(git);
+const metadata = await createBaselineSnapshot({
+  createdAt: new Date().toISOString(),
+  git,
+  sourceDirectory: join(benchmarkRoot, 'fixtures/host/dist'),
+  targetDirectory,
+});
+
+console.log(`[benchmark] snapshot: ${targetDirectory}`);
+console.log(`[benchmark] bundle: ${metadata.bundleHash}`);

--- a/benchmark/src/browser.mjs
+++ b/benchmark/src/browser.mjs
@@ -1,0 +1,69 @@
+const BROWSER_CONTEXT_OPTIONS = {
+  colorScheme: 'light',
+  deviceScaleFactor: 1,
+  locale: 'en-US',
+  reducedMotion: 'reduce',
+  serviceWorkers: 'block',
+  timezoneId: 'UTC',
+  viewport: { height: 720, width: 1280 },
+};
+
+async function withTimeout(promise, timeoutMs) {
+  let timeout;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(`benchmark sample timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function runBrowserSample({ browser, fixtureOrigin, hostOrigin, timeoutMs, variant }) {
+  const context = await browser.newContext(BROWSER_CONTEXT_OPTIONS);
+  try {
+    const page = await context.newPage();
+    const errors = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') errors.push(`console: ${message.text()}`);
+    });
+    page.on('pageerror', (error) => errors.push(`page: ${error.message}`));
+    page.on('requestfailed', (request) => {
+      errors.push(`request: ${request.url()} (${request.failure()?.errorText ?? 'failed'})`);
+    });
+    page.on('response', (response) => {
+      const status = response.status();
+      if (status >= 400) errors.push(`response: ${response.url()} (${status})`);
+    });
+
+    await page.goto(`${hostOrigin}/${variant.framework}.html`, {
+      timeout: timeoutMs,
+      waitUntil: 'load',
+    });
+    const measurement = await withTimeout(
+      page.evaluate(
+        async ({ delivery, entryOrigin, frameworkOptions, timeout }) => {
+          if (!window.__BENCHMARK__) throw new Error('benchmark host API is unavailable');
+          return window.__BENCHMARK__.run({
+            entry: `${entryOrigin}/app?delivery=${delivery}`,
+            frameworkOptions,
+            timeoutMs: timeout,
+          });
+        },
+        {
+          delivery: variant.delivery,
+          entryOrigin: fixtureOrigin,
+          frameworkOptions: variant.frameworkOptions,
+          timeout: timeoutMs,
+        },
+      ),
+      timeoutMs,
+    );
+    if (errors.length > 0) throw new Error(errors.join('\n'));
+    return measurement;
+  } finally {
+    await context.close();
+  }
+}

--- a/benchmark/src/collect.mjs
+++ b/benchmark/src/collect.mjs
@@ -1,0 +1,38 @@
+import { createBalancedSchedule } from './schedule.mjs';
+
+export async function collectSamples({ rounds, sample, seed, variants }) {
+  const variantsById = new Map(variants.map((variant) => [variant.id, variant]));
+  const sampleSchedule = createBalancedSchedule(
+    variants.map((variant) => variant.id),
+    rounds,
+    seed,
+  );
+  const samples = [];
+
+  for (const entry of sampleSchedule) {
+    const sequence = samples.length;
+    const variant = variantsById.get(entry.variant);
+    try {
+      const measurement = await sample(variant, entry);
+      samples.push({
+        ...measurement,
+        position: entry.position,
+        round: entry.round,
+        sequence,
+        valid: true,
+        variant: entry.variant,
+      });
+    } catch (error) {
+      samples.push({
+        error: error instanceof Error ? error.message : String(error),
+        position: entry.position,
+        round: entry.round,
+        sequence,
+        valid: false,
+        variant: entry.variant,
+      });
+    }
+  }
+
+  return samples;
+}

--- a/benchmark/src/options.mjs
+++ b/benchmark/src/options.mjs
@@ -1,12 +1,20 @@
 const DEFAULT_OPTIONS = {
+  baselineDir: null,
   calibrationGate: true,
   calibrationSamples: 50,
   chunkIntervalMs: 50,
+  comparisonGate: true,
+  mode: 'framework',
   samples: 100,
   seed: 20260711,
   timeoutMs: 10_000,
   warmup: 5,
 };
+
+const BOOLEAN_OPTIONS = new Map([
+  ['calibration-gate', 'calibrationGate'],
+  ['comparison-gate', 'comparisonGate'],
+]);
 
 const INTEGER_OPTIONS = new Map([
   ['calibration-samples', 'calibrationSamples'],
@@ -24,11 +32,25 @@ export function parseRunnerOptions(args) {
     if (!match) throw new Error(`unknown option: ${argument}`);
     const [, name, rawValue] = match;
 
-    if (name === 'calibration-gate') {
+    const booleanProperty = BOOLEAN_OPTIONS.get(name);
+    if (booleanProperty) {
       if (rawValue !== 'true' && rawValue !== 'false') {
-        throw new Error('calibration-gate must be true or false');
+        throw new Error(`${name} must be true or false`);
       }
-      options.calibrationGate = rawValue === 'true';
+      options[booleanProperty] = rawValue === 'true';
+      continue;
+    }
+
+    if (name === 'mode') {
+      if (rawValue !== 'framework' && rawValue !== 'revision') {
+        throw new Error('mode must be framework or revision');
+      }
+      options.mode = rawValue;
+      continue;
+    }
+
+    if (name === 'baseline-dir') {
+      options.baselineDir = rawValue;
       continue;
     }
 
@@ -38,5 +60,13 @@ export function parseRunnerOptions(args) {
     if (!Number.isInteger(value) || value <= 0) throw new Error(`${name} must be a positive integer`);
     options[property] = value;
   }
+
+  if (options.mode === 'revision' && !options.baselineDir) {
+    throw new Error('baseline-dir is required in revision mode');
+  }
+  if (options.mode === 'framework' && options.baselineDir) {
+    throw new Error('baseline-dir requires revision mode');
+  }
+
   return options;
 }

--- a/benchmark/src/options.mjs
+++ b/benchmark/src/options.mjs
@@ -1,0 +1,42 @@
+const DEFAULT_OPTIONS = {
+  calibrationGate: true,
+  calibrationSamples: 50,
+  chunkIntervalMs: 50,
+  samples: 100,
+  seed: 20260711,
+  timeoutMs: 10_000,
+  warmup: 5,
+};
+
+const INTEGER_OPTIONS = new Map([
+  ['calibration-samples', 'calibrationSamples'],
+  ['chunk-interval', 'chunkIntervalMs'],
+  ['samples', 'samples'],
+  ['seed', 'seed'],
+  ['timeout', 'timeoutMs'],
+  ['warmup', 'warmup'],
+]);
+
+export function parseRunnerOptions(args) {
+  const options = { ...DEFAULT_OPTIONS };
+  for (const argument of args) {
+    const match = /^--([^=]+)=(.+)$/u.exec(argument);
+    if (!match) throw new Error(`unknown option: ${argument}`);
+    const [, name, rawValue] = match;
+
+    if (name === 'calibration-gate') {
+      if (rawValue !== 'true' && rawValue !== 'false') {
+        throw new Error('calibration-gate must be true or false');
+      }
+      options.calibrationGate = rawValue === 'true';
+      continue;
+    }
+
+    const property = INTEGER_OPTIONS.get(name);
+    if (!property) throw new Error(`unknown option: --${name}`);
+    const value = Number(rawValue);
+    if (!Number.isInteger(value) || value <= 0) throw new Error(`${name} must be a positive integer`);
+    options[property] = value;
+  }
+  return options;
+}

--- a/benchmark/src/report.mjs
+++ b/benchmark/src/report.mjs
@@ -1,0 +1,87 @@
+import { comparePairedSamples, summarize } from './stats.mjs';
+
+function formatSignedPercent(value) {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+}
+
+export function buildReport({ comparisons, samples, seed, variants }) {
+  const variantReports = {};
+  for (const variant of variants) {
+    const matching = samples.filter((sample) => sample.variant === variant.id);
+    const valid = matching.filter((sample) => sample.valid);
+    variantReports[variant.id] = {
+      invalidCount: matching.length - valid.length,
+      label: variant.label,
+      summary: valid.length === 0 ? null : summarize(valid.map((sample) => sample.duration)),
+    };
+  }
+
+  const comparisonReports = {};
+  comparisons.forEach((comparison, comparisonIndex) => {
+    const referenceByRound = new Map(
+      samples
+        .filter((sample) => sample.valid && sample.variant === comparison.reference)
+        .map((sample) => [sample.round, sample.duration]),
+    );
+    const candidateByRound = new Map(
+      samples
+        .filter((sample) => sample.valid && sample.variant === comparison.candidate)
+        .map((sample) => [sample.round, sample.duration]),
+    );
+    const pairedRounds = [...referenceByRound.keys()].filter((round) => candidateByRound.has(round));
+    const measured = comparePairedSamples(
+      pairedRounds.map((round) => referenceByRound.get(round)),
+      pairedRounds.map((round) => candidateByRound.get(round)),
+      { seed: seed + comparisonIndex },
+    );
+    comparisonReports[comparison.id] = {
+      ...measured,
+      candidate: comparison.candidate,
+      label: comparison.label,
+      pairedCount: pairedRounds.length,
+      reference: comparison.reference,
+    };
+  });
+
+  return { comparisons: comparisonReports, variants: variantReports };
+}
+
+export function renderSummaryMarkdown(report, { headingLevel = 1, title }) {
+  if (!Number.isInteger(headingLevel) || headingLevel < 1 || headingLevel > 5) {
+    throw new Error('headingLevel must be an integer from 1 to 5');
+  }
+  const heading = '#'.repeat(headingLevel);
+  const sectionHeading = `${heading}#`;
+  const lines = [
+    `${heading} ${title}`,
+    '',
+    `${sectionHeading} Variants`,
+    '',
+    '| Variant | Valid | Invalid | Median (ms) | p95 (ms) | MAD (ms) |',
+    '| --- | ---: | ---: | ---: | ---: | ---: |',
+  ];
+
+  Object.values(report.variants).forEach((variant) => {
+    const summary = variant.summary;
+    lines.push(
+      `| ${variant.label} | ${summary?.count ?? 0} | ${variant.invalidCount} | ${summary ? summary.median.toFixed(2) : 'n/a'} | ${summary ? summary.p95.toFixed(2) : 'n/a'} | ${summary ? summary.mad.toFixed(2) : 'n/a'} |`,
+    );
+  });
+
+  lines.push(
+    '',
+    `${sectionHeading} Comparisons`,
+    '',
+    '| Comparison | Relative delta | 95% CI | Paired samples |',
+    '| --- | ---: | ---: | ---: |',
+  );
+  Object.values(report.comparisons).forEach((comparison) => {
+    const [lower, upper] = comparison.confidenceInterval95;
+    lines.push(
+      `| ${comparison.label} | ${formatSignedPercent(comparison.relativeDeltaPercent)} | ${formatSignedPercent(lower)} to ${formatSignedPercent(upper)} | ${comparison.pairedCount} |`,
+    );
+  });
+
+  lines.push('');
+  return lines.join('\n');
+}

--- a/benchmark/src/revisions.mjs
+++ b/benchmark/src/revisions.mjs
@@ -1,0 +1,19 @@
+function formatSignedPercent(value) {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+}
+
+export function evaluateRevisionComparison(comparison) {
+  const upperBound = comparison.confidenceInterval95[1];
+  const failures = [];
+  if (upperBound >= 0) {
+    failures.push(`95% confidence interval upper bound ${formatSignedPercent(upperBound)} is not below 0%`);
+  }
+  return { failures, passed: failures.length === 0 };
+}
+
+export function resolveVariantHostOrigin(variant, hostOrigins) {
+  const role = variant.hostRole ?? 'candidate';
+  const origin = hostOrigins[role];
+  if (!origin) throw new Error(`host origin is unavailable for role: ${role}`);
+  return origin;
+}

--- a/benchmark/src/schedule.mjs
+++ b/benchmark/src/schedule.mjs
@@ -1,0 +1,39 @@
+function createSeededRandom(seed) {
+  let value = seed >>> 0;
+  return () => {
+    value += 0x6d2b79f5;
+    let result = value;
+    result = Math.imul(result ^ (result >>> 15), result | 1);
+    result ^= result + Math.imul(result ^ (result >>> 7), result | 61);
+    return ((result ^ (result >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffle(values, seed) {
+  const result = [...values];
+  const random = createSeededRandom(seed);
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    const target = Math.floor(random() * (index + 1));
+    [result[index], result[target]] = [result[target], result[index]];
+  }
+  return result;
+}
+
+export function createBalancedSchedule(variants, rounds, seed) {
+  if (variants.length === 0) throw new Error('at least one variant is required');
+  if (new Set(variants).size !== variants.length) throw new Error('variant ids must be unique');
+  if (!Number.isInteger(rounds) || rounds <= 0) throw new Error('rounds must be a positive integer');
+
+  const base = shuffle(variants, seed);
+  const schedule = [];
+
+  for (let round = 0; round < rounds; round += 1) {
+    const block = Math.floor(round / base.length);
+    const blockOrder = block % 2 === 0 ? base : [...base].reverse();
+    const offset = round % base.length;
+    const order = [...blockOrder.slice(offset), ...blockOrder.slice(0, offset)];
+    order.forEach((variant, position) => schedule.push({ position, round, variant }));
+  }
+
+  return schedule;
+}

--- a/benchmark/src/server.mjs
+++ b/benchmark/src/server.mjs
@@ -1,0 +1,166 @@
+import { createServer } from 'node:http';
+
+const FIXTURE_STYLE = `
+#benchmark-core {
+  --benchmark-style-ready: 1;
+  box-sizing: border-box;
+  display: block;
+  min-height: 240px;
+  width: 640px;
+  padding: 16px;
+  color: rgb(17, 34, 51);
+  background: rgb(245, 247, 250);
+}
+
+#benchmark-core .benchmark-row {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 8px;
+  min-height: 20px;
+}
+`.trim();
+
+const ENTRY = `
+(function (global) {
+  function mountedRoot() {
+    var core = document.querySelector('#benchmark-core');
+    if (core) core.setAttribute('data-mounted', 'true');
+  }
+
+  function unmount() {
+    var core = document.querySelector('#benchmark-core');
+    if (core) core.setAttribute('data-mounted', 'false');
+    return Promise.resolve();
+  }
+
+  global['benchmark-app'] = {
+    bootstrap: function () { return Promise.resolve(); },
+    mount: function () { mountedRoot(); return Promise.resolve(); },
+    unmount: unmount,
+  };
+  global.__WUJIE_MOUNT = mountedRoot;
+  global.__WUJIE_UNMOUNT = unmount;
+})(window);
+`.trim();
+
+const HTML_CHUNKS = [
+  `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>benchmark-app</title>
+    <link rel="stylesheet" href="./style.css">
+  </head>
+  <body>
+    <main id="benchmark-root"></main>`,
+  `<script>
+      (function () {
+        var root = document.querySelector('#benchmark-root');
+        var rows = '';
+        for (var index = 0; index < 100; index++) {
+          rows += '<div class="benchmark-row"><b>' + index + '</b><span>deterministic benchmark row</span></div>';
+        }
+        root.innerHTML = '<section id="benchmark-core" data-mounted="false"><h1>micro app core</h1>' + rows + '</section>';
+      })();
+    </script>`,
+  `<script src="./entry.js" entry></script>
+  </body>
+</html>`,
+];
+
+const FULL_HTML = HTML_CHUNKS.join('');
+
+function setSharedHeaders(response) {
+  response.setHeader('Access-Control-Allow-Origin', '*');
+  response.setHeader('Cache-Control', 'no-store');
+}
+
+function sendText(response, statusCode, contentType, body) {
+  setSharedHeaders(response);
+  response.writeHead(statusCode, {
+    'Content-Length': Buffer.byteLength(body),
+    'Content-Type': contentType,
+  });
+  response.end(body);
+}
+
+function listen(server, port, host) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+}
+
+function close(server) {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+export function createFixtureServer({ chunkIntervalMs = 50, host = '127.0.0.1', port = 7601 } = {}) {
+  let origin;
+  const server = createServer((request, response) => {
+    setSharedHeaders(response);
+    if (request.method === 'OPTIONS') {
+      response.writeHead(204, {
+        'Access-Control-Allow-Headers': '*',
+        'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
+      });
+      response.end();
+      return;
+    }
+
+    const url = new URL(request.url ?? '/', origin ?? `http://${host}:${port}`);
+    if (url.pathname === '/style.css') {
+      sendText(response, 200, 'text/css; charset=utf-8', FIXTURE_STYLE);
+      return;
+    }
+    if (url.pathname === '/entry.js') {
+      sendText(response, 200, 'text/javascript; charset=utf-8', ENTRY);
+      return;
+    }
+    if (url.pathname !== '/app') {
+      sendText(response, 404, 'text/plain; charset=utf-8', 'Not Found');
+      return;
+    }
+
+    const delivery = url.searchParams.get('delivery') ?? 'buffered';
+    if (delivery === 'buffered') {
+      sendText(response, 200, 'text/html; charset=utf-8', FULL_HTML);
+      return;
+    }
+    if (delivery !== 'streamed') {
+      sendText(response, 400, 'text/plain; charset=utf-8', 'Unknown delivery mode');
+      return;
+    }
+
+    response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    response.write(HTML_CHUNKS[0]);
+    const secondTimer = setTimeout(() => response.write(HTML_CHUNKS[1]), chunkIntervalMs);
+    const finalTimer = setTimeout(() => response.end(HTML_CHUNKS[2]), chunkIntervalMs * 2);
+    response.once('close', () => {
+      clearTimeout(secondTimer);
+      clearTimeout(finalTimer);
+    });
+  });
+
+  return {
+    async close() {
+      await close(server);
+    },
+    get origin() {
+      if (!origin) throw new Error('fixture server has not started');
+      return origin;
+    },
+    async start() {
+      await listen(server, port, host);
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('fixture server did not expose a TCP port');
+      origin = `http://${host}:${address.port}`;
+    },
+  };
+}

--- a/benchmark/src/snapshot.mjs
+++ b/benchmark/src/snapshot.mjs
@@ -1,0 +1,89 @@
+import { createHash } from 'node:crypto';
+import { access, cp, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, relative } from 'node:path';
+
+async function listFiles(directory) {
+  const files = [];
+  const entries = await readdir(directory, { withFileTypes: true });
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(path)));
+    } else if (entry.isFile()) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+async function hashDirectory(directory) {
+  const hash = createHash('sha256');
+  for (const file of await listFiles(directory)) {
+    hash.update(relative(directory, file));
+    hash.update('\0');
+    hash.update(await readFile(file));
+    hash.update('\0');
+  }
+  return hash.digest('hex');
+}
+
+async function assertMissing(path) {
+  try {
+    await access(path);
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') return;
+    throw error;
+  }
+  throw new Error(`baseline snapshot already exists: ${path}`);
+}
+
+export async function createBaselineSnapshot({ createdAt, git, sourceDirectory, targetDirectory }) {
+  await assertMissing(targetDirectory);
+  const stagingDirectory = `${targetDirectory}.tmp-${process.pid}`;
+  await assertMissing(stagingDirectory);
+  await mkdir(dirname(targetDirectory), { recursive: true });
+
+  try {
+    await mkdir(stagingDirectory);
+    await cp(sourceDirectory, join(stagingDirectory, 'host'), { recursive: true });
+    const bundleHash = await hashDirectory(join(stagingDirectory, 'host'));
+    const metadata = { bundleHash, createdAt, git, schemaVersion: 1 };
+    await writeFile(join(stagingDirectory, 'metadata.json'), `${JSON.stringify(metadata, null, 2)}\n`);
+    await rename(stagingDirectory, targetDirectory);
+    return metadata;
+  } catch (error) {
+    await rm(stagingDirectory, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+export function assertCleanBaselineGitState(git) {
+  if (git.dirty) throw new Error('baseline snapshot requires a clean git worktree');
+}
+
+function validateMetadata(metadata) {
+  if (
+    !metadata ||
+    typeof metadata !== 'object' ||
+    metadata.schemaVersion !== 1 ||
+    typeof metadata.bundleHash !== 'string' ||
+    !/^[a-f\d]{64}$/u.test(metadata.bundleHash) ||
+    typeof metadata.createdAt !== 'string' ||
+    !metadata.git ||
+    typeof metadata.git !== 'object' ||
+    typeof metadata.git.commit !== 'string' ||
+    typeof metadata.git.dirty !== 'boolean'
+  ) {
+    throw new Error('baseline snapshot metadata is invalid');
+  }
+  return metadata;
+}
+
+export async function readBaselineSnapshot(directory) {
+  const metadata = validateMetadata(JSON.parse(await readFile(join(directory, 'metadata.json'), 'utf8')));
+  const actualHash = await hashDirectory(join(directory, 'host'));
+  if (actualHash !== metadata.bundleHash) {
+    throw new Error(`baseline bundle hash mismatch: expected ${metadata.bundleHash}, received ${actualHash}`);
+  }
+  return metadata;
+}

--- a/benchmark/src/static-server.mjs
+++ b/benchmark/src/static-server.mjs
@@ -1,0 +1,72 @@
+import { readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { extname, join, relative, resolve } from 'node:path';
+
+const CONTENT_TYPES = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+};
+
+function listen(server, port, host) {
+  return new Promise((resolveListening, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => {
+      server.off('error', reject);
+      resolveListening();
+    });
+  });
+}
+
+function close(server) {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolveClosing, reject) => {
+    server.close((error) => (error ? reject(error) : resolveClosing()));
+  });
+}
+
+export function createStaticServer({ host = '127.0.0.1', port = 7600, root }) {
+  const absoluteRoot = resolve(root);
+  let origin;
+  const server = createServer(async (request, response) => {
+    response.setHeader('Cache-Control', 'no-store');
+    const url = new URL(request.url ?? '/', origin ?? `http://${host}:${port}`);
+    const requestedPath = url.pathname === '/' ? '/qiankun.html' : decodeURIComponent(url.pathname);
+    const filePath = resolve(join(absoluteRoot, requestedPath));
+    const relativePath = relative(absoluteRoot, filePath);
+    if (relativePath.startsWith('..') || relativePath === '') {
+      response.writeHead(403);
+      response.end('Forbidden');
+      return;
+    }
+
+    try {
+      const content = await readFile(filePath);
+      response.writeHead(200, {
+        'Content-Length': content.byteLength,
+        'Content-Type': CONTENT_TYPES[extname(filePath)] ?? 'application/octet-stream',
+      });
+      response.end(content);
+    } catch {
+      response.writeHead(404);
+      response.end('Not Found');
+    }
+  });
+
+  return {
+    async close() {
+      await close(server);
+    },
+    get origin() {
+      if (!origin) throw new Error('static server has not started');
+      return origin;
+    },
+    async start() {
+      await listen(server, port, host);
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('static server did not expose a TCP port');
+      origin = `http://${host}:${address.port}`;
+    },
+  };
+}

--- a/benchmark/src/stats.mjs
+++ b/benchmark/src/stats.mjs
@@ -1,0 +1,104 @@
+function validateSamples(samples, { positive = false } = {}) {
+  if (samples.length === 0) throw new Error('at least one sample is required');
+  const valid = samples.every((sample) => Number.isFinite(sample) && (!positive || sample > 0));
+  if (!valid) {
+    throw new Error(positive ? 'samples must be positive finite numbers' : 'samples must be finite numbers');
+  }
+}
+
+function quantileSorted(sorted, probability) {
+  const position = (sorted.length - 1) * probability;
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  if (lower === upper) return sorted[lower];
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
+}
+
+function medianSorted(sorted) {
+  return quantileSorted(sorted, 0.5);
+}
+
+function createSeededRandom(seed) {
+  let value = seed >>> 0;
+  return () => {
+    value += 0x6d2b79f5;
+    let result = value;
+    result = Math.imul(result ^ (result >>> 15), result | 1);
+    result ^= result + Math.imul(result ^ (result >>> 7), result | 61);
+    return ((result ^ (result >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function summarize(samples) {
+  validateSamples(samples);
+  const sorted = [...samples].sort((left, right) => left - right);
+  const count = sorted.length;
+  const mean = sorted.reduce((total, sample) => total + sample, 0) / count;
+  const median = medianSorted(sorted);
+  const absoluteDeviations = sorted.map((sample) => Math.abs(sample - median)).sort((left, right) => left - right);
+  const variance = sorted.reduce((total, sample) => total + (sample - mean) ** 2, 0) / count;
+  const standardDeviation = Math.sqrt(variance);
+
+  return {
+    count,
+    cv: mean === 0 ? null : standardDeviation / mean,
+    mad: medianSorted(absoluteDeviations),
+    mean,
+    median,
+    p75: quantileSorted(sorted, 0.75),
+    p95: quantileSorted(sorted, 0.95),
+    standardDeviation,
+  };
+}
+
+export function comparePairedSamples(reference, candidate, { iterations = 10_000, seed = 20260711 } = {}) {
+  if (reference.length !== candidate.length) throw new Error('paired sample arrays must have the same length');
+  validateSamples(reference, { positive: true });
+  validateSamples(candidate, { positive: true });
+  if (!Number.isInteger(iterations) || iterations <= 0) {
+    throw new Error('bootstrap iterations must be a positive integer');
+  }
+
+  const logRatios = reference.map((sample, index) => Math.log(candidate[index] / sample));
+  const estimate = medianSorted([...logRatios].sort((left, right) => left - right));
+  const random = createSeededRandom(seed);
+  const bootstrap = [];
+
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const resampled = [];
+    for (let index = 0; index < logRatios.length; index += 1) {
+      resampled.push(logRatios[Math.floor(random() * logRatios.length)]);
+    }
+    resampled.sort((left, right) => left - right);
+    bootstrap.push(Math.expm1(medianSorted(resampled)) * 100);
+  }
+  bootstrap.sort((left, right) => left - right);
+
+  return {
+    confidenceInterval95: [quantileSorted(bootstrap, 0.025), quantileSorted(bootstrap, 0.975)],
+    relativeDeltaPercent: Math.expm1(estimate) * 100,
+  };
+}
+
+export function evaluateCalibration(
+  comparison,
+  { maxAbsoluteDeltaPercent = 3, maxIntervalWidthPercentPoints = 10 } = {},
+) {
+  const [lower, upper] = comparison.confidenceInterval95;
+  const width = upper - lower;
+  const failures = [];
+
+  if (Math.abs(comparison.relativeDeltaPercent) > maxAbsoluteDeltaPercent) {
+    failures.push(
+      `absolute median delta ${Math.abs(comparison.relativeDeltaPercent).toFixed(2)}% exceeds ${maxAbsoluteDeltaPercent.toFixed(2)}%`,
+    );
+  }
+  if (lower > 0 || upper < 0) failures.push('95% confidence interval does not include 0%');
+  if (width > maxIntervalWidthPercentPoints) {
+    failures.push(
+      `95% confidence interval width ${width.toFixed(2)}pp exceeds ${maxIntervalWidthPercentPoints.toFixed(2)}pp`,
+    );
+  }
+
+  return { failures, passed: failures.length === 0 };
+}

--- a/benchmark/tests/browser.integration.test.mjs
+++ b/benchmark/tests/browser.integration.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import { chromium } from 'playwright';
+
+import { runBrowserSample } from '../src/browser.mjs';
+import { createFixtureServer } from '../src/server.mjs';
+import { createStaticServer } from '../src/static-server.mjs';
+import { PRODUCT_VARIANTS } from '../scenarios.mjs';
+
+const hostRoot = fileURLToPath(new URL('../fixtures/host/dist', import.meta.url));
+
+test('every benchmark variant reaches a painted core element and a settled app', async () => {
+  const fixture = createFixtureServer({ chunkIntervalMs: 10, port: 0 });
+  const host = createStaticServer({ port: 0, root: hostRoot });
+  await Promise.all([fixture.start(), host.start()]);
+  const browser = await chromium.launch({ headless: true });
+
+  try {
+    for (const variant of PRODUCT_VARIANTS) {
+      const measurement = await runBrowserSample({
+        browser,
+        fixtureOrigin: fixture.origin,
+        hostOrigin: host.origin,
+        timeoutMs: 10_000,
+        variant,
+      });
+      assert.ok(measurement.duration > 0, variant.id);
+      assert.ok(measurement.t1 >= measurement.t0, variant.id);
+      assert.equal(measurement.settled, true, variant.id);
+    }
+  } finally {
+    await browser.close();
+    await Promise.all([fixture.close(), host.close()]);
+  }
+});

--- a/benchmark/tests/browser.test.mjs
+++ b/benchmark/tests/browser.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { runBrowserSample } from '../src/browser.mjs';
+
+const VARIANT = {
+  delivery: 'buffered',
+  framework: 'qiankun',
+  frameworkOptions: {},
+};
+
+test('runBrowserSample times out a hung benchmark and closes its context', { timeout: 1_000 }, async () => {
+  let contextClosed = false;
+  const page = {
+    evaluate: () => new Promise(() => {}),
+    goto: async () => {},
+    on: () => {},
+  };
+  const context = {
+    close: async () => {
+      contextClosed = true;
+    },
+    newPage: async () => page,
+  };
+  const browser = {
+    newContext: async () => context,
+  };
+
+  await assert.rejects(
+    runBrowserSample({
+      browser,
+      fixtureOrigin: 'http://127.0.0.1:7601',
+      hostOrigin: 'http://127.0.0.1:7600',
+      timeoutMs: 10,
+      variant: VARIANT,
+    }),
+    /benchmark sample timed out after 10ms/u,
+  );
+  assert.equal(contextClosed, true);
+});
+
+test('runBrowserSample closes its context when page creation fails', async () => {
+  let contextClosed = false;
+  const browser = {
+    newContext: async () => ({
+      close: async () => {
+        contextClosed = true;
+      },
+      newPage: async () => {
+        throw new Error('page creation failed');
+      },
+    }),
+  };
+
+  await assert.rejects(
+    runBrowserSample({
+      browser,
+      fixtureOrigin: 'http://127.0.0.1:7601',
+      hostOrigin: 'http://127.0.0.1:7600',
+      timeoutMs: 10,
+      variant: VARIANT,
+    }),
+    /page creation failed/u,
+  );
+  assert.equal(contextClosed, true);
+});
+
+test('runBrowserSample rejects HTTP error responses', async () => {
+  const handlers = new Map();
+  const page = {
+    evaluate: async () => {
+      handlers.get('response')?.({
+        status: () => 404,
+        url: () => 'http://127.0.0.1:7601/missing.css',
+      });
+      return { duration: 10, settled: true, t0: 1, t1: 11 };
+    },
+    goto: async () => {},
+    on: (event, handler) => handlers.set(event, handler),
+  };
+  const browser = {
+    newContext: async () => ({
+      close: async () => {},
+      newPage: async () => page,
+    }),
+  };
+
+  await assert.rejects(
+    runBrowserSample({
+      browser,
+      fixtureOrigin: 'http://127.0.0.1:7601',
+      hostOrigin: 'http://127.0.0.1:7600',
+      timeoutMs: 10,
+      variant: VARIANT,
+    }),
+    /response: http:\/\/127\.0\.0\.1:7601\/missing\.css \(404\)/u,
+  );
+});

--- a/benchmark/tests/collect.test.mjs
+++ b/benchmark/tests/collect.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { collectSamples } from '../src/collect.mjs';
+
+test('collectSamples executes variants serially and preserves schedule metadata', async () => {
+  const variants = [{ id: 'a' }, { id: 'b' }];
+  let active = 0;
+  let maximumActive = 0;
+
+  const samples = await collectSamples({
+    rounds: 3,
+    seed: 11,
+    sample: async (variant) => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await Promise.resolve();
+      active -= 1;
+      return { duration: variant.id === 'a' ? 10 : 20, t0: 1, t1: variant.id === 'a' ? 11 : 21 };
+    },
+    variants,
+  });
+
+  assert.equal(maximumActive, 1);
+  assert.equal(samples.length, 6);
+  for (let round = 0; round < 3; round += 1) {
+    const entries = samples.filter((sample) => sample.round === round);
+    assert.deepEqual([...entries.map((sample) => sample.variant)].sort(), ['a', 'b']);
+    assert.deepEqual(entries.map((sample) => sample.position).sort(), [0, 1]);
+    assert.ok(entries.every((sample) => sample.valid));
+  }
+});
+
+test('collectSamples records failures and continues without silently replacing them', async () => {
+  let failed = false;
+  const samples = await collectSamples({
+    rounds: 2,
+    seed: 3,
+    sample: async (variant) => {
+      if (variant.id === 'b' && !failed) {
+        failed = true;
+        throw new Error('page crashed');
+      }
+      return { duration: 10, t0: 1, t1: 11 };
+    },
+    variants: [{ id: 'a' }, { id: 'b' }],
+  });
+
+  assert.equal(samples.length, 4);
+  assert.equal(samples.filter((sample) => sample.valid).length, 3);
+  assert.deepEqual(
+    samples.find((sample) => !sample.valid),
+    {
+      error: 'page crashed',
+      position: 1,
+      round: 0,
+      sequence: 1,
+      valid: false,
+      variant: 'b',
+    },
+  );
+});

--- a/benchmark/tests/options.test.mjs
+++ b/benchmark/tests/options.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { parseRunnerOptions } from '../src/options.mjs';
+
+test('parseRunnerOptions provides the formal smoke defaults', () => {
+  assert.deepEqual(parseRunnerOptions([]), {
+    calibrationGate: true,
+    calibrationSamples: 50,
+    chunkIntervalMs: 50,
+    samples: 100,
+    seed: 20260711,
+    timeoutMs: 10_000,
+    warmup: 5,
+  });
+});
+
+test('parseRunnerOptions accepts explicit check-run overrides', () => {
+  assert.deepEqual(
+    parseRunnerOptions([
+      '--samples=5',
+      '--warmup=2',
+      '--calibration-samples=5',
+      '--calibration-gate=false',
+      '--seed=9',
+      '--chunk-interval=10',
+      '--timeout=2000',
+    ]),
+    {
+      calibrationGate: false,
+      calibrationSamples: 5,
+      chunkIntervalMs: 10,
+      samples: 5,
+      seed: 9,
+      timeoutMs: 2_000,
+      warmup: 2,
+    },
+  );
+});
+
+test('parseRunnerOptions rejects unknown, non-integer, and non-positive values', () => {
+  assert.throws(() => parseRunnerOptions(['--wat=1']), /unknown option/);
+  assert.throws(() => parseRunnerOptions(['--samples=1.5']), /samples must be a positive integer/);
+  assert.throws(() => parseRunnerOptions(['--timeout=0']), /timeout must be a positive integer/);
+  assert.throws(() => parseRunnerOptions(['--calibration-gate=maybe']), /calibration-gate must be true or false/);
+});

--- a/benchmark/tests/options.test.mjs
+++ b/benchmark/tests/options.test.mjs
@@ -5,9 +5,12 @@ import { parseRunnerOptions } from '../src/options.mjs';
 
 test('parseRunnerOptions provides the formal smoke defaults', () => {
   assert.deepEqual(parseRunnerOptions([]), {
+    baselineDir: null,
     calibrationGate: true,
     calibrationSamples: 50,
     chunkIntervalMs: 50,
+    comparisonGate: true,
+    mode: 'framework',
     samples: 100,
     seed: 20260711,
     timeoutMs: 10_000,
@@ -27,13 +30,39 @@ test('parseRunnerOptions accepts explicit check-run overrides', () => {
       '--timeout=2000',
     ]),
     {
+      baselineDir: null,
       calibrationGate: false,
       calibrationSamples: 5,
       chunkIntervalMs: 10,
+      comparisonGate: true,
+      mode: 'framework',
       samples: 5,
       seed: 9,
       timeoutMs: 2_000,
       warmup: 2,
+    },
+  );
+});
+
+test('parseRunnerOptions accepts revision comparison options', () => {
+  assert.deepEqual(
+    parseRunnerOptions([
+      '--mode=revision',
+      '--baseline-dir=artifacts/baseline',
+      '--comparison-gate=false',
+      '--samples=5',
+    ]),
+    {
+      baselineDir: 'artifacts/baseline',
+      calibrationGate: true,
+      calibrationSamples: 50,
+      chunkIntervalMs: 50,
+      comparisonGate: false,
+      mode: 'revision',
+      samples: 5,
+      seed: 20260711,
+      timeoutMs: 10_000,
+      warmup: 5,
     },
   );
 });
@@ -43,4 +72,6 @@ test('parseRunnerOptions rejects unknown, non-integer, and non-positive values',
   assert.throws(() => parseRunnerOptions(['--samples=1.5']), /samples must be a positive integer/);
   assert.throws(() => parseRunnerOptions(['--timeout=0']), /timeout must be a positive integer/);
   assert.throws(() => parseRunnerOptions(['--calibration-gate=maybe']), /calibration-gate must be true or false/);
+  assert.throws(() => parseRunnerOptions(['--mode=revision']), /baseline-dir is required/u);
+  assert.throws(() => parseRunnerOptions(['--mode=unknown']), /mode must be framework or revision/u);
 });

--- a/benchmark/tests/report.test.mjs
+++ b/benchmark/tests/report.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildReport, renderSummaryMarkdown } from '../src/report.mjs';
+
+const variants = [
+  { id: 'a', label: 'Variant A' },
+  { id: 'b', label: 'Variant B' },
+];
+
+const samples = [
+  { duration: 10, position: 0, round: 0, sequence: 0, valid: true, variant: 'a' },
+  { duration: 20, position: 1, round: 0, sequence: 1, valid: true, variant: 'b' },
+  { duration: 30, position: 1, round: 1, sequence: 2, valid: true, variant: 'a' },
+  { duration: 60, position: 0, round: 1, sequence: 3, valid: true, variant: 'b' },
+  { error: 'timeout', position: 0, round: 2, sequence: 4, valid: false, variant: 'a' },
+];
+
+test('buildReport summarizes valid samples while retaining invalid counts', () => {
+  const report = buildReport({
+    comparisons: [{ candidate: 'b', id: 'b-vs-a', label: 'B vs A', reference: 'a' }],
+    samples,
+    seed: 5,
+    variants,
+  });
+
+  assert.equal(report.variants.a.summary.count, 2);
+  assert.equal(report.variants.a.invalidCount, 1);
+  assert.equal(report.variants.b.summary.count, 2);
+  assert.ok(Math.abs(report.comparisons['b-vs-a'].relativeDeltaPercent - 100) < 1e-10);
+});
+
+test('renderSummaryMarkdown exposes counts, medians, and comparison confidence intervals', () => {
+  const report = buildReport({
+    comparisons: [{ candidate: 'b', id: 'b-vs-a', label: 'B vs A', reference: 'a' }],
+    samples,
+    seed: 5,
+    variants,
+  });
+  const markdown = renderSummaryMarkdown(report, { title: 'Smoke result' });
+
+  assert.match(markdown, /# Smoke result/);
+  assert.match(markdown, /Variant A \| 2 \| 1 \| 20\.00/);
+  assert.match(markdown, /B vs A \| \+100\.00%/);
+});
+
+test('renderSummaryMarkdown can nest a report without flattening its sections', () => {
+  const report = buildReport({
+    comparisons: [{ candidate: 'b', id: 'b-vs-a', label: 'B vs A', reference: 'a' }],
+    samples,
+    seed: 5,
+    variants,
+  });
+  const markdown = renderSummaryMarkdown(report, { headingLevel: 2, title: 'Nested result' });
+
+  assert.match(markdown, /^## Nested result$/mu);
+  assert.match(markdown, /^### Variants$/mu);
+  assert.match(markdown, /^### Comparisons$/mu);
+});

--- a/benchmark/tests/revisions.test.mjs
+++ b/benchmark/tests/revisions.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test('evaluateRevisionComparison requires the confidence interval upper bound below zero', async () => {
+  const { evaluateRevisionComparison } = await import('../src/revisions.mjs');
+
+  assert.deepEqual(evaluateRevisionComparison({ confidenceInterval95: [-12, -3], relativeDeltaPercent: -7 }), {
+    failures: [],
+    passed: true,
+  });
+  assert.deepEqual(evaluateRevisionComparison({ confidenceInterval95: [-4, 0.5], relativeDeltaPercent: -2 }), {
+    failures: ['95% confidence interval upper bound +0.50% is not below 0%'],
+    passed: false,
+  });
+});
+
+test('resolveVariantHostOrigin selects the revision host and fails on missing roles', async () => {
+  const { resolveVariantHostOrigin } = await import('../src/revisions.mjs');
+  const hostOrigins = { baseline: 'http://baseline', candidate: 'http://candidate' };
+
+  assert.equal(resolveVariantHostOrigin({}, hostOrigins), 'http://candidate');
+  assert.equal(resolveVariantHostOrigin({ hostRole: 'baseline' }, hostOrigins), 'http://baseline');
+  assert.throws(
+    () => resolveVariantHostOrigin({ hostRole: 'missing' }, hostOrigins),
+    /host origin is unavailable for role: missing/u,
+  );
+});

--- a/benchmark/tests/scenarios.test.mjs
+++ b/benchmark/tests/scenarios.test.mjs
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { CALIBRATION_VARIANTS, PRODUCT_VARIANTS, PRODUCT_COMPARISONS } from '../scenarios.mjs';
+import * as scenarios from '../scenarios.mjs';
+
+const { CALIBRATION_VARIANTS, PRODUCT_COMPARISONS, PRODUCT_VARIANTS } = scenarios;
 
 test('the product matrix contains six explicit variants instead of a cartesian product', () => {
   assert.deepEqual(
@@ -43,5 +45,48 @@ test('A/A calibration aliases the exact same qiankun variant', () => {
   assert.deepEqual(
     CALIBRATION_VARIANTS.map(({ sourceVariant }) => sourceVariant),
     ['qk-full-isolation', 'qk-full-isolation'],
+  );
+});
+
+test('revision comparison variants differ only by revision host role', () => {
+  const { REVISION_CALIBRATION_VARIANTS, REVISION_COMPARISONS, REVISION_VARIANTS } = scenarios;
+
+  assert.deepEqual(
+    REVISION_VARIANTS.map(({ hostRole, id }) => ({ hostRole, id })),
+    [
+      { hostRole: 'baseline', id: 'revision-baseline' },
+      { hostRole: 'candidate', id: 'revision-candidate' },
+    ],
+  );
+  assert.deepEqual(
+    REVISION_VARIANTS.map(({ delivery, framework, frameworkOptions }) => ({
+      delivery,
+      framework,
+      frameworkOptions,
+    })),
+    [
+      {
+        delivery: 'streamed',
+        framework: 'qiankun',
+        frameworkOptions: { sandbox: true, styleIsolation: true },
+      },
+      {
+        delivery: 'streamed',
+        framework: 'qiankun',
+        frameworkOptions: { sandbox: true, styleIsolation: true },
+      },
+    ],
+  );
+  assert.deepEqual(REVISION_COMPARISONS, [
+    {
+      candidate: 'revision-candidate',
+      id: 'candidate-vs-baseline',
+      label: 'candidate vs baseline',
+      reference: 'revision-baseline',
+    },
+  ]);
+  assert.deepEqual(
+    REVISION_CALIBRATION_VARIANTS.map(({ sourceVariant }) => sourceVariant),
+    ['revision-candidate', 'revision-candidate'],
   );
 });

--- a/benchmark/tests/scenarios.test.mjs
+++ b/benchmark/tests/scenarios.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { CALIBRATION_VARIANTS, PRODUCT_VARIANTS, PRODUCT_COMPARISONS } from '../scenarios.mjs';
+
+test('the product matrix contains six explicit variants instead of a cartesian product', () => {
+  assert.deepEqual(
+    PRODUCT_VARIANTS.map((variant) => variant.id),
+    ['qk-no-isolation', 'qk-sandbox', 'qk-full-isolation', 'wujie-isolated', 'qk-streamed', 'wujie-streamed'],
+  );
+});
+
+test('qiankun variants isolate sandbox and style costs one feature at a time', () => {
+  const noIsolation = PRODUCT_VARIANTS[0];
+  const sandbox = PRODUCT_VARIANTS[1];
+  const fullIsolation = PRODUCT_VARIANTS[2];
+
+  assert.deepEqual(noIsolation.frameworkOptions, { sandbox: false, styleIsolation: false });
+  assert.deepEqual(sandbox.frameworkOptions, { sandbox: true, styleIsolation: false });
+  assert.deepEqual(fullIsolation.frameworkOptions, { sandbox: true, styleIsolation: true });
+});
+
+test('wujie variants use its fastest cold-load isolated configuration', () => {
+  for (const variant of PRODUCT_VARIANTS.filter(({ framework }) => framework === 'wujie')) {
+    assert.deepEqual(variant.frameworkOptions, {
+      alive: false,
+      degrade: false,
+      fiber: false,
+      sync: false,
+    });
+  }
+});
+
+test('the matrix defines the four comparisons used to diagnose optimization directions', () => {
+  assert.deepEqual(
+    PRODUCT_COMPARISONS.map((comparison) => comparison.id),
+    ['sandbox-cost', 'style-isolation-cost', 'isolated-framework', 'streaming-framework'],
+  );
+});
+
+test('A/A calibration aliases the exact same qiankun variant', () => {
+  assert.equal(CALIBRATION_VARIANTS.length, 2);
+  assert.deepEqual(
+    CALIBRATION_VARIANTS.map(({ sourceVariant }) => sourceVariant),
+    ['qk-full-isolation', 'qk-full-isolation'],
+  );
+});

--- a/benchmark/tests/schedule.test.mjs
+++ b/benchmark/tests/schedule.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createBalancedSchedule } from '../src/schedule.mjs';
+
+const VARIANTS = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+test('createBalancedSchedule is deterministic for the same seed', () => {
+  const first = createBalancedSchedule(VARIANTS, 12, 20260711);
+  const second = createBalancedSchedule(VARIANTS, 12, 20260711);
+
+  assert.deepEqual(first, second);
+});
+
+test('createBalancedSchedule runs every variant once per round', () => {
+  const schedule = createBalancedSchedule(VARIANTS, 12, 20260711);
+
+  for (let round = 0; round < 12; round += 1) {
+    const entries = schedule.filter((entry) => entry.round === round);
+    assert.equal(entries.length, VARIANTS.length);
+    assert.deepEqual(
+      entries.map((entry) => entry.position),
+      [0, 1, 2, 3, 4, 5],
+    );
+    assert.deepEqual([...entries.map((entry) => entry.variant)].sort(), [...VARIANTS].sort());
+  }
+});
+
+test('createBalancedSchedule balances each variant across positions', () => {
+  const schedule = createBalancedSchedule(VARIANTS, 12, 20260711);
+
+  for (const variant of VARIANTS) {
+    const counts = Array.from({ length: VARIANTS.length }, () => 0);
+    for (const entry of schedule.filter((candidate) => candidate.variant === variant)) {
+      counts[entry.position] += 1;
+    }
+    assert.deepEqual(counts, [2, 2, 2, 2, 2, 2]);
+  }
+});
+
+test('createBalancedSchedule rejects ambiguous or empty inputs', () => {
+  assert.throws(() => createBalancedSchedule([], 1, 1), /at least one variant/);
+  assert.throws(() => createBalancedSchedule(['a', 'a'], 1, 1), /variant ids must be unique/);
+  assert.throws(() => createBalancedSchedule(['a'], 0, 1), /rounds must be a positive integer/);
+});

--- a/benchmark/tests/server.test.mjs
+++ b/benchmark/tests/server.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import test from 'node:test';
+
+import { createFixtureServer } from '../src/server.mjs';
+
+function request(url) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    const arrivals = [];
+    const requestStartedAt = performance.now();
+    const req = http.get(url, (response) => {
+      response.on('data', (chunk) => {
+        chunks.push(chunk);
+        arrivals.push(performance.now() - requestStartedAt);
+      });
+      response.on('end', () => {
+        resolve({
+          arrivals,
+          body: Buffer.concat(chunks).toString('utf8'),
+          headers: response.headers,
+          statusCode: response.statusCode,
+        });
+      });
+    });
+    req.on('error', reject);
+  });
+}
+
+test('streamed and buffered HTML produce identical bytes with observable chunk gaps', async () => {
+  const fixture = createFixtureServer({ chunkIntervalMs: 20, port: 0 });
+  await fixture.start();
+
+  try {
+    const buffered = await request(`${fixture.origin}/app?delivery=buffered`);
+    const streamed = await request(`${fixture.origin}/app?delivery=streamed`);
+
+    assert.equal(buffered.statusCode, 200);
+    assert.equal(streamed.statusCode, 200);
+    assert.equal(streamed.body, buffered.body);
+    assert.ok(streamed.arrivals.length >= 3);
+    assert.ok(streamed.arrivals.at(-1) - streamed.arrivals[0] >= 30);
+    assert.equal(streamed.headers['access-control-allow-origin'], '*');
+    assert.equal(streamed.headers['cache-control'], 'no-store');
+  } finally {
+    await fixture.close();
+  }
+});
+
+test('fixture assets are deterministic and missing paths return 404', async () => {
+  const fixture = createFixtureServer({ chunkIntervalMs: 1, port: 0 });
+  await fixture.start();
+
+  try {
+    const style = await request(`${fixture.origin}/style.css`);
+    const entry = await request(`${fixture.origin}/entry.js`);
+    const missing = await request(`${fixture.origin}/missing.js`);
+
+    assert.equal(style.statusCode, 200);
+    assert.match(style.body, /--benchmark-style-ready:\s*1/);
+    assert.equal(entry.statusCode, 200);
+    assert.match(entry.body, /__WUJIE_MOUNT/);
+    assert.equal(missing.statusCode, 404);
+  } finally {
+    await fixture.close();
+  }
+});

--- a/benchmark/tests/snapshot.test.mjs
+++ b/benchmark/tests/snapshot.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+test('createBaselineSnapshot copies a complete host bundle and records reproducibility metadata', async (t) => {
+  const { createBaselineSnapshot, readBaselineSnapshot } = await import('../src/snapshot.mjs');
+  const root = await mkdtemp(join(tmpdir(), 'qiankun-benchmark-snapshot-'));
+  t.after(() => rm(root, { force: true, recursive: true }));
+  const sourceDirectory = join(root, 'dist');
+  const targetDirectory = join(root, 'artifacts', 'baseline');
+  await mkdir(join(sourceDirectory, 'assets'), { recursive: true });
+  await writeFile(join(sourceDirectory, 'qiankun.html'), '<script src="./assets/app.js"></script>');
+  await writeFile(join(sourceDirectory, 'assets/app.js'), 'console.log("baseline");');
+
+  const created = await createBaselineSnapshot({
+    createdAt: '2026-07-11T00:00:00.000Z',
+    git: { commit: 'abc123', dirty: false },
+    sourceDirectory,
+    targetDirectory,
+  });
+
+  assert.equal(
+    await readFile(join(targetDirectory, 'host/qiankun.html'), 'utf8'),
+    '<script src="./assets/app.js"></script>',
+  );
+  assert.match(created.bundleHash, /^[a-f\d]{64}$/u);
+  assert.deepEqual(await readBaselineSnapshot(targetDirectory), created);
+  await assert.rejects(
+    createBaselineSnapshot({
+      createdAt: '2026-07-11T00:00:00.000Z',
+      git: { commit: 'abc123', dirty: false },
+      sourceDirectory,
+      targetDirectory,
+    }),
+    /already exists/u,
+  );
+
+  await writeFile(join(targetDirectory, 'host/assets/app.js'), 'console.log("tampered");');
+  await assert.rejects(readBaselineSnapshot(targetDirectory), /baseline bundle hash mismatch/u);
+});
+
+test('assertCleanBaselineGitState rejects dirty snapshots', async () => {
+  const { assertCleanBaselineGitState } = await import('../src/snapshot.mjs');
+
+  assert.doesNotThrow(() => assertCleanBaselineGitState({ commit: 'abc123', dirty: false }));
+  assert.throws(
+    () => assertCleanBaselineGitState({ commit: 'abc123', dirty: true }),
+    /baseline snapshot requires a clean git worktree/u,
+  );
+});

--- a/benchmark/tests/stats.test.mjs
+++ b/benchmark/tests/stats.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { comparePairedSamples, evaluateCalibration, summarize } from '../src/stats.mjs';
+
+test('summarize reports robust and tail statistics without removing samples', () => {
+  const summary = summarize([1, 2, 3, 4, 5]);
+
+  assert.equal(summary.count, 5);
+  assert.equal(summary.mean, 3);
+  assert.equal(summary.median, 3);
+  assert.equal(summary.p75, 4);
+  assert.equal(summary.p95, 4.8);
+  assert.equal(summary.mad, 1);
+  assert.ok(Math.abs(summary.standardDeviation - Math.sqrt(2)) < 1e-12);
+  assert.ok(Math.abs(summary.cv - Math.sqrt(2) / 3) < 1e-12);
+});
+
+test('comparePairedSamples returns an exact zero interval for identical samples', () => {
+  const comparison = comparePairedSamples([10, 20, 30, 40], [10, 20, 30, 40], {
+    iterations: 500,
+    seed: 7,
+  });
+
+  assert.equal(comparison.relativeDeltaPercent, 0);
+  assert.deepEqual(comparison.confidenceInterval95, [0, 0]);
+});
+
+test('comparePairedSamples reports a deterministic 100 percent regression', () => {
+  const comparison = comparePairedSamples([10, 20, 30, 40], [20, 40, 60, 80], {
+    iterations: 500,
+    seed: 7,
+  });
+
+  assert.ok(Math.abs(comparison.relativeDeltaPercent - 100) < 1e-10);
+  assert.ok(Math.abs(comparison.confidenceInterval95[0] - 100) < 1e-10);
+  assert.ok(Math.abs(comparison.confidenceInterval95[1] - 100) < 1e-10);
+});
+
+test('evaluateCalibration enforces delta, zero coverage, and interval width', () => {
+  assert.deepEqual(evaluateCalibration({ relativeDeltaPercent: 1, confidenceInterval95: [-2, 3] }), {
+    passed: true,
+    failures: [],
+  });
+
+  assert.deepEqual(evaluateCalibration({ relativeDeltaPercent: 4, confidenceInterval95: [1, 12] }), {
+    passed: false,
+    failures: [
+      'absolute median delta 4.00% exceeds 3.00%',
+      '95% confidence interval does not include 0%',
+      '95% confidence interval width 11.00pp exceeds 10.00pp',
+    ],
+  });
+});
+
+test('statistics reject missing, mismatched, and non-positive samples', () => {
+  assert.throws(() => summarize([]), /at least one sample/);
+  assert.throws(() => comparePairedSamples([1], [1, 2], { iterations: 10, seed: 1 }), /same length/);
+  assert.throws(() => comparePairedSamples([0], [1], { iterations: 10, seed: 1 }), /positive finite numbers/);
+});

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "noEmit": true,
+    "paths": {},
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["fixtures/host/src/**/*.ts", "fixtures/host/vite.config.ts"]
+}

--- a/e2e/fixtures/sub-classic/bodyless.html
+++ b/e2e/fixtures/sub-classic/bodyless.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>sub-classic-bodyless</title>
+    <style data-testid="bodyless-static-style">
+      .bodyless-static-target {
+        color: rgb(11, 12, 13);
+      }
+    </style>
+  </head>
+
+  <!-- Intentionally no explicit <body>: WritableDOM parses this content as an entry fragment. -->
+  <main id="bodyless-root">
+    <p class="bodyless-static-target" data-testid="bodyless-static-target">static head style</p>
+    <p class="bodyless-dynamic-head-target" data-testid="bodyless-dynamic-head-target">dynamic document.head style</p>
+    <p class="bodyless-dynamic-body-target" data-testid="bodyless-dynamic-body-target">dynamic document.body style</p>
+  </main>
+  <script src="./entry-bodyless.js" entry></script>
+</html>

--- a/e2e/fixtures/sub-classic/entry-bodyless.js
+++ b/e2e/fixtures/sub-classic/entry-bodyless.js
@@ -1,0 +1,36 @@
+(function (global) {
+  var stylesInjected = false;
+
+  function appendStyle(targetElement, testId, cssText) {
+    var style = document.createElement('style');
+    style.setAttribute('data-testid', testId);
+    style.textContent = cssText;
+    targetElement.appendChild(style);
+  }
+
+  global['sub-classic-bodyless'] = {
+    bootstrap: function () {
+      return Promise.resolve();
+    },
+    mount: function () {
+      if (!stylesInjected) {
+        appendStyle(
+          document.head,
+          'bodyless-dynamic-head-style',
+          '.bodyless-dynamic-head-target { color: rgb(21, 22, 23) }',
+        );
+        appendStyle(
+          document.body,
+          'bodyless-dynamic-body-style',
+          '.bodyless-dynamic-body-target { color: rgb(31, 32, 33) }',
+        );
+        stylesInjected = true;
+      }
+
+      return Promise.resolve();
+    },
+    unmount: function () {
+      return Promise.resolve();
+    },
+  };
+})(window);

--- a/e2e/ports.ts
+++ b/e2e/ports.ts
@@ -12,6 +12,8 @@ export const SUB_APP_ENTRIES = {
   'sub-classic': `http://localhost:${PORTS['sub-classic']}`,
   // same server, dedicated pages exercising classic script streaming semantics
   'sub-classic-multiscript': `http://localhost:${PORTS['sub-classic']}/multiscript.html`,
+  // explicit <head>, intentionally no <body>: exercises the fragment parsing + sandbox body facade
+  'sub-classic-bodyless': `http://localhost:${PORTS['sub-classic']}/bodyless.html`,
   'sub-classic-broken-asset': `http://localhost:${PORTS['sub-classic']}/broken-asset.html`,
   'sub-esm': `http://localhost:${PORTS['sub-esm']}`,
   // same server, dedicated page whose HTML carries a <link rel="modulepreload">

--- a/e2e/tests/style-isolation.spec.ts
+++ b/e2e/tests/style-isolation.spec.ts
@@ -29,6 +29,42 @@ test.describe('runtime style isolation (@scope)', () => {
     await expect(page.locator('#main-title')).toHaveCSS('color', BLUE);
   });
 
+  test('a body-less entry keeps static and dynamically appended styles in the app container', async ({ page }) => {
+    const STATIC = 'rgb(11, 12, 13)';
+    const DYNAMIC_HEAD = 'rgb(21, 22, 23)';
+    const DYNAMIC_BODY = 'rgb(31, 32, 33)';
+
+    await loadApp(page, 'sub-classic-bodyless', { sandbox: true, styleIsolation: true });
+
+    const container = page.locator('[data-name="sub-classic-bodyless"]');
+    const virtualHead = container.locator(':scope > qiankun-head');
+
+    // WritableDOM accepts a source entry without an explicit <body>; the sandbox exposes the app
+    // container itself as document.body rather than inserting a body element into the live DOM.
+    await expect(container.locator('body')).toHaveCount(0);
+    await expect(virtualHead).toHaveCount(1);
+
+    const staticStyle = virtualHead.locator(':scope > style[data-testid="bodyless-static-style"]');
+    const dynamicHeadStyle = virtualHead.locator(':scope > style[data-testid="bodyless-dynamic-head-style"]');
+    const dynamicBodyStyle = container.locator(':scope > style[data-testid="bodyless-dynamic-body-style"]');
+
+    // Static head content and document.head insertions stay in the virtual head; document.body
+    // insertions land directly in the app container. All three still pass through @scope isolation.
+    await expect(staticStyle).toHaveCount(1);
+    await expect(dynamicHeadStyle).toHaveCount(1);
+    await expect(dynamicBodyStyle).toHaveCount(1);
+    const scopedStyles = await Promise.all(
+      [staticStyle, dynamicHeadStyle, dynamicBodyStyle].map((style) =>
+        style.evaluate((element) => (element.textContent ?? '').trim().startsWith('@scope')),
+      ),
+    );
+    expect(scopedStyles).toEqual([true, true, true]);
+
+    await expect(page.getByTestId('bodyless-static-target')).toHaveCSS('color', STATIC);
+    await expect(page.getByTestId('bodyless-dynamic-head-target')).toHaveCSS('color', DYNAMIC_HEAD);
+    await expect(page.getByTestId('bodyless-dynamic-body-target')).toHaveCSS('color', DYNAMIC_BODY);
+  });
+
   test('a fragment-wrapped innerHTML style (jQuery-style injection) is scoped too', async ({ page }) => {
     const INJECTED = 'rgb(1, 2, 3)';
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   },
   "scripts": {
     "start:example": "pnpm run build:packages && pnpm --parallel --filter './examples/*' run dev",
+    "benchmark:check": "pnpm run build:packages && pnpm --filter @qiankunjs/benchmark run run:check",
+    "benchmark:smoke": "pnpm run build:packages && pnpm --filter @qiankunjs/benchmark run smoke",
     "build": "pnpm -r run build",
     "build:packages": "pnpm --filter './packages/**' run build",
     "prerelease:alpha": "changeset pre enter alpha && changeset && changeset version",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   },
   "scripts": {
     "start:example": "pnpm run build:packages && pnpm --parallel --filter './examples/*' run dev",
+    "benchmark:baseline": "pnpm run build:packages && pnpm --filter @qiankunjs/benchmark run snapshot:baseline",
     "benchmark:check": "pnpm run build:packages && pnpm --filter @qiankunjs/benchmark run run:check",
+    "benchmark:compare": "pnpm run build:packages && pnpm --filter @qiankunjs/benchmark run compare",
+    "benchmark:compare:check": "pnpm run build:packages && pnpm --filter @qiankunjs/benchmark run compare:check",
     "benchmark:smoke": "pnpm run build:packages && pnpm --filter @qiankunjs/benchmark run smoke",
     "build": "pnpm -r run build",
     "build:packages": "pnpm --filter './packages/**' run build",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -12,7 +12,8 @@
   "sideEffects": false,
   "scripts": {
     "build": "father build",
-    "bench": "npm run build && tachometer ./benchmarks/parser/tern/import-html-entry.html ./benchmarks/parser/tern/parser.html --timeout=1"
+    "bench": "npm run build && tachometer ./benchmarks/parser/tern/import-html-entry.html ./benchmarks/parser/tern/parser.html --timeout=1",
+    "test": "vitest --run"
   },
   "author": "Kuitos",
   "license": "MIT",

--- a/packages/loader/src/TagTransformStream.ts
+++ b/packages/loader/src/TagTransformStream.ts
@@ -1,7 +1,7 @@
 type TagReplacement = {
-  // start tag
+  // literal tag pattern
   tag: string;
-  // start tag replacement
+  // replacement text
   alt: string;
 };
 
@@ -16,6 +16,12 @@ type TransformedBuffer = {
   remainingReplacements: TagReplacement[];
 };
 
+/**
+ * Finds the longest suffix that is also a prefix of an unconsumed tag pattern.
+ * That suffix may be the start of a tag split across chunks; every earlier byte
+ * is safe to emit. The length bound retains no more than the longest possible
+ * incomplete pattern; complete matches have already been consumed by the caller.
+ */
 function findPendingPrefixLength(input: string, replacements: TagReplacement[]): number {
   const maximumLength = Math.min(
     input.length,
@@ -34,6 +40,9 @@ function validateReplacements(replacements: TagReplacement[]): void {
     throw new Error('tag replacement patterns must not be empty');
   }
 
+  // If one pattern contains another, the shorter pattern may become complete
+  // before the longer one across a chunk boundary. The selected replacement would
+  // then depend on chunking, so containment (including duplicates) is unsupported.
   replacements.forEach((replacement, index) => {
     for (let otherIndex = index + 1; otherIndex < replacements.length; otherIndex += 1) {
       const otherTag = replacements[otherIndex].tag;
@@ -44,6 +53,19 @@ function validateReplacements(replacements: TagReplacement[]): void {
   });
 }
 
+/**
+ * Transforms every byte that is safe to emit without waiting for the next chunk.
+ *
+ * Each configured structural tag is replaced at most once. After a match, its
+ * replacement is removed so identical text appearing later in scripts, templates,
+ * or content is left untouched. This is a literal matcher rather than an HTML
+ * parser; that protection applies after the structural occurrence consumes its
+ * rule. Of the unmatched tail, only a suffix that could be the prefix of a remaining
+ * tag is kept pending across chunks.
+ *
+ * At EOF, complete remaining tags are still replaced, but no suffix is kept pending:
+ * an incomplete tag prefix can no longer be completed and is emitted unchanged.
+ */
 function transformAvailable(input: string, replacements: TagReplacement[], finalChunk: boolean): TransformedBuffer {
   const remainingReplacements = [...replacements];
   let cursor = 0;
@@ -52,6 +74,7 @@ function transformAvailable(input: string, replacements: TagReplacement[], final
   while (cursor < input.length) {
     let nextIndex = -1;
     let nextReplacementIndex = -1;
+    // Process the earliest remaining tag first so replacements preserve document order.
     remainingReplacements.forEach((replacement, replacementIndex) => {
       const index = input.indexOf(replacement.tag, cursor);
       if (index !== -1 && (nextIndex === -1 || index < nextIndex)) {
@@ -61,12 +84,15 @@ function transformAvailable(input: string, replacements: TagReplacement[], final
     });
     if (nextReplacementIndex === -1) break;
 
+    // Consume the rule so later duplicate tags or raw-text literals are not rewritten.
     const [nextReplacement] = remainingReplacements.splice(nextReplacementIndex, 1);
     output += input.slice(cursor, nextIndex) + nextReplacement.alt;
     cursor = nextIndex + nextReplacement.tag.length;
   }
 
   const tail = input.slice(cursor);
+  // Keep the longest suffix that could prefix an unconsumed tag, such as "<he"
+  // followed by "ad>" in the next chunk. Everything before it is safe to emit.
   const pendingLength = finalChunk ? 0 : findPendingPrefixLength(tail, remainingReplacements);
   const readyLength = tail.length - pendingLength;
   return {
@@ -76,6 +102,20 @@ function transformAvailable(input: string, replacements: TagReplacement[], final
   };
 }
 
+/**
+ * Creates a streaming structural-tag rewriter.
+ *
+ * The previous implementation used output equality to decide whether buffered
+ * HTML could be emitted. Once the document tags had been replaced, ordinary body
+ * chunks no longer changed and were retained until EOF, effectively turning the
+ * rest of a streaming response into a buffered one. A real match was also mistaken
+ * for "no match" when its replacement text was identical to the original tag.
+ *
+ * The normal loader path now emits safe HTML incrementally and carries only a
+ * possible split-tag suffix into the next transform. Auto-completion deliberately
+ * keeps the legacy tail-buffering behavior because it must inspect unmatched bytes
+ * at EOF before synthesizing a missing wrapper.
+ */
 export function createTagTransformStream(
   tagReplacements: TagReplacement[],
   autoCompleteTags: AutoCompleteTags,
@@ -90,8 +130,9 @@ export function createTagTransformStream(
         transform(chunk: string, controller: TransformStreamDefaultController<string>) {
           buffer += chunk;
 
-          // Auto-completion needs the legacy whole-buffer view to decide whether a missing wrapper
-          // must be synthesized at EOF. The loader's normal path does not enable this mode.
+          // Preserve legacy auto-completion semantics: a match may emit and clear the
+          // buffer, but the unmatched tail since that match stays buffered for the EOF
+          // wrapper check. The loader's regular path disables this mode.
           if (usesLegacyAutoCompletion) {
             const data = replacements.reduce(
               (acc, replacement) => acc.replace(replacement.tag, replacement.alt),

--- a/packages/loader/src/TagTransformStream.ts
+++ b/packages/loader/src/TagTransformStream.ts
@@ -10,40 +10,119 @@ type AutoCompleteTags = {
   body?: boolean;
 };
 
+type TransformedBuffer = {
+  output: string;
+  pending: string;
+  remainingReplacements: TagReplacement[];
+};
+
+function findPendingPrefixLength(input: string, replacements: TagReplacement[]): number {
+  const maximumLength = Math.min(
+    input.length,
+    replacements.reduce((length, replacement) => Math.max(length, replacement.tag.length - 1), 0),
+  );
+
+  for (let length = maximumLength; length > 0; length -= 1) {
+    const suffix = input.slice(-length);
+    if (replacements.some((replacement) => replacement.tag.startsWith(suffix))) return length;
+  }
+  return 0;
+}
+
+function validateReplacements(replacements: TagReplacement[]): void {
+  if (replacements.some((replacement) => !replacement.tag)) {
+    throw new Error('tag replacement patterns must not be empty');
+  }
+
+  replacements.forEach((replacement, index) => {
+    for (let otherIndex = index + 1; otherIndex < replacements.length; otherIndex += 1) {
+      const otherTag = replacements[otherIndex].tag;
+      if (replacement.tag.includes(otherTag) || otherTag.includes(replacement.tag)) {
+        throw new Error('tag replacement patterns must not contain one another');
+      }
+    }
+  });
+}
+
+function transformAvailable(input: string, replacements: TagReplacement[], finalChunk: boolean): TransformedBuffer {
+  const remainingReplacements = [...replacements];
+  let cursor = 0;
+  let output = '';
+
+  while (cursor < input.length) {
+    let nextIndex = -1;
+    let nextReplacementIndex = -1;
+    remainingReplacements.forEach((replacement, replacementIndex) => {
+      const index = input.indexOf(replacement.tag, cursor);
+      if (index !== -1 && (nextIndex === -1 || index < nextIndex)) {
+        nextIndex = index;
+        nextReplacementIndex = replacementIndex;
+      }
+    });
+    if (nextReplacementIndex === -1) break;
+
+    const [nextReplacement] = remainingReplacements.splice(nextReplacementIndex, 1);
+    output += input.slice(cursor, nextIndex) + nextReplacement.alt;
+    cursor = nextIndex + nextReplacement.tag.length;
+  }
+
+  const tail = input.slice(cursor);
+  const pendingLength = finalChunk ? 0 : findPendingPrefixLength(tail, remainingReplacements);
+  const readyLength = tail.length - pendingLength;
+  return {
+    output: output + tail.slice(0, readyLength),
+    pending: tail.slice(readyLength),
+    remainingReplacements,
+  };
+}
+
 export function createTagTransformStream(
   tagReplacements: TagReplacement[],
   autoCompleteTags: AutoCompleteTags,
 ): TransformStream<string, string> {
+  validateReplacements(tagReplacements);
   class TagTransformStream extends TransformStream {
-    constructor(trs: TagReplacement[], acts: AutoCompleteTags) {
+    constructor(replacements: TagReplacement[], completion: AutoCompleteTags) {
       let buffer = '';
+      let remainingReplacements = [...replacements];
+      const usesLegacyAutoCompletion = completion.body || completion.head;
       super({
-        async transform(chunk: string, controller: TransformStreamDefaultController<string>) {
+        transform(chunk: string, controller: TransformStreamDefaultController<string>) {
           buffer += chunk;
 
-          const data = trs.reduce((acc, replacement) => acc.replace(replacement.tag, replacement.alt), buffer);
-
-          // while buffer is equal to data, it means that the data has not been replaced, and the data will be written to the buffer for checking next time
-          if (buffer === data) {
+          // Auto-completion needs the legacy whole-buffer view to decide whether a missing wrapper
+          // must be synthesized at EOF. The loader's normal path does not enable this mode.
+          if (usesLegacyAutoCompletion) {
+            const data = replacements.reduce(
+              (acc, replacement) => acc.replace(replacement.tag, replacement.alt),
+              buffer,
+            );
+            if (buffer === data) return;
+            controller.enqueue(data);
+            buffer = '';
             return;
           }
 
-          controller.enqueue(data);
-          buffer = '';
+          const transformed = transformAvailable(buffer, remainingReplacements, false);
+          buffer = transformed.pending;
+          remainingReplacements = transformed.remainingReplacements;
+          if (transformed.output) controller.enqueue(transformed.output);
         },
 
         flush(controller: TransformStreamDefaultController<string>) {
           if (buffer) {
             // FIXME It may be a non-standard HTML chunk that does not contain the head tag, in which case you need to manually fill in a head element
-            if (buffer.indexOf(`<body>`) === -1 && acts.body) {
+            if (buffer.indexOf(`<body>`) === -1 && completion.body) {
               buffer = `<body>${buffer}</body>`;
             }
             // if (buffer.indexOf(`<head>`) === -1) {
             //   buffer = `<head></head>${buffer}`;
             // }
 
-            const data = trs.reduce((acc, replacement) => acc.replace(replacement.tag, replacement.alt), buffer);
-            controller.enqueue(data);
+            const data = usesLegacyAutoCompletion
+              ? replacements.reduce((acc, replacement) => acc.replace(replacement.tag, replacement.alt), buffer)
+              : transformAvailable(buffer, remainingReplacements, true).output;
+            if (data) controller.enqueue(data);
 
             buffer = '';
           }

--- a/packages/loader/src/TagTransformStream.ts
+++ b/packages/loader/src/TagTransformStream.ts
@@ -5,11 +5,6 @@ type TagReplacement = {
   alt: string;
 };
 
-type AutoCompleteTags = {
-  head?: boolean;
-  body?: boolean;
-};
-
 type TransformedBuffer = {
   output: string;
   pending: string;
@@ -112,37 +107,20 @@ function transformAvailable(input: string, replacements: TagReplacement[], final
  * for "no match" when its replacement text was identical to the original tag.
  *
  * The normal loader path now emits safe HTML incrementally and carries only a
- * possible split-tag suffix into the next transform. Auto-completion deliberately
- * keeps the legacy tail-buffering behavior because it must inspect unmatched bytes
- * at EOF before synthesizing a missing wrapper.
+ * possible split-tag suffix into the next transform. Entries without an explicit
+ * `<body>` remain supported by WritableDOM's downstream HTML parser, which is
+ * rooted in `<body><template>` and does not require this transform to buffer until
+ * EOF to synthesize a wrapper.
  */
-export function createTagTransformStream(
-  tagReplacements: TagReplacement[],
-  autoCompleteTags: AutoCompleteTags,
-): TransformStream<string, string> {
+export function createTagTransformStream(tagReplacements: TagReplacement[]): TransformStream<string, string> {
   validateReplacements(tagReplacements);
   class TagTransformStream extends TransformStream {
-    constructor(replacements: TagReplacement[], completion: AutoCompleteTags) {
+    constructor(replacements: TagReplacement[]) {
       let buffer = '';
       let remainingReplacements = [...replacements];
-      const usesLegacyAutoCompletion = completion.body || completion.head;
       super({
         transform(chunk: string, controller: TransformStreamDefaultController<string>) {
           buffer += chunk;
-
-          // Preserve legacy auto-completion semantics: a match may emit and clear the
-          // buffer, but the unmatched tail since that match stays buffered for the EOF
-          // wrapper check. The loader's regular path disables this mode.
-          if (usesLegacyAutoCompletion) {
-            const data = replacements.reduce(
-              (acc, replacement) => acc.replace(replacement.tag, replacement.alt),
-              buffer,
-            );
-            if (buffer === data) return;
-            controller.enqueue(data);
-            buffer = '';
-            return;
-          }
 
           const transformed = transformAvailable(buffer, remainingReplacements, false);
           buffer = transformed.pending;
@@ -152,17 +130,7 @@ export function createTagTransformStream(
 
         flush(controller: TransformStreamDefaultController<string>) {
           if (buffer) {
-            // FIXME It may be a non-standard HTML chunk that does not contain the head tag, in which case you need to manually fill in a head element
-            if (buffer.indexOf(`<body>`) === -1 && completion.body) {
-              buffer = `<body>${buffer}</body>`;
-            }
-            // if (buffer.indexOf(`<head>`) === -1) {
-            //   buffer = `<head></head>${buffer}`;
-            // }
-
-            const data = usesLegacyAutoCompletion
-              ? replacements.reduce((acc, replacement) => acc.replace(replacement.tag, replacement.alt), buffer)
-              : transformAvailable(buffer, remainingReplacements, true).output;
+            const data = transformAvailable(buffer, remainingReplacements, true).output;
             if (data) controller.enqueue(data);
 
             buffer = '';
@@ -172,5 +140,5 @@ export function createTagTransformStream(
     }
   }
 
-  return new TagTransformStream(tagReplacements, autoCompleteTags);
+  return new TagTransformStream(tagReplacements);
 }

--- a/packages/loader/src/__tests__/TagTransformStream.test.ts
+++ b/packages/loader/src/__tests__/TagTransformStream.test.ts
@@ -7,7 +7,7 @@ const HEAD_REPLACEMENTS = [
 ];
 
 async function transformChunks(chunks: string[], replacements = HEAD_REPLACEMENTS): Promise<string[]> {
-  const stream = createTagTransformStream(replacements, {});
+  const stream = createTagTransformStream(replacements);
   const reader = stream.readable.getReader();
   const writer = stream.writable.getWriter();
   const output: string[] = [];
@@ -56,6 +56,12 @@ describe('createTagTransformStream', () => {
     await expect(transformChunks(['before<he'])).resolves.toEqual(['before', '<he']);
   });
 
+  it('passes through entries without an explicit body for downstream parser completion', async () => {
+    await expect(
+      transformChunks(['<head><title>app</title></head>', '<main id="root">body-less entry</main>']),
+    ).resolves.toEqual(['<qiankun-head><title>app</title></qiankun-head>', '<main id="root">body-less entry</main>']);
+  });
+
   it('replaces each structural tag once independently of chunk boundaries', async () => {
     const input = '<head>one</head><head>two</head>';
     const expected = '<qiankun-head>one</qiankun-head><head>two</head>';
@@ -84,24 +90,18 @@ describe('createTagTransformStream', () => {
   });
 
   it('rejects empty or containment-ambiguous replacement tags', () => {
-    expect(() => createTagTransformStream([{ alt: 'x', tag: '' }], {})).toThrow(/must not be empty/);
+    expect(() => createTagTransformStream([{ alt: 'x', tag: '' }])).toThrow(/must not be empty/);
     expect(() =>
-      createTagTransformStream(
-        [
-          { alt: 'long', tag: 'abc' },
-          { alt: 'short', tag: 'ab' },
-        ],
-        {},
-      ),
+      createTagTransformStream([
+        { alt: 'long', tag: 'abc' },
+        { alt: 'short', tag: 'ab' },
+      ]),
     ).toThrow(/must not contain one another/);
     expect(() =>
-      createTagTransformStream(
-        [
-          { alt: 'long', tag: 'abcd' },
-          { alt: 'inner', tag: 'bc' },
-        ],
-        {},
-      ),
+      createTagTransformStream([
+        { alt: 'long', tag: 'abcd' },
+        { alt: 'inner', tag: 'bc' },
+      ]),
     ).toThrow(/must not contain one another/);
   });
 });

--- a/packages/loader/src/__tests__/TagTransformStream.test.ts
+++ b/packages/loader/src/__tests__/TagTransformStream.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { createTagTransformStream } from '../TagTransformStream';
+
+const HEAD_REPLACEMENTS = [
+  { alt: '<qiankun-head>', tag: '<head>' },
+  { alt: '</qiankun-head>', tag: '</head>' },
+];
+
+async function transformChunks(chunks: string[], replacements = HEAD_REPLACEMENTS): Promise<string[]> {
+  const stream = createTagTransformStream(replacements, {});
+  const reader = stream.readable.getReader();
+  const writer = stream.writable.getWriter();
+  const output: string[] = [];
+  const consume = (async () => {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) return;
+      output.push(result.value);
+    }
+  })();
+
+  for (const chunk of chunks) {
+    await writer.write(chunk);
+  }
+  await writer.close();
+  await consume;
+  return output;
+}
+
+describe('createTagTransformStream', () => {
+  it('emits every safe HTML chunk instead of buffering non-matching chunks until EOF', async () => {
+    const chunks = [
+      '<html><head><title>app</title></head><body><main id="root">',
+      '<section id="benchmark-core">ready</section>',
+      '<script src="entry.js"></script></main></body></html>',
+    ];
+
+    await expect(transformChunks(chunks)).resolves.toEqual([
+      '<html><qiankun-head><title>app</title></qiankun-head><body><main id="root">',
+      chunks[1],
+      chunks[2],
+    ]);
+  });
+
+  it('preserves replacement tags split at every chunk boundary', async () => {
+    const input = 'before<head>inside</head>after';
+    const expected = 'before<qiankun-head>inside</qiankun-head>after';
+
+    for (let boundary = 1; boundary < input.length; boundary += 1) {
+      const output = await transformChunks([input.slice(0, boundary), input.slice(boundary)]);
+      expect(output.join('')).toBe(expected);
+    }
+  });
+
+  it('flushes an incomplete replacement prefix unchanged at EOF', async () => {
+    await expect(transformChunks(['before<he'])).resolves.toEqual(['before', '<he']);
+  });
+
+  it('replaces each structural tag once independently of chunk boundaries', async () => {
+    const input = '<head>one</head><head>two</head>';
+    const expected = '<qiankun-head>one</qiankun-head><head>two</head>';
+
+    await expect(transformChunks([input])).resolves.toEqual([expected]);
+    await expect(transformChunks(['<hea', 'd>one</he', 'ad><head>two</head>'])).resolves.toEqual([
+      '<qiankun-head>one',
+      '</qiankun-head><head>two</head>',
+    ]);
+  });
+
+  it('preserves matching literals in raw text after replacing the document head', async () => {
+    const head = '<head><title>app</title></head>';
+    const body = `<body><script>const template = '<head>x</head>';</script></body>`;
+
+    await expect(transformChunks([head, body])).resolves.toEqual([
+      '<qiankun-head><title>app</title></qiankun-head>',
+      body,
+    ]);
+  });
+
+  it('does not use output equality as a signal to keep buffering', async () => {
+    const replacements = [{ alt: '<head>', tag: '<head>' }];
+
+    await expect(transformChunks(['<head>first', 'second'], replacements)).resolves.toEqual(['<head>first', 'second']);
+  });
+
+  it('rejects empty or containment-ambiguous replacement tags', () => {
+    expect(() => createTagTransformStream([{ alt: 'x', tag: '' }], {})).toThrow(/must not be empty/);
+    expect(() =>
+      createTagTransformStream(
+        [
+          { alt: 'long', tag: 'abc' },
+          { alt: 'short', tag: 'ab' },
+        ],
+        {},
+      ),
+    ).toThrow(/must not contain one another/);
+    expect(() =>
+      createTagTransformStream(
+        [
+          { alt: 'long', tag: 'abcd' },
+          { alt: 'inner', tag: 'bc' },
+        ],
+        {},
+      ),
+    ).toThrow(/must not contain one another/);
+  });
+});

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -98,16 +98,12 @@ export async function loadEntry<T>(
 
     void readableStream
       .pipeThrough(
-        createTagTransformStream(
-          [
-            { tag: '<head>', alt: `<${qiankunHeadTagName}>` },
-            { tag: '</head>', alt: `</${qiankunHeadTagName}>` },
-            // TODO support body replacement
-            // { tag: 'body', alt: 'qiankun-body' },
-          ],
-          // { head: true },
-          {},
-        ),
+        createTagTransformStream([
+          { tag: '<head>', alt: `<${qiankunHeadTagName}>` },
+          { tag: '</head>', alt: `</${qiankunHeadTagName}>` },
+          // TODO support body replacement
+          // { tag: 'body', alt: 'qiankun-body' },
+        ]),
       )
       .pipeTo(
         new WritableDOMStream(container, null, (clone) => {

--- a/packages/loader/src/writable-dom/index.ts
+++ b/packages/loader/src/writable-dom/index.ts
@@ -72,6 +72,9 @@ function writableDOM(
   const nextSibling = previousSibling ? previousSibling.nextSibling : null;
   const owner = target.ownerDocument!;
   const doc = createDocument(target, nextSibling);
+  // Seed the streaming parse root with a body and template. Besides keeping parsed
+  // nodes detached, the browser parser can place entry fragments that omit an
+  // explicit <body> into this template without TagTransformStream buffering to EOF.
   doc.write('<!DOCTYPE html><body><template>');
   const root = (doc.body.firstChild as HTMLTemplateElement).content;
   const walker = doc.createTreeWalker(root);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,25 @@ importers:
         specifier: ^0.34.6
         version: 0.34.6(@edge-runtime/vm@3.2.0)(happy-dom@12.10.3)(less@4.5.1)(lightningcss@1.32.0)(playwright@1.61.1)(sass@1.54.0)(terser@5.46.0)
 
+  benchmark:
+    dependencies:
+      qiankun:
+        specifier: workspace:*
+        version: link:../packages/qiankun
+      wujie:
+        specifier: 2.1.0
+        version: 2.1.0
+    devDependencies:
+      playwright:
+        specifier: 1.61.1
+        version: 1.61.1
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 5.4.21
+        version: 5.4.21(@types/node@25.2.0)(less@4.5.1)(lightningcss@1.32.0)(sass@1.54.0)(terser@5.46.0)
+
   e2e:
     devDependencies:
       '@playwright/test':
@@ -8371,6 +8390,9 @@ packages:
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
+
+  wujie@2.1.0:
+    resolution: {integrity: sha512-qLkI9M30WRlQGlqJJKUDz0FJon30XnH0amUepOaCWwOohhqhvgfP7jeLTykuQfoGm1R7tnqvB7U59G/DW+ud4A==}
 
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
@@ -17641,6 +17663,10 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  wujie@2.1.0:
+    dependencies:
+      '@babel/runtime': 7.28.6
 
   xml-name-validator@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "packages/*"
   - "packages/ui-bindings/*"
+  - "benchmark"
   - "e2e"
   - "examples/*"


### PR DESCRIPTION
## Summary

- add a dedicated qiankun vs Wujie loading benchmark with six representative cells, A/A calibration, balanced ordering, paired bootstrap confidence intervals, and raw sample retention
- add reproducible baseline bundle snapshots plus interleaved baseline/candidate revision comparison
- make `TagTransformStream` flush safe HTML immediately while retaining only a possible cross-chunk tag prefix

## Root cause

`TagTransformStream` previously enqueued data only when a `<head>` replacement changed the current buffer. Once the structural head had already been replaced, later chunks containing the micro-app core had no replacement and remained buffered until EOF. This defeated incremental HTML delivery.

The new scanner consumes each structural replacement once across the stream, preserves later matching literals in script raw text, rejects ambiguous replacement patterns, and keeps the pending buffer bounded by the longest unconsumed tag prefix.

## Performance

Formal interleaved comparison, 100 valid samples per revision:

| | Baseline | Candidate |
| --- | ---: | ---: |
| median | 141.70 ms | 87.15 ms |
| p95 | 152.70 ms | 98.20 ms |

Paired relative delta: **-38.52%**, bootstrap 95% CI **[-39.36%, -37.06%]**.

A/A calibration passed at **+0.29%**, 95% CI **[-0.17%, +0.81%]**. There were no invalid samples.

## Validation

- `pnpm --filter @qiankunjs/loader test`
- relevant package tests: 172 passed
- loader stream tests: 7 passed
- deterministic chunk-boundary fuzzing: 40,000 valid random splits with no counterexample
- `pnpm run eslint`
- package builds and six-cell browser smoke matrix
- `pnpm run benchmark:compare`

The repository-wide `pnpm test` reached the unrelated bundler-plugin webpack fixture, then stopped because the execution environment did not provide the system `npm` binary; all affected loader/shared/sandbox tests passed independently.