### PR TITLE
chore: add Codex skills symlink

### DIFF
--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## What changed

Added the repository-local `.codex/skills` symbolic link pointing to `.claude/skills`.

## Why

This lets Codex discover the same shared skills configuration from this checkout.

## Impact

No runtime or package behavior changes; this only adds local agent-tool configuration.

## Validation

- Verified the link target is `../.claude/skills`.
- Ran `git show --check` on the committed change.
