### PR TITLE
ci(benchmark): tighten basic overhead budgets

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -113,11 +113,11 @@ Each trial first interleaves two aliases of the exact same selected qiankun cell
 
 The `ci-basic` suite uses one browser trial, five warmups, 100 paired samples per product cell, and 100 samples per A/A arm. Every sample must still satisfy the complete measurement contract, including visible styled content, lifecycle settlement, error-free loading, and cleanup. Its paired-bootstrap 95% confidence-interval upper bounds must also satisfy:
 
-- sandbox versus no isolation: no greater than `+25%`;
-- sandbox versus native iframe: no greater than `+30%`;
+- sandbox versus no isolation: no greater than `+10%`;
+- sandbox versus native iframe: no greater than `+10%`;
 - streamed versus delayed-buffered SSR: no greater than `-30%`, proving the progressive path is at least 30% faster with 95% confidence.
 
-These are deliberately broad regression floors, not optimization targets. Relative, within-run comparisons avoid absolute millisecond thresholds that would vary with CI runner hardware. The suite comparison gate can be disabled with `--comparison-gate=false` for plumbing diagnostics, but such a run is not performance evidence.
+These are regression floors, not optimization targets. Both basic overhead comparisons are capped at 10%. Relative, within-run comparisons avoid absolute millisecond thresholds that would vary with CI runner hardware. The suite comparison gate can be disabled with `--comparison-gate=false` for plumbing diagnostics, but such a run is not performance evidence.
 
 ## Revision comparison
 

--- a/benchmark/scenarios.mjs
+++ b/benchmark/scenarios.mjs
@@ -205,6 +205,8 @@ const SSR_STREAMING_GAIN_COMPARISON = {
   reference: 'qk-v3-ssr-delayed-buffered',
 };
 
+const BASIC_OVERHEAD_BUDGET_PERCENT = 10;
+
 const SAME_SITE_COMPARISONS = [
   {
     candidate: 'qk-full-isolation',
@@ -429,8 +431,8 @@ export const SUITES = {
     calibrationSourceVariant: 'qk-sandbox',
     ciOnly: true,
     comparisonGates: [
-      { comparison: 'sandbox-cost', maxUpperBoundPercent: 25 },
-      { comparison: 'qiankun-sandbox-native', maxUpperBoundPercent: 30 },
+      { comparison: 'sandbox-cost', maxUpperBoundPercent: BASIC_OVERHEAD_BUDGET_PERCENT },
+      { comparison: 'qiankun-sandbox-native', maxUpperBoundPercent: BASIC_OVERHEAD_BUDGET_PERCENT },
       { comparison: 'qiankun-v3-ssr-streaming-gain', maxUpperBoundPercent: -30 },
     ],
     comparisons: [

--- a/benchmark/tests/comparison-gates.test.mjs
+++ b/benchmark/tests/comparison-gates.test.mjs
@@ -4,16 +4,16 @@ import test from 'node:test';
 import { evaluateComparisonGates, renderComparisonGateSummary } from '../src/comparison-gates.mjs';
 
 const gates = [
-  { comparison: 'sandbox-cost', maxUpperBoundPercent: 25 },
-  { comparison: 'sandbox-native', maxUpperBoundPercent: 30 },
+  { comparison: 'sandbox-cost', maxUpperBoundPercent: 10 },
+  { comparison: 'sandbox-native', maxUpperBoundPercent: 10 },
   { comparison: 'streaming-gain', maxUpperBoundPercent: -30 },
 ];
 
 test('comparison gates accept confidence-interval upper bounds at their inclusive thresholds', () => {
   const evaluation = evaluateComparisonGates(
     {
-      'sandbox-cost': { confidenceInterval95: [-4, 25], label: 'sandbox cost' },
-      'sandbox-native': { confidenceInterval95: [-2, 30], label: 'sandbox vs native' },
+      'sandbox-cost': { confidenceInterval95: [-4, 10], label: 'sandbox cost' },
+      'sandbox-native': { confidenceInterval95: [-2, 10], label: 'sandbox vs native' },
       'streaming-gain': { confidenceInterval95: [-70, -30], label: 'streaming gain' },
     },
     gates,
@@ -34,8 +34,8 @@ test('comparison gates accept confidence-interval upper bounds at their inclusiv
 test('comparison gates report every upper bound that exceeds its threshold', () => {
   const evaluation = evaluateComparisonGates(
     {
-      'sandbox-cost': { confidenceInterval95: [-4, 25.01], label: 'sandbox cost' },
-      'sandbox-native': { confidenceInterval95: [-2, 31], label: 'sandbox vs native' },
+      'sandbox-cost': { confidenceInterval95: [-4, 10.01], label: 'sandbox cost' },
+      'sandbox-native': { confidenceInterval95: [-2, 11], label: 'sandbox vs native' },
       'streaming-gain': { confidenceInterval95: [-70, -29.5], label: 'streaming gain' },
     },
     gates,
@@ -43,8 +43,8 @@ test('comparison gates report every upper bound that exceeds its threshold', () 
 
   assert.equal(evaluation.passed, false);
   assert.deepEqual(evaluation.failures, [
-    'sandbox-cost: 95% confidence interval upper bound +25.01% exceeds +25.00%',
-    'sandbox-native: 95% confidence interval upper bound +31.00% exceeds +30.00%',
+    'sandbox-cost: 95% confidence interval upper bound +10.01% exceeds +10.00%',
+    'sandbox-native: 95% confidence interval upper bound +11.00% exceeds +10.00%',
     'streaming-gain: 95% confidence interval upper bound -29.50% exceeds -30.00%',
   ]);
 });
@@ -53,7 +53,7 @@ test('comparison gate summary shows every label, id, measured upper bound, budge
   const evaluation = evaluateComparisonGates(
     {
       'sandbox-cost': { confidenceInterval95: [-4, 5.2], label: 'sandbox cost' },
-      'sandbox-native': { confidenceInterval95: [-2, 31], label: 'sandbox vs native' },
+      'sandbox-native': { confidenceInterval95: [-2, 11], label: 'sandbox vs native' },
       'streaming-gain': { confidenceInterval95: [-70, -65], label: 'streaming gain' },
     },
     gates,
@@ -61,8 +61,8 @@ test('comparison gate summary shows every label, id, measured upper bound, budge
   const summary = renderComparisonGateSummary(evaluation);
 
   assert.match(summary, /^## Performance budgets$/mu);
-  assert.match(summary, /sandbox cost \(`sandbox-cost`\) \| \+5\.20% \| ≤ \+25\.00% \| passed/u);
-  assert.match(summary, /sandbox vs native \(`sandbox-native`\) \| \+31\.00% \| ≤ \+30\.00% \| FAILED/u);
+  assert.match(summary, /sandbox cost \(`sandbox-cost`\) \| \+5\.20% \| ≤ \+10\.00% \| passed/u);
+  assert.match(summary, /sandbox vs native \(`sandbox-native`\) \| \+11\.00% \| ≤ \+10\.00% \| FAILED/u);
   assert.match(summary, /streaming gain \(`streaming-gain`\) \| -65\.00% \| ≤ -30\.00% \| passed/u);
 });
 

--- a/benchmark/tests/suites.test.mjs
+++ b/benchmark/tests/suites.test.mjs
@@ -64,8 +64,8 @@ test('suite memberships stay explicit while the core fingerprint remains frozen'
   assert.equal(SUITES['ci-basic'].calibrationSourceVariant, 'qk-sandbox');
   assert.equal(SUITES['ci-basic'].ciOnly, true);
   assert.deepEqual(SUITES['ci-basic'].comparisonGates, [
-    { comparison: 'sandbox-cost', maxUpperBoundPercent: 25 },
-    { comparison: 'qiankun-sandbox-native', maxUpperBoundPercent: 30 },
+    { comparison: 'sandbox-cost', maxUpperBoundPercent: 10 },
+    { comparison: 'qiankun-sandbox-native', maxUpperBoundPercent: 10 },
     { comparison: 'qiankun-v3-ssr-streaming-gain', maxUpperBoundPercent: -30 },
   ]);
 });


### PR DESCRIPTION
## Summary

- tighten the `ci-basic` sandbox/no-isolation 95% CI upper-bound budget from `+25%` to `+10%`
- tighten the sandbox/native iframe budget from `+30%` to `+10%`
- keep the streamed/delayed-buffered SSR floor unchanged at `-30%`
- align the benchmark documentation and gate regression tests with the shared 10% overhead policy

## Why

The original 25% and 30% limits were broad disaster guards. For the minimal performance suite, both basic overhead comparisons should stay within 10% so ordinary regressions are caught before they become large.

## Validation

- `pnpm benchmark:ci-basic`
  - A/A: `-0.52%`, 95% CI `[-1.28%, +0.26%]`
  - sandbox vs no isolation: 95% CI upper bound `+2.74% <= +10%`
  - sandbox vs native iframe: 95% CI upper bound `-7.95% <= +10%`
  - streamed vs delayed-buffered SSR: 95% CI upper bound `-72.46% <= -30%`
  - 200 calibration samples and 500 product samples, all valid
- benchmark unit tests and typecheck (included in `benchmark:ci-basic`)
- Prettier and `git diff --check`
