### PR TITLE
feat(sandbox): expose standalone sandbox controller

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ qiankun/
 `loadApp` (`packages/qiankun/src/core/loadApp.ts`) is the orchestrator. Per micro-app it wires:
 
 1. **fetch** — decorated `window.fetch`: `makeFetchCacheable(makeFetchRetryable(makeFetchThrowable(fetch)))`.
-2. **sandbox** — `createSandboxContainer()` builds a Proxy-membrane `window`/`document` view; patchers (dynamicAppend, timers, listeners, history) each return a `free()` cleanup called on unmount.
+2. **sandbox** — `createSandbox()` builds a Proxy-membrane `window`/`document` view; patchers (dynamicAppend, timers, listeners, history) each return a `free()` cleanup called on unmount. Without a container it uses the JS-only preset; a container enables DOM containment.
 3. **loader** — `loadEntry(entry, container, opts)` streams the HTML entry through `writable-dom`, virtualizing `<head>` → `<qiankun-head>` and running each node through a `nodeTransformer`.
 4. **transpilers** (`shared/assets-transpilers`) rewrite each script/link/style node before it hits live DOM.
 

--- a/docs/rfcs/compartment-alignment.md
+++ b/docs/rfcs/compartment-alignment.md
@@ -139,6 +139,8 @@ Layer 4 草案已将 `importHook` 更名为 `loadHook`（草案原文承认与 s
 
 各阶段可独立落地、独立发版；①② 是 ③ 的前置（插件协议依赖 Compartment 公开接口），④ 贯穿始终。
 
+**延伸阶段⑤（沙箱独立开放）**：让 `@qiankunjs/sandbox` 成为非 qiankun 用户可直接使用的隔离库（`createSandbox` 默认值完备化、容器协议包内化、qiankun 收编为普通消费者），由独立的 [Standalone Sandbox RFC](./standalone-sandbox.md) 承接——它是本 RFC「替换边界 + 插件协议」故事的自然终点：对外开放的公开面，同时也是内部替换的稳定面。
+
 ## Detailed Design
 
 ### 1. Compartment 名实相符（阶段一）

--- a/docs/rfcs/standalone-sandbox.md
+++ b/docs/rfcs/standalone-sandbox.md
@@ -76,7 +76,7 @@ function createSandbox(
 ### 3. 容器协议包内化
 
 - 新增公开 helper `prepareSandboxContainer(container, appName)`：确保 `<qiankun-head>` 存在、设置 `data-name`、返回配好的 `StyleIsolationOpts` 与清理函数。`createSandbox({ container })` 自动调用。
-- dynamicAppend 插件在 mount 时若容器缺 `<qiankun-head>` **且不处于 loader 流式管线**（以 loader streamed 标记区分）则自动创建，消除 standalone 用户的 `QiankunError` 硬雷；loader 场景保持现状报错——那里缺失代表真实的时序 bug，不应被静默掩盖。
+- `createSandbox` 在 mount 阶段若容器缺 `<qiankun-head>` **且不处于 loader 流式管线**（以 loader streamed 标记区分）则自动创建，消除 standalone 用户的 `QiankunError` 硬雷；loader 场景保持现状报错——那里缺失代表真实的时序 bug，不应被静默掩盖。容器准备只属于完整沙箱预设：JS-only 预设即使在 `mount(container)` 收到元素也不触碰它。
 - `styleIsolation` 的 `{ appName, scopeRoot }` 构造从 `loadApp` 下沉进包内，qiankun 与 standalone 共享同一份契约代码。
 
 ### 4. qiankun 收编为消费者

--- a/docs/rfcs/standalone-sandbox.md
+++ b/docs/rfcs/standalone-sandbox.md
@@ -1,0 +1,132 @@
+# RFC: Standalone Sandbox — 沙箱能力独立开放
+
+- **Status**: Draft
+- **Author**: qiankun maintainers
+- **Created**: 2026-07-18
+- **Target Release**: `@qiankunjs/sandbox` v3.x
+- **Tracking Issue**: TBD
+- **Depends on**: [Compartment Alignment RFC](./compartment-alignment.md)（Accepted，本 RFC 是其延伸阶段⑤）
+
+## Summary
+
+让 `@qiankunjs/sandbox` 成为可被**非 qiankun 用户**独立使用的浏览器隔离库：
+
+1. **JS 隔离开箱即用**——classic 脚本求值与 ESM `import()` 不需要任何 qiankun/loader 上下文。
+2. **DOM/样式遏制按需开启**——容器协议由包自身负责建立，不再要求用户复刻 loader 的隐式约定。
+3. **qiankun 退化为普通消费者**——`loadApp` 与独立用户走同一公开入口，吃自己的狗粮。
+
+**边界**：纯开放，不改隔离分寸。membrane 的 non-transitive 定位、写隔离/身份共享语义、副作用清理范围均维持 Compartment Alignment RFC 声明的现状。
+
+## Motivation
+
+Compartment 对齐完成后（2026-07-18 standalone 可用性审计），独立使用的现状分三层：
+
+1. **JS 隔离层已可独立用**：`moduleHost` 全部字段可选且默认值完备（`entryUrl` = `document.baseURI`、`fetch` = 原生、`globalsBaseSet` = `esmDestructurableGlobals`、`instanceId` 自动分配）。`new StandardSandbox(name, globals)` + `evaluateScript()` / `import()` 即可运行——这是对齐工作的直接红利，但没有任何文档承认这条路径。
+2. **完整沙箱层能跑但要伪造 loader 形状**：`createSandboxContainer` 的 `nodeTransformer` / `fetch` 必填（loader 概念泄漏）；head 定向动态样式要求容器内存在 `<qiankun-head>`（本由 loader 流式改写产生，缺失抛 `QiankunError`）；`styleIsolation` 的 `scopeRoot` 与容器 `data-name` 配对约定拼装在 `loadApp` 里，包内无 helper。
+3. **文档为零**：无 README、无示例；唯一的 standalone「教程」是单元测试。
+
+另有一个无文档的坑：裸 `Compartment` 的 `defaultUnshadowableGlobalNames` 只含 ES intrinsics + rAF/cAF，不含 `window`/`self`/`document`——classic 脚本里 `window.x = 1` 会穿透污染宿主。自引用安装是 `StandardSandbox` 第二阶段的职责，但没有任何指引告诉用户「classic 求值必须走 StandardSandbox」。
+
+## Design
+
+### 1. 分层公开面：两个入口，各自完整
+
+| 层 | 入口 | 能力 | 依赖 |
+| --- | --- | --- | --- |
+| **Layer A — JS 隔离** | `StandardSandbox`（预设）/ `Compartment`（机制） | 写隔离 global、classic 求值、ESM `import()`/hooks | 无 DOM 假设 |
+| **Layer B — 完整沙箱** | `createSandbox()` | Layer A + DOM 遏制、样式隔离、定时器/监听器回收、插件生命周期 | 需要容器 |
+
+分层职责不变：`Compartment` 保持规范投影的纯粹性（不默认安装 `window` 自引用——那不是 Compartment 规范形状的一部分）；`StandardSandbox` 是 classic 求值的安全入口。针对穿透坑的防护：
+
+- `Compartment.evaluateScript()` 在 dev 模式检测 `window` 未被定义为自引用时发出一次性 `console.warn`，指向 `StandardSandbox`；运行语义不变。
+- README 与文档以「两个入口」为第一原则组织，杜绝用户按规范直觉误入裸 `Compartment`。
+
+### 2. `createSandbox()`：默认值完备的完整沙箱入口
+
+现 `createSandboxContainer` 直接更名为 `createSandbox`，不保留旧名——`@qiankunjs/sandbox` 目前没有外部用户，无兼容负担。选项全面默认值化：
+
+```ts
+function createSandbox(
+  appName: string,
+  opts?: {
+    /** 提供即开启 DOM 遏制；缺省为纯 JS 隔离（不安装 dynamicAppend 插件） */
+    container?: HTMLElement | (() => HTMLElement);
+    globals?: CompartmentGlobals;
+    incubatorContext?: WindowProxy;
+    modules?: Modules;
+    resolveHook?: ResolveHook;
+    importHook?: ImportHook;
+    loadHook?: ImportHook;
+    plugins?: readonly IsolationPlugin[];
+    /** boolean 即可；scopeRoot/data 属性契约由包内部建立 */
+    styleIsolation?: boolean;
+    /** 默认 window.fetch */
+    fetch?: typeof window.fetch;
+    /** 默认为「隔离保持」转换器（见下），可覆盖 */
+    nodeTransformer?: NodeTransformer;
+    compartmentOptions?: Omit<CompartmentOptions, 'globals' | 'incubatorContext' | 'name'>;
+  },
+): SandboxController;
+```
+
+**关键设计约束：默认值必须保隔离。** `nodeTransformer` 的默认值**绝不能是 identity**——dynamicAppend 拦截到的动态 `<script>` 依赖 transformer 经 `transformClassicScript` 包装后执行，identity 等于沙箱逃逸。默认实现基于 `@qiankunjs/shared` 的 `transpileAssets`（sandbox 已依赖 shared，不引入新依赖方向），entry 基准取 `document.baseURI`；它是内部实现细节，不将 assets-transpilers 提升为公开 API。
+
+必填项收敛为 `appName` 一个；`container` 缺省时按「JS-only 预设」装配插件（interval / windowListener / historyListener——它们不依赖容器），提供 `container` 时装配完整 Standard 预设。
+
+### 3. 容器协议包内化
+
+- 新增公开 helper `prepareSandboxContainer(container, appName)`：确保 `<qiankun-head>` 存在、设置 `data-name`、返回配好的 `StyleIsolationOpts` 与清理函数。`createSandbox({ container })` 自动调用。
+- dynamicAppend 插件在 mount 时若容器缺 `<qiankun-head>` **且不处于 loader 流式管线**（以 loader streamed 标记区分）则自动创建，消除 standalone 用户的 `QiankunError` 硬雷；loader 场景保持现状报错——那里缺失代表真实的时序 bug，不应被静默掩盖。
+- `styleIsolation` 的 `{ appName, scopeRoot }` 构造从 `loadApp` 下沉进包内，qiankun 与 standalone 共享同一份契约代码。
+
+### 4. qiankun 收编为消费者
+
+`loadApp` 改走 `createSandbox` 同一入口：传入真实的 nodeTransformer（含 moduleResolver / styleIsolation）、装饰后的 fetch、真实容器。qiankun 专有的 `moduleHost` 字段（`entryUrl` / `instanceId` / `materializeRedirect` / `isLifecycleNamespace`）继续经 `compartmentOptions.moduleHost` 传入——它们全部有默认值，非 qiankun 用户零感知。此步骤与 IsolationPlugin 的「dynamicAppend 吃狗粮」同构：qiankun 对包的每一次使用都必须可被外部用户复刻。
+
+### 5. 文档与示例
+
+- `packages/sandbox/README.md`：两条路径的快速上手 + **隔离分寸声明**（non-transitive membrane、写隔离、身份共享——链接 Compartment Alignment RFC 的机制定位段），npm 页面可见。
+- `docs/cookbook/standalone-sandbox.md`（en + zh-CN）：完整教程。
+- `examples/standalone-sandbox`：零 qiankun 依赖的 demo（隔离加载一个第三方 widget 脚本）。
+
+### 6. 形状与回归守卫
+
+- **standalone 冒烟测试套件**：以 README 示例为蓝本（classic 写隔离、`window` 穿透防护、ESM `import()`、动态 append 遏制、styleIsolation、dispose 无泄漏），全程不 import qiankun/loader，进 CI。
+- 依赖方向守卫维持（sandbox → shared）；新增守卫：sandbox 源码不得出现 loader 专有类型（结构化 facade 除外）。
+- qiankun 路径回归门禁：全量 e2e 保持通过 + 复用 rfc-performance 性能闸门（含 95% CI 分辨率守卫），作为「收编不改行为、不回归性能」的硬指标。
+
+## 阶段划分（接 Compartment Alignment 的①—④）
+
+| 阶段 | 内容 | 性质 |
+| --- | --- | --- |
+| ⑤a 入口与默认值 | `createSandbox`、默认 transformer/fetch、容器协议内化、穿透 dev 警告 | 新增 + 少量重构 |
+| ⑤b 文档与示例 | README、cookbook（双语）、standalone example、冒烟测试 | 纯新增 |
+| ⑤c 收编与守卫 | `loadApp` 消费同一入口、形状守卫、e2e/性能门禁 | 内部重构 |
+
+## Acceptance Criteria
+
+1. 一个不依赖 qiankun/loader 的项目，仅按 README 即可完成：classic 脚本隔离执行、ESM 入口 `import()`、动态 DOM/样式遏制、卸载与 dispose 清理。
+2. `createSandbox` 必填项仅 `appName`；所有默认值保持隔离语义（尤其动态 script 的包装路径有专门测试钉住「默认非 identity」）。
+3. 裸 `Compartment` 的 classic 求值在 dev 模式有穿透警告；README 有明确的两入口分层指引。
+4. qiankun `loadApp` 与 standalone 用户走同一公开入口；全量 e2e 保持通过；rfc-performance 闸门无回归。
+5. standalone 冒烟测试套件进 CI，且不 import qiankun/loader。
+6. 零新增运行时依赖；CSP 无 `unsafe-eval` 场景全覆盖（含默认 transformer 路径）。
+
+## Non-Goals
+
+- **不做强隔离**——iframe / Worker / callable boundary 是独立产品形态；本 RFC 与 Compartment Alignment 的 Non-Goals 完全继承（不 harden、不 lockdown、不改隔离分寸）。
+- **不把 `shared/assets-transpilers` 提升为公开 API**——默认 nodeTransformer 是内部实现细节，覆盖点是 `nodeTransformer` 本身。
+- **不支持 Node/SSR 环境**——浏览器专用（blob script、DOM、import map）。
+- **不做独立品牌化**——包名维持 `@qiankunjs/sandbox`，独立命名留待生态验证后再议。
+
+## Risks and Mitigations
+
+- **默认 transformer 的隐式行为**（动态 script 被自动包装）可能让 standalone 用户意外 → README 显式声明 + `nodeTransformer` 可覆盖 + 冒烟测试展示两种行为。
+- **`qiankun-head` 自动创建与 loader 流的边界**：靠 loader streamed 标记区分，两侧各有测试钉住（standalone 自动建成功 / loader 缺失仍报错）。
+- **dev 警告误报**（用户自行定义了 window 自引用）：检测基于 `definedUnshadowableGlobalNames` 实际状态而非入口类型。
+
+## References
+
+- [Compartment Alignment RFC](./compartment-alignment.md)——依赖的公开面与机制定位（membrane non-transitive、`incubatorContext` 出处）
+- [TC39 proposal-compartments](https://github.com/tc39/proposal-compartments) / [ses](https://github.com/endojs/endo/tree/master/packages/ses)
+- 现有单元测试中的 standalone 用法（`packages/sandbox/src/core/**/__tests__`）——本 RFC 将其升格为受支持的公开旅程

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -91,6 +91,27 @@ export default defineConfig([
     },
   },
   {
+    name: 'qiankun/sandbox-boundaries',
+    files: ['packages/sandbox/src/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['lodash/*'],
+              message: "Import named methods from 'lodash'; the library build rewrites them to method subpaths.",
+            },
+            {
+              group: ['@qiankunjs/loader', '@qiankunjs/loader/**'],
+              message: 'The standalone sandbox must not depend on the qiankun HTML loader.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     name: 'qiankun/sandbox-patcher-boundaries',
     files: ['packages/sandbox/src/patchers/**/*.ts'],
     rules: {
@@ -110,6 +131,10 @@ export default defineConfig([
                 '@qiankunjs/sandbox/**/membrane/**',
               ],
               message: 'Isolation plugins must only use the public Compartment API.',
+            },
+            {
+              group: ['@qiankunjs/loader', '@qiankunjs/loader/**'],
+              message: 'The standalone sandbox must not depend on the qiankun HTML loader.',
             },
           ],
         },

--- a/packages/qiankun/src/core/__tests__/loadApp.test.ts
+++ b/packages/qiankun/src/core/__tests__/loadApp.test.ts
@@ -4,10 +4,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LoaderOpts } from '@qiankunjs/loader';
 import { nativeGlobal } from '@qiankunjs/sandbox';
-import { createSandboxContainer as createRealSandboxContainer } from '../../../../sandbox/src/core/sandbox';
+import { createSandbox as createRealSandbox } from '../../../../sandbox/src/core/sandbox';
 
 const mocks = vi.hoisted(() => ({
-  createSandboxContainer: vi.fn(),
+  createSandbox: vi.fn(),
   dispose: vi.fn(async () => {}),
   loadEntry: vi.fn(),
   mount: vi.fn(async () => {}),
@@ -21,7 +21,7 @@ vi.mock('@qiankunjs/loader', async (importOriginal) => ({
 
 vi.mock('@qiankunjs/sandbox', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
-  createSandboxContainer: mocks.createSandboxContainer,
+  createSandbox: mocks.createSandbox,
 }));
 
 import type { MicroAppLifeCycles } from '../../types';
@@ -36,12 +36,13 @@ const validLifecycles: MicroAppLifeCycles = {
 
 describe('loadApp sandbox cleanup', () => {
   beforeEach(() => {
-    mocks.createSandboxContainer.mockReturnValue({
+    mocks.createSandbox.mockReturnValue({
       dispose: mocks.dispose,
       instance: {
         globalThis: window,
         latestSetProp: undefined,
       },
+      nodeTransformer: (node: Node) => node,
       mount: mocks.mount,
       unmount: mocks.unmount,
     });
@@ -70,7 +71,7 @@ describe('loadApp sandbox cleanup', () => {
       Object.getOwnPropertyNames(nativeGlobal).filter((key) => key.startsWith('__compartment_globalThis__'));
     const accessorsBeforeLoad = listAccessors();
 
-    mocks.createSandboxContainer.mockImplementationOnce(createRealSandboxContainer);
+    mocks.createSandbox.mockImplementationOnce(createRealSandbox);
     mocks.loadEntry.mockImplementationOnce((_entry: unknown, _container: HTMLElement, opts: LoaderOpts) => {
       opts.compartment?.registerImportMap('{"imports":{}}', document.baseURI);
       return Promise.reject(loadError);
@@ -124,6 +125,64 @@ describe('loadApp sandbox cleanup', () => {
     await parcelConfig.unload[0]();
 
     expect(mocks.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('uses the public sandbox controller and shares its configured transformer with the loader', async () => {
+    const controllerNodeTransformer = vi.fn(<T extends Node>(node: T) => node);
+    const configuredNodeTransformer = vi.fn(<T extends Node>(node: T) => node);
+    const resolveHook = (specifier: string) => specifier;
+    const importHook = async () => ({ namespace: { ready: true } });
+    const modules = { preset: { namespace: { preset: true } } };
+    const container = document.createElement('div');
+    mocks.createSandbox.mockReturnValueOnce({
+      dispose: mocks.dispose,
+      instance: {
+        globalThis: window,
+        latestSetProp: undefined,
+      },
+      mount: mocks.mount,
+      nodeTransformer: controllerNodeTransformer,
+      unmount: mocks.unmount,
+    });
+    mocks.loadEntry.mockResolvedValue(validLifecycles);
+
+    await loadApp(createApp(container), {
+      nodeTransformer: configuredNodeTransformer,
+      sandbox: {
+        globals: { tenant: 'acme' },
+        importHook,
+        modules,
+        resolveHook,
+        styleIsolation: true,
+      },
+    });
+
+    expect(mocks.createSandbox).toHaveBeenCalledWith(
+      'sandbox-cleanup-test',
+      expect.objectContaining({
+        globals: { tenant: 'acme' },
+        importHook,
+        modules,
+        nodeTransformer: configuredNodeTransformer,
+        resolveHook,
+        styleIsolation: true,
+      }),
+    );
+    const createOptions = mocks.createSandbox.mock.calls[0][1];
+    expect(createOptions.container()).toBe(container);
+    expect(createOptions.compartmentOptions.moduleHost).toEqual(
+      expect.objectContaining({
+        entryUrl: 'https://sandbox-cleanup.test/index.html',
+        instanceId: expect.any(Number),
+        isLifecycleNamespace: expect.any(Function),
+        materializeRedirect: expect.any(Function),
+      }),
+    );
+    expect(mocks.loadEntry).toHaveBeenCalledWith(
+      'https://sandbox-cleanup.test/index.html',
+      container,
+      expect.objectContaining({ nodeTransformer: controllerNodeTransformer }),
+    );
   });
 });
 

--- a/packages/qiankun/src/core/loadApp.ts
+++ b/packages/qiankun/src/core/loadApp.ts
@@ -4,8 +4,8 @@
  */
 import type { LoaderOpts } from '@qiankunjs/loader';
 import { loadEntry } from '@qiankunjs/loader';
-import type { Sandbox } from '@qiankunjs/sandbox';
-import { createSandboxContainer, esmDestructurableGlobals, nativeGlobal } from '@qiankunjs/sandbox';
+import type { Sandbox, SandboxController } from '@qiankunjs/sandbox';
+import { createSandbox, nativeGlobal } from '@qiankunjs/sandbox';
 import {
   defineProperty,
   hasOwnProperty,
@@ -16,7 +16,6 @@ import {
   transpileAssets,
   warn,
 } from '@qiankunjs/shared';
-import type { StyleIsolationOpts } from '@qiankunjs/shared';
 import { concat, isFunction, mergeWith } from 'lodash';
 import type { ParcelConfigObject } from 'single-spa';
 import getAddOns from '../addons';
@@ -59,7 +58,7 @@ export default async function loadApp<T extends ObjectType>(
   const { name: appName, entry, container } = app;
   const defaultNodeTransformer: AppConfiguration['nodeTransformer'] = (node, opts) => {
     const moduleResolver = (url: string) => defaultModuleResolver(url, microAppDOMContainer, document.head);
-    return transpileAssets(node, entry, { ...opts, moduleResolver, styleIsolation: styleIsolationOpts });
+    return transpileAssets(node, entry, { ...opts, moduleResolver });
   };
   const {
     fetch = window.fetch,
@@ -80,10 +79,6 @@ export default async function loadApp<T extends ObjectType>(
 
   const enhancedFetch = makeFetchCacheable(makeFetchRetryable(makeFetchThrowable(fetch)));
 
-  const styleIsolationOpts: StyleIsolationOpts | undefined = styleIsolationEnabled
-    ? { appName, scopeRoot: `[data-name="${appName}"]` }
-    : undefined;
-
   const markName = `[qiankun] App ${appName} Loading`;
   if (process.env.NODE_ENV === 'development') {
     performanceMark(markName);
@@ -93,21 +88,21 @@ export default async function loadApp<T extends ObjectType>(
   let mountSandbox: (container: HTMLElement) => Promise<void> = () => Promise.resolve();
   let unmountSandbox = () => Promise.resolve();
   let sandboxInstance: Sandbox | undefined;
-  let sandboxController: ReturnType<typeof createSandboxContainer> | undefined;
+  let sandboxController: SandboxController | undefined;
+  let resolvedNodeTransformer = nodeTransformer;
   const instanceId = genInstanceId(appName);
   let mountTimes = 1;
 
   let microAppDOMContainer: HTMLElement = container;
-  initContainer(microAppDOMContainer, appName, { sandboxCfg: sandbox, mountTimes, instanceId });
+  initContainer(microAppDOMContainer, { sandboxCfg: sandbox, mountTimes, instanceId });
+  if (!sandboxEnabled) microAppDOMContainer.dataset.name = appName;
 
   if (sandboxEnabled) {
-    sandboxController = createSandboxContainer(appName, () => microAppDOMContainer, {
+    sandboxController = createSandbox(appName, {
+      container: () => microAppDOMContainer,
       compartmentOptions: {
-        ...compartmentHooks,
         moduleHost: {
           entryUrl: entry,
-          fetch: enhancedFetch,
-          globalsBaseSet: [...esmDestructurableGlobals, ...Object.keys(globals)],
           instanceId,
           materializeRedirect: (url) => defaultModuleResolver(url, microAppDOMContainer, document.head)?.url,
           isLifecycleNamespace: (namespace) =>
@@ -119,10 +114,12 @@ export default async function loadApp<T extends ObjectType>(
       fetch: enhancedFetch,
       nodeTransformer,
       plugins,
-      styleIsolation: styleIsolationOpts,
+      styleIsolation: styleIsolationEnabled,
+      ...compartmentHooks,
     });
 
     sandboxInstance = sandboxController.instance;
+    resolvedNodeTransformer = sandboxController.nodeTransformer;
     global = sandboxInstance.globalThis;
 
     mountSandbox = (domContainer) => sandboxController!.mount(domContainer);
@@ -136,7 +133,7 @@ export default async function loadApp<T extends ObjectType>(
   const containerOpts: LoaderOpts = {
     compartment: sandboxInstance,
     fetch: enhancedFetch,
-    nodeTransformer,
+    nodeTransformer: resolvedNodeTransformer,
     ...restConfiguration,
   };
   const lifecycleSetup = await (async () => {
@@ -207,7 +204,8 @@ export default async function loadApp<T extends ObjectType>(
           // explicitly rather than inferred from the DOM, since markup noise (whitespace text nodes,
           // framework placeholder comments) would fool an emptiness check
           if (mountTimes > 1 || !initializedContainers.has(mountContainer)) {
-            initContainer(mountContainer, appName, { sandboxCfg: sandbox, mountTimes, instanceId });
+            initContainer(mountContainer, { sandboxCfg: sandbox, mountTimes, instanceId });
+            if (!sandboxEnabled) mountContainer.dataset.name = appName;
             // html scripts should be removed to avoid repeatedly execute
             const htmlString = await getPureHTMLStringWithoutScripts(entry, enhancedFetch);
             await loadEntry(
@@ -279,7 +277,6 @@ const initializedContainers = new WeakSet<HTMLElement>();
 
 function initContainer(
   container: HTMLElement,
-  appName: string,
   opts: { sandboxCfg: AppConfiguration['sandbox']; mountTimes: number; instanceId: number },
 ): void {
   const { sandboxCfg, mountTimes, instanceId } = opts;
@@ -288,7 +285,6 @@ function initContainer(
   }
   initializedContainers.add(container);
 
-  container.dataset.name = appName;
   container.dataset.version = __QIANKUN_VERSION__;
   // The sandbox configuration object may carry functions and large globals — store a
   // debug-friendly summary instead of serializing it verbatim.

--- a/packages/qiankun/src/types.ts
+++ b/packages/qiankun/src/types.ts
@@ -3,13 +3,14 @@
  * @since 2023-04-25
  */
 import type { LoaderOpts } from '@qiankunjs/loader';
-import type { CompartmentOptions, IsolationPlugin } from '@qiankunjs/sandbox';
+import type { CreateSandboxOptions } from '@qiankunjs/sandbox';
 import type { LifeCycles as ParcelLifeCycles, Parcel, RegisterApplicationConfig } from 'single-spa';
 
 export type {
   Compartment,
   CompartmentGlobals,
   CompartmentOptions,
+  CreateSandboxOptions,
   Free,
   ImportHook,
   IsolationPlugin,
@@ -22,6 +23,8 @@ export type {
   PrecompileModuleSourceOpts,
   ResolveHook,
   Rebuild,
+  SandboxContainerPreparation,
+  SandboxController,
   UnshadowableGlobals,
 } from '@qiankunjs/sandbox';
 
@@ -68,18 +71,9 @@ export type RegistrableApp<T extends ObjectType> = LoadableApp<T> & {
  * `CompartmentOptions` plus two qiankun host extensions (`plugins`, `styleIsolation`).
  */
 export type SandboxConfiguration = Pick<
-  CompartmentOptions,
-  'globals' | 'incubatorContext' | 'modules' | 'resolveHook' | 'importHook' | 'loadHook'
-> & {
-  /** Isolation plugins appended after qiankun's built-in plugins. */
-  plugins?: readonly IsolationPlugin[];
-  /**
-   * Enable runtime CSS isolation via @scope wrapping: all micro-app styles are scoped to the
-   * app container. Dynamically injected styles ride on the sandbox's DOM interception, which
-   * is why CSS isolation is only configurable while the sandbox is enabled.
-   */
-  styleIsolation?: boolean;
-};
+  CreateSandboxOptions,
+  'globals' | 'incubatorContext' | 'modules' | 'resolveHook' | 'importHook' | 'loadHook' | 'plugins' | 'styleIsolation'
+>;
 
 export type AppConfiguration = Partial<Pick<LoaderOpts, 'fetch' | 'streamTransformer' | 'nodeTransformer'>> & {
   /**

--- a/packages/sandbox/AGENTS.md
+++ b/packages/sandbox/AGENTS.md
@@ -7,7 +7,7 @@ JS isolation engine: a Compartment-shaped facade owns the Proxy **Membrane**, cl
 ```
 sandbox/
 ├── core/
-│   ├── sandbox/          # createSandboxContainer() + StandardSandbox preset (mount/unmount)
+│   ├── sandbox/          # createSandbox() + StandardSandbox preset + container protocol
 │   ├── membrane/         # Proxy wrapper for global (window/document) isolation
 │   ├── compartment/      # globals + module hooks + blob classic evaluation facade
 │   ├── globals.ts        # global property definitions
@@ -24,7 +24,8 @@ sandbox/
 
 | Task | File | Notes |
 | --- | --- | --- |
-| Create sandbox | `core/sandbox/index.ts` | Builds a `StandardSandbox`, installs built-in then user plugins, and returns mount/unmount |
+| Create sandbox | `core/sandbox/index.ts` | Builds a `StandardSandbox`, installs the JS-only or DOM preset, and returns mount/unmount/dispose |
+| Prepare container | `core/sandbox/container.ts` | Owns `<qiankun-head>`, `data-name`, style scope, and cleanup contracts |
 | Proxy logic | `core/membrane/index.ts` | Write → local target; Read → local → configured globals → host window |
 | Compartment facade | `core/compartment/index.ts` | Owns the membrane, module facade, and CSP-safe blob classic evaluation |
 | Plugin protocol | `patchers/types.ts` | Public `IsolationPlugin`, context, `Free`, and `Rebuild` contracts |
@@ -56,7 +57,9 @@ sandbox/
 
 The module engine in `@qiankunjs/shared` is an implementation detail behind `Compartment.import()`, `load()`, and `importDocumentModules()`. Cross-package consumers must depend on the structural Compartment facade, never `EsmSandboxEngine`.
 
-`createSandboxContainer().dispose()` is the terminal owner cleanup: it frees active plugin effects, deactivates the sandbox, and idempotently disposes the Compartment. Initial load failures must call it without replacing the original loading error.
+`createSandbox().dispose()` is the terminal owner cleanup: it frees active plugin effects, restores container protocol state, deactivates the sandbox, and idempotently disposes the Compartment. Initial load failures must call it without replacing the original loading error.
+
+`createSandbox(appName)` is the JS-only preset: interval, window-listener, and history cleanup are available without a container. Providing `container` enables dynamic DOM interception; `mount()` prepares standalone containers lazily so qiankun's streaming loader never gets a duplicate `<qiankun-head>`. The controller's public `nodeTransformer` is the single configured transformer for both streaming and dynamic assets.
 
 ### IsolationPlugin / Free pattern
 
@@ -102,7 +105,7 @@ If a native Compartment becomes available, it may replace only globalThis virtua
 ## EXPORTS (`src/index.ts`)
 
 ```typescript
-export * from './core/sandbox'; // createSandboxContainer, type Sandbox, StandardSandbox
+export * from './core/sandbox'; // createSandbox, prepareSandboxContainer, StandardSandbox, controller/options types
 export * from './core/compartment'; // Compartment, options, compatibility lists
 export * from './consts'; // qiankunHeadTagName, qiankunBodyTagName, nativeGlobal, nativeDocument
 export { esmDestructurableGlobals } from './core/esm-globals';

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -98,7 +98,7 @@ currentContainer = document.querySelector<HTMLElement>('#second')!;
 await controller.mount();
 ```
 
-Calling `createSandbox('name')` without a container creates the JS-only preset. Its timer, window-listener, and history plugins can be activated with `mount()` without providing an arbitrary DOM element. `styleIsolation: true` requires a configured container.
+Calling `createSandbox('name')` without a container creates the JS-only preset. Its timer, window-listener, and history plugins can be activated with `mount()` without providing an arbitrary DOM element, and an element passed to `mount()` is left untouched — container preparation belongs to the container-backed preset. `styleIsolation: true` requires a configured container.
 
 ### Container preparation
 

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -1,0 +1,174 @@
+# @qiankunjs/sandbox
+
+`@qiankunjs/sandbox` provides qiankun's browser sandbox as a standalone package. It can isolate classic-script and ESM global writes, and can optionally contain dynamic DOM and styles inside an application container. It does not require `qiankun` or `@qiankunjs/loader`.
+
+> This package is browser-only. It uses DOM APIs, blob URLs, and dynamically injected import maps; it does not support Node.js or SSR execution.
+
+## Choose an API layer
+
+| Need | API | What it provides |
+| --- | --- | --- |
+| JavaScript isolation only | `StandardSandbox` | A safe preset for classic scripts and ESM, including `window`/`self` self-references |
+| Low-level Compartment mechanics | `Compartment` | A Compartment-shaped global and module-hook facade for advanced hosts |
+| Browser containment and lifecycle | `createSandbox()` | `StandardSandbox` plus optional DOM/style containment, timer and listener cleanup, and isolation plugins |
+
+Use `StandardSandbox` for direct classic-script evaluation. A bare `Compartment` deliberately does not install a sandboxed `window` self-reference. Calling `Compartment.evaluateScript()` without defining one emits a development warning, but it does not change execution semantics: code such as `window.answer = 42` may write to the host window.
+
+## JavaScript isolation
+
+### Classic scripts
+
+```ts
+import { StandardSandbox } from '@qiankunjs/sandbox';
+
+const sandbox = new StandardSandbox('report-widget', {
+  tenantId: 'acme',
+});
+
+await sandbox.evaluateScript(
+  `
+    window.reportState = { tenantId };
+  `,
+  { sourceURL: 'https://widgets.example/report.js' },
+);
+
+console.log(Reflect.get(sandbox.globalThis, 'reportState')); // { tenantId: 'acme' }
+console.log(Reflect.get(window, 'reportState')); // undefined
+
+sandbox.dispose();
+```
+
+`evaluateScript()` executes through a native blob script. It does not use `eval` or `new Function`.
+
+### ESM
+
+```ts
+const sandbox = new StandardSandbox('report-module');
+const namespace = await sandbox.import(new URL('./report-entry.js', document.baseURI).href);
+
+console.log(namespace);
+sandbox.dispose();
+```
+
+Relative module resolution defaults to `document.baseURI`. `StandardSandbox` accepts custom module tables and hooks through its fourth, Compartment-options argument; `createSandbox()` promotes `modules`, `resolveHook`, `importHook`, and `loadHook` to top-level options. See the [sandbox plugins guide](../../docs/cookbook/sandbox-plugins.md) for an advanced example.
+
+## Full browser sandbox
+
+Pass a container to `createSandbox()` to enable document virtualization and dynamic DOM interception. Set `styleIsolation: true` to scope application styles to that container.
+
+```ts
+import { createSandbox } from '@qiankunjs/sandbox';
+
+const container = document.querySelector<HTMLElement>('#widget')!;
+const controller = createSandbox('report-widget', {
+  container,
+  styleIsolation: true,
+});
+
+// Mount before application code so timers and listeners are tracked.
+await controller.mount();
+
+const response = await fetch('/vendor/report-widget.js');
+const source = await response.text();
+await controller.instance.evaluateScript(source, {
+  sourceURL: response.url,
+});
+
+// Releases active plugin effects and keeps the controller available for remount.
+await controller.unmount();
+await controller.mount();
+
+// Terminal cleanup. A disposed controller cannot be mounted or evaluated again.
+await controller.dispose();
+```
+
+When `container` is a function, it is resolved again for each mount. This supports hosts that replace the mount element between activations:
+
+```ts
+let currentContainer = document.querySelector<HTMLElement>('#first')!;
+
+const controller = createSandbox('report-widget', {
+  container: () => currentContainer,
+});
+
+await controller.mount();
+await controller.unmount();
+
+currentContainer = document.querySelector<HTMLElement>('#second')!;
+await controller.mount();
+```
+
+Calling `createSandbox('name')` without a container creates the JS-only preset. Its timer, window-listener, and history plugins can be activated with `mount()` without providing an arbitrary DOM element. `styleIsolation: true` requires a configured container.
+
+### Container preparation
+
+`createSandbox()` establishes its container contract automatically. Advanced hosts that compose the lower-level APIs can prepare a container directly:
+
+```ts
+import { prepareSandboxContainer } from '@qiankunjs/sandbox';
+
+const { styleIsolation, cleanup } = prepareSandboxContainer(container, 'report-widget');
+
+console.log(styleIsolation);
+// { appName: 'report-widget', scopeRoot: '[data-name="report-widget"]' }
+
+// Later, release only the attributes and virtual head created by this call.
+cleanup();
+```
+
+The helper sets `data-name`, ensures a `<qiankun-head>` mount point for the sandboxed `document.head`, and returns the matching style-isolation options. Cleanup is idempotent: it preserves an existing virtual head, restores a previous `data-name`, and does not overwrite a later host update to that attribute.
+
+## Default asset transformation
+
+The default `nodeTransformer` is isolation-preserving. A classic `<script>` dynamically appended by sandboxed code is fetched, wrapped with the controller's classic-script transformer, and executed through a blob URL. Dynamic styles and stylesheet links go through the same pipeline, including style scoping when enabled.
+
+You may provide a custom transformer. Returning each node unchanged is not a neutral optimization:
+
+```ts
+const controller = createSandbox('trusted-widget', {
+  container,
+  nodeTransformer: (node) => node,
+});
+```
+
+An identity transformer disables the default classic-script wrapping. A dynamically appended classic script can then execute against the host global. Use this override only when the host supplies equivalent isolation or fully trusts every script. The internal asset transpiler is intentionally not a public API; the supported extension point is `nodeTransformer`.
+
+For a custom HTML loading pipeline, use `controller.nodeTransformer`. It is the fully configured transformer shared with dynamic DOM interception, including the current Compartment, fetch implementation, classic-script wrapper, and style-isolation options.
+
+## Lifecycle ownership
+
+- `mount(container?)` activates or rebuilds timer, listener, history, DOM, and user-plugin effects. The argument overrides the configured container for that mount.
+- `unmount()` releases active effects and records any state required for a later mount. It does not run an application's own unmount function or clear caller-owned DOM.
+- `dispose()` permanently releases plugin effects, generated module resources, global accessors, and container preparation. It is safe to call more than once.
+
+Mount the controller before evaluating application code when its timers and listeners must participate in cleanup. Run the application's own teardown before `unmount()` or `dispose()`, and clear application DOM according to the host's ownership rules.
+
+## Isolation boundary
+
+This package is a compatibility sandbox, not a security boundary for hostile code.
+
+- Writes to the sandbox global stay local to that sandbox.
+- Reads fall through to the host window unless a value is configured or shadowed.
+- The membrane is non-transitive: objects crossing the boundary retain their identity. `===`, `instanceof`, DOM nodes, events, and shared library instances continue to work.
+- Mutating a host object obtained through read-through also mutates that shared object. Only the global property write is isolated.
+- DOM containment redirects the sandboxed `document.head` and `document.body`; it does not create a separate browser realm or origin.
+
+Use an iframe, Worker, or another origin/callable boundary for untrusted code. See the [Compartment Alignment RFC](../../docs/rfcs/compartment-alignment.md) for the rationale behind the write-isolation and identity-sharing model.
+
+## Content Security Policy
+
+Classic and ESM execution do not require `'unsafe-eval'`. They do require the page's `script-src` policy to allow `blob:` URLs. The ESM engine also injects an inline `script[type="importmap"]`, which must be permitted by the page's script policy. ESM and external classic assets are fetched first, so their origins must satisfy CORS and `connect-src` as well.
+
+Style isolation can create blob stylesheet URLs; allow `blob:` in `style-src` when external styles are used. Dynamically created inline `<style>` elements remain subject to the page's normal nonce, hash, or inline-style policy.
+
+```http
+Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline' blob:; connect-src 'self' https://widgets.example
+```
+
+This illustrative policy allows the runtime import map and a widget-created inline style. Tighten it to the assets and execution path the host actually uses. Do not add `'unsafe-eval'` for this package.
+
+## Further reading
+
+- [Standalone sandbox cookbook](../../docs/cookbook/standalone-sandbox.md)
+- [Extending sandbox isolation](../../docs/cookbook/sandbox-plugins.md)
+- [Standalone Sandbox RFC](../../docs/rfcs/standalone-sandbox.md)

--- a/packages/sandbox/src/__tests__/standalone.test.ts
+++ b/packages/sandbox/src/__tests__/standalone.test.ts
@@ -37,6 +37,27 @@ describe('standalone sandbox public journey', () => {
     await controller.dispose();
   });
 
+  it('leaves an explicitly mounted container untouched in the JS-only preset', async () => {
+    const container = appendContainer();
+    const controller = createSandbox('standalone-js-mount-target');
+
+    await controller.mount(container);
+
+    expect(container.hasAttribute('data-name')).toBe(false);
+    expect(container.querySelector('qiankun-head')).toBeNull();
+
+    await controller.unmount();
+    await controller.dispose();
+    expect(container.hasAttribute('data-name')).toBe(false);
+    expect(container.querySelector('qiankun-head')).toBeNull();
+  });
+
+  it('rejects style isolation without a container', () => {
+    expect(() => createSandbox('standalone-style-no-container', { styleIsolation: true })).toThrow(
+      /requires a container when style isolation is enabled/,
+    );
+  });
+
   it('uses an isolation-preserving default transformer for classic scripts', async () => {
     const controller = createSandbox('standalone-transformer');
     const script = document.createElement('script');

--- a/packages/sandbox/src/__tests__/standalone.test.ts
+++ b/packages/sandbox/src/__tests__/standalone.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as sandboxApi from '../index';
+import { createSandbox, prepareSandboxContainer, StandardSandbox } from '../index';
+
+const mountedContainers: HTMLElement[] = [];
+
+function appendContainer(): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  mountedContainers.push(container);
+  return container;
+}
+
+afterEach(() => {
+  mountedContainers.splice(0).forEach((container) => container.remove());
+  vi.restoreAllMocks();
+});
+
+describe('standalone sandbox public journey', () => {
+  it('creates a JS-only preset with appName as its only required input', async () => {
+    const controller = createSandbox('standalone-js');
+    const view = controller.instance.globalThis as unknown as Record<string, unknown>;
+    const listener = vi.fn();
+
+    expect(controller.instance).toBeInstanceOf(StandardSandbox);
+    expect('createSandboxContainer' in sandboxApi).toBe(false);
+    expect(view.window).toBe(controller.instance.globalThis);
+    expect(view.self).toBe(controller.instance.globalThis);
+    expect(view.globalThis).toBe(controller.instance.globalThis);
+
+    await controller.mount();
+    controller.instance.globalThis.addEventListener('standalone-event', listener);
+    await controller.unmount();
+    window.dispatchEvent(new Event('standalone-event'));
+
+    expect(listener).not.toHaveBeenCalled();
+    await controller.dispose();
+  });
+
+  it('uses an isolation-preserving default transformer for classic scripts', async () => {
+    const controller = createSandbox('standalone-transformer');
+    const script = document.createElement('script');
+    script.textContent = 'window.thirdPartyWrite = true;';
+
+    const transformed = controller.nodeTransformer(script, { fetch: window.fetch });
+
+    expect(transformed).toBe(script);
+    expect(script.dataset.consumed).toBe('true');
+    expect(script.textContent).toContain('window.__compartment_globalThis__');
+    expect(script.textContent).toContain('window.thirdPartyWrite = true;');
+    expect(window).not.toHaveProperty('thirdPartyWrite');
+    await controller.dispose();
+  });
+
+  it('contains dynamic DOM and scopes styles after a container-backed mount', async () => {
+    const container = appendContainer();
+    const controller = createSandbox('standalone-dom', { container, styleIsolation: true });
+
+    expect(container.dataset.name).toBe('standalone-dom');
+    expect(container.querySelector('qiankun-head')).toBeNull();
+
+    await controller.mount();
+    const sandboxDocument = controller.instance.globalThis.document;
+    const style = sandboxDocument.createElement('style');
+    style.textContent = '.widget { color: rebeccapurple; }';
+    sandboxDocument.head.appendChild(style);
+    const script = sandboxDocument.createElement('script');
+    script.textContent = 'window.dynamicWidgetLoaded = true;';
+    sandboxDocument.body.appendChild(script);
+
+    expect(container.querySelectorAll('qiankun-head')).toHaveLength(1);
+    expect(container.querySelector('qiankun-head')?.contains(style)).toBe(true);
+    expect(style.textContent).toContain('@scope ([data-name="standalone-dom"])');
+    expect(container.contains(script)).toBe(true);
+    expect(script.textContent).toContain('window.__compartment_globalThis__');
+
+    await controller.unmount();
+    await controller.dispose();
+    expect(container.querySelector('qiankun-head')).toBeNull();
+    expect(container.hasAttribute('data-name')).toBe(false);
+  });
+
+  it('resolves a container getter again when remounting', async () => {
+    const firstContainer = appendContainer();
+    const secondContainer = appendContainer();
+    let currentContainer = firstContainer;
+    const controller = createSandbox('standalone-remount', { container: () => currentContainer });
+
+    await controller.mount();
+    expect(firstContainer.querySelectorAll('qiankun-head')).toHaveLength(1);
+    await controller.unmount();
+
+    currentContainer = secondContainer;
+    await controller.mount();
+    expect(secondContainer.dataset.name).toBe('standalone-remount');
+    expect(secondContainer.querySelectorAll('qiankun-head')).toHaveLength(1);
+
+    await controller.dispose();
+    expect(firstContainer.querySelector('qiankun-head')).toBeNull();
+    expect(secondContainer.querySelector('qiankun-head')).toBeNull();
+  });
+
+  it('imports ESM namespaces through the public module hooks', async () => {
+    const importHook = vi.fn(async () => ({ namespace: { answer: 42 } }));
+    const controller = createSandbox('standalone-esm', {
+      importHook,
+      resolveHook: (specifier) => specifier,
+    });
+
+    await expect(controller.instance.import('widget:entry')).resolves.toEqual({ answer: 42 });
+    expect(importHook).toHaveBeenCalledWith('widget:entry');
+    await controller.dispose();
+  });
+
+  it('lets a top-level module-hook alias override the lower-level alias pair', async () => {
+    const lowerImportHook = vi.fn(async () => ({ namespace: { source: 'lower' } }));
+    const topLevelLoadHook = vi.fn(async () => ({ namespace: { source: 'top-level' } }));
+    const controller = createSandbox('standalone-hook-precedence', {
+      compartmentOptions: { importHook: lowerImportHook },
+      loadHook: topLevelLoadHook,
+      resolveHook: (specifier) => specifier,
+    });
+
+    await expect(controller.instance.import('widget:entry')).resolves.toEqual({ source: 'top-level' });
+    expect(topLevelLoadHook).toHaveBeenCalledWith('widget:entry');
+    expect(lowerImportHook).not.toHaveBeenCalled();
+    await controller.dispose();
+  });
+
+  it('uses the top-level fetch option for standalone ESM loading', async () => {
+    const fetch = vi.fn(async () => new Response('export const ready = true;', { status: 200 }));
+    const lowerLevelFetch = vi.fn(async () => new Response('export const ready = false;', { status: 200 }));
+    const moduleImporter = vi.fn(async () => ({ ready: true }));
+    const controller = createSandbox('standalone-fetch', {
+      compartmentOptions: {
+        moduleHost: {
+          createModuleUrl: () => 'blob:standalone-fetch',
+          fetch: lowerLevelFetch,
+          moduleImporter,
+          revokeModuleUrl: () => {},
+        },
+      },
+      fetch,
+    });
+
+    await expect(controller.instance.import('https://standalone.test/entry.js')).resolves.toEqual({ ready: true });
+    expect(fetch).toHaveBeenCalledWith('https://standalone.test/entry.js', undefined);
+    expect(lowerLevelFetch).not.toHaveBeenCalled();
+    expect(moduleImporter).toHaveBeenCalledWith('blob:standalone-fetch');
+    await controller.dispose();
+  });
+
+  it('preserves the lower-level module fetch when no top-level fetch is provided', async () => {
+    const fetch = vi.fn(async () => new Response('export const ready = true;', { status: 200 }));
+    const moduleImporter = vi.fn(async () => ({ ready: true }));
+    const controller = createSandbox('standalone-lower-fetch', {
+      compartmentOptions: {
+        moduleHost: {
+          createModuleUrl: () => 'blob:standalone-lower-fetch',
+          fetch,
+          moduleImporter,
+          revokeModuleUrl: () => {},
+        },
+      },
+    });
+
+    await expect(controller.instance.import('https://standalone.test/lower.js')).resolves.toEqual({ ready: true });
+    expect(fetch).toHaveBeenCalledWith('https://standalone.test/lower.js', undefined);
+    await controller.dispose();
+  });
+
+  it('uses the top-level fetch option for external dynamic classic scripts', async () => {
+    const fetch = vi.fn(async () => new Response('window.dynamicAssetLoaded = true;', { status: 200 }));
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:standalone-dynamic-fetch');
+    const controller = createSandbox('standalone-dynamic-fetch', { fetch });
+    const script = document.createElement('script');
+    script.setAttribute('src', 'https://standalone.test/widget.js');
+
+    controller.nodeTransformer(script, { fetch: window.fetch });
+
+    expect(fetch).toHaveBeenCalledWith('https://standalone.test/widget.js', {
+      credentials: undefined,
+      priority: 'high',
+    });
+    await vi.waitFor(() => expect(script.src).toBe('blob:standalone-dynamic-fetch'));
+    await controller.dispose();
+  });
+});
+
+describe('prepareSandboxContainer', () => {
+  it('reuses an existing head and restores the previous data-name on cleanup', () => {
+    const container = appendContainer();
+    container.dataset.name = 'host-owned';
+    const existingHead = document.createElement('qiankun-head');
+    container.appendChild(existingHead);
+
+    const preparation = prepareSandboxContainer(container, 'prepared-app');
+
+    expect(preparation.styleIsolation).toEqual({
+      appName: 'prepared-app',
+      scopeRoot: '[data-name="prepared-app"]',
+    });
+    expect(container.querySelectorAll('qiankun-head')).toHaveLength(1);
+    expect(container.querySelector('qiankun-head')).toBe(existingHead);
+
+    preparation.cleanup();
+    preparation.cleanup();
+    expect(container.dataset.name).toBe('host-owned');
+    expect(container.querySelector('qiankun-head')).toBe(existingHead);
+  });
+
+  it('removes only the head and data-name created by the helper', () => {
+    const container = appendContainer();
+    const { cleanup } = prepareSandboxContainer(container, 'prepared-app');
+
+    expect(container.querySelectorAll('qiankun-head')).toHaveLength(1);
+    expect(container.dataset.name).toBe('prepared-app');
+
+    cleanup();
+    expect(container.querySelector('qiankun-head')).toBeNull();
+    expect(container.hasAttribute('data-name')).toBe(false);
+  });
+
+  it('keeps shared preparation state until the last owner cleans up', () => {
+    const container = appendContainer();
+    const first = prepareSandboxContainer(container, 'shared-app');
+    const second = prepareSandboxContainer(container, 'shared-app');
+
+    first.cleanup();
+    expect(container.dataset.name).toBe('shared-app');
+    expect(container.querySelectorAll('qiankun-head')).toHaveLength(1);
+
+    second.cleanup();
+    expect(container.hasAttribute('data-name')).toBe(false);
+    expect(container.querySelector('qiankun-head')).toBeNull();
+  });
+
+  it('preserves a host data-name update made after preparation', () => {
+    const container = appendContainer();
+    const { cleanup } = prepareSandboxContainer(container, 'prepared-app');
+
+    container.dataset.name = 'host-update';
+    cleanup();
+
+    expect(container.dataset.name).toBe('host-update');
+    expect(container.querySelector('qiankun-head')).toBeNull();
+  });
+});

--- a/packages/sandbox/src/core/compartment/__tests__/index.test.ts
+++ b/packages/sandbox/src/core/compartment/__tests__/index.test.ts
@@ -6,6 +6,7 @@ import {
   type DocumentModule,
   type ModuleNamespace,
   type Sandbox,
+  StandardSandbox,
 } from '../../../index';
 import { type MembraneTarget } from '../../membrane';
 
@@ -289,6 +290,77 @@ describe('classic script evaluation', () => {
     const generatedSource = await generatedBlob!.text();
     expect(generatedSource).toContain('original();\ntransformed();');
     expect(generatedSource).not.toMatch(/\beval\s*\(|new Function/);
+  });
+
+  it('warns once per bare Compartment in development and points classic users to StandardSandbox', async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:compartment-warning');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    vi.spyOn(document.head, 'appendChild').mockImplementation((node) => {
+      queueMicrotask(() => node.dispatchEvent(new Event('load')));
+      return node;
+    });
+
+    try {
+      const compartment = new Compartment({ name: 'unsafe-classic' });
+      await compartment.evaluateScript('void window;');
+      await compartment.evaluateScript('void window;');
+
+      expect(warning).toHaveBeenCalledOnce();
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('Use StandardSandbox'));
+      compartment.dispose();
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
+  it('does not warn when StandardSandbox installs the window self-reference', async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:standard-sandbox-warning');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    vi.spyOn(document.head, 'appendChild').mockImplementation((node) => {
+      queueMicrotask(() => node.dispatchEvent(new Event('load')));
+      return node;
+    });
+
+    try {
+      const sandbox = new StandardSandbox('safe-classic');
+      await sandbox.evaluateScript('void window;');
+
+      expect(warning).not.toHaveBeenCalled();
+      sandbox.dispose();
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+
+  it('does not warn when a Compartment host installs its own window self-reference', async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:custom-self-reference-warning');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    vi.spyOn(document.head, 'appendChild').mockImplementation((node) => {
+      queueMicrotask(() => node.dispatchEvent(new Event('load')));
+      return node;
+    });
+
+    try {
+      const compartment = new Compartment({ name: 'custom-self-reference' });
+      compartment.defineUnshadowableGlobals({
+        window: { get: () => compartment.globalThis, configurable: true },
+      });
+      await compartment.evaluateScript('void window;');
+
+      expect(warning).not.toHaveBeenCalled();
+      compartment.dispose();
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
   });
 
   it('cancels a queued classic evaluation when the compartment is disposed', async () => {

--- a/packages/sandbox/src/core/compartment/index.ts
+++ b/packages/sandbox/src/core/compartment/index.ts
@@ -68,6 +68,8 @@ export class Compartment implements CompartmentLoaderFacade {
 
   private disposed = false;
 
+  private unsafeClassicEvaluationWarned = false;
+
   private readonly pendingClassicEvaluations = new Set<PendingClassicEvaluation>();
 
   private unshadowableGlobalNames = defaultUnshadowableGlobalNames.slice();
@@ -172,6 +174,7 @@ export class Compartment implements CompartmentLoaderFacade {
    */
   async evaluateScript(source: string, options: EvaluateScriptOptions = {}): Promise<void> {
     const code = this.transformClassicScript(source, options.sourceURL);
+    this.warnAboutUnsafeClassicSelfReference();
     const script = nativeDocument.createElement('script');
     const blobUrl = URL.createObjectURL(new Blob([code], { type: 'text/javascript' }));
 
@@ -303,6 +306,21 @@ export class Compartment implements CompartmentLoaderFacade {
     this.assertAlive();
     this.moduleEngine ??= new EsmSandboxEngine(this.moduleEngineOptions);
     return this.moduleEngine;
+  }
+
+  private warnAboutUnsafeClassicSelfReference(): void {
+    if (process.env.NODE_ENV !== 'development' || this.unsafeClassicEvaluationWarned) return;
+
+    const hasWindowSelfReference =
+      this.definedUnshadowableGlobalNames.has('window') && this.globalThis.window === this.globalThis;
+    if (!hasWindowSelfReference) {
+      this.unsafeClassicEvaluationWarned = true;
+      console.warn(
+        `[qiankun:sandbox] Compartment ${
+          this.name || '(anonymous)'
+        } evaluates classic scripts without an isolated window self-reference. Use StandardSandbox for classic script evaluation.`,
+      );
+    }
   }
 
   private assertAlive(): void {

--- a/packages/sandbox/src/core/sandbox/StandardSandbox.ts
+++ b/packages/sandbox/src/core/sandbox/StandardSandbox.ts
@@ -28,7 +28,7 @@ export class StandardSandbox extends Compartment implements Sandbox {
 
   constructor(
     name: string,
-    globals: CompartmentGlobals,
+    globals: CompartmentGlobals = {},
     incubatorContext: WindowProxy = window,
     options: Omit<CompartmentOptions, 'globals' | 'incubatorContext' | 'name'> = {},
   ) {

--- a/packages/sandbox/src/core/sandbox/__tests__/index.test.ts
+++ b/packages/sandbox/src/core/sandbox/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import { nativeGlobal } from '../../../consts';
 import { Compartment } from '../../compartment';
 import { defaultIsolationPlugins } from '../../../patchers';
 import type { Free, IsolationPlugin, IsolationPluginConfig, Rebuild } from '../../../patchers/types';
-import { createSandboxContainer } from '..';
+import { createSandbox } from '..';
 import { SandboxType } from '../types';
 
 const standardDefaultPlugins = defaultIsolationPlugins[SandboxType.Standard];
@@ -17,7 +17,8 @@ const createdCompartments: Compartment[] = [];
 
 function createContainer(plugins: readonly IsolationPlugin[] = []) {
   const container = document.createElement('div');
-  const controller = createSandboxContainer(`plugin-lifecycle-${String(appSequence++)}`, () => container, {
+  const controller = createSandbox(`plugin-lifecycle-${String(appSequence++)}`, {
+    container: () => container,
     fetch: window.fetch,
     nodeTransformer: identityNodeTransformer,
     plugins,
@@ -117,6 +118,33 @@ describe('isolation plugin lifecycle', () => {
     await mounting;
     expect(events).toEqual(['mount:async-first', 'mount:sync-second']);
     await controller.unmount();
+  });
+
+  it('rejects a second mount until the active mount has been unmounted', async () => {
+    const mountingFree = vi.fn(() => noopRebuild);
+    const mountHook = vi.fn(() => mountingFree);
+    const { container, controller } = createContainer([{ name: 'single-mount', mount: mountHook }]);
+
+    await controller.mount(container);
+    await expect(controller.mount(container)).rejects.toThrowError('is already mounted');
+    await controller.unmount();
+
+    expect(mountHook).toHaveBeenCalledOnce();
+    expect(mountingFree).toHaveBeenCalledOnce();
+  });
+
+  it('rejects mounting while an unmount is in flight and allows the next mount afterward', async () => {
+    const mountHook = vi.fn(() => noopFree);
+    const { container, controller } = createContainer([{ name: 'serialized-transition', mount: mountHook }]);
+
+    await controller.mount(container);
+    const unmounting = controller.unmount();
+    await expect(controller.mount(container)).rejects.toThrowError('is currently unmounting');
+    await unmounting;
+
+    await controller.mount(container);
+    await controller.unmount();
+    expect(mountHook).toHaveBeenCalledTimes(2);
   });
 
   it('frees and rebuilds bootstrap and mount effects in registration order', async () => {
@@ -394,7 +422,8 @@ describe('isolation plugin lifecycle', () => {
       Object.getOwnPropertyNames(nativeGlobal).filter((key) => key.startsWith('__compartment_globalThis__')),
     );
     const container = document.createElement('div');
-    const controller = createSandboxContainer(`controller-dispose-${String(appSequence++)}`, () => container, {
+    const controller = createSandbox(`controller-dispose-${String(appSequence++)}`, {
+      container: () => container,
       compartmentOptions: {
         moduleHost: {
           createModuleUrl,

--- a/packages/sandbox/src/core/sandbox/container.ts
+++ b/packages/sandbox/src/core/sandbox/container.ts
@@ -1,0 +1,138 @@
+import { isLoaderStreamedNode, type StyleIsolationOpts } from '@qiankunjs/shared';
+import { nativeDocument, qiankunHeadTagName } from '../../consts';
+
+export interface SandboxContainerPreparation {
+  styleIsolation: StyleIsolationOpts;
+  cleanup: () => void;
+}
+
+interface HeadPreparationState {
+  head: HTMLElement;
+  owners: Set<symbol>;
+}
+
+interface NamePreparationState {
+  originalHadName: boolean;
+  originalName: string | null;
+  owners: Array<{ appName: string; token: symbol }>;
+}
+
+const headPreparationStates = new WeakMap<HTMLElement, HeadPreparationState>();
+const namePreparationStates = new WeakMap<HTMLElement, NamePreparationState>();
+
+export function createStyleIsolationOpts(appName: string): StyleIsolationOpts {
+  return { appName, scopeRoot: `[data-name="${appName}"]` };
+}
+
+export function containsLoaderStreamedNode(container: HTMLElement): boolean {
+  return Array.from(container.querySelectorAll('*')).some(isLoaderStreamedNode);
+}
+
+export function ensureSandboxContainerHead(container: HTMLElement): {
+  head: HTMLElement;
+  cleanup: () => void;
+} {
+  const existingHead = container.querySelector<HTMLElement>(qiankunHeadTagName);
+  const existingState = headPreparationStates.get(container);
+  if (existingHead && existingState?.head === existingHead) {
+    const token = Symbol('sandbox-container-head-owner');
+    existingState.owners.add(token);
+    return {
+      head: existingHead,
+      cleanup: () => {
+        const currentState = headPreparationStates.get(container);
+        if (currentState !== existingState || !currentState.owners.delete(token) || currentState.owners.size > 0)
+          return;
+        if (currentState.head.parentNode === container) container.removeChild(currentState.head);
+        headPreparationStates.delete(container);
+      },
+    };
+  }
+  if (existingHead) {
+    return { head: existingHead, cleanup: () => {} };
+  }
+
+  const head = nativeDocument.createElement(qiankunHeadTagName);
+  const token = Symbol('sandbox-container-head-owner');
+  const state: HeadPreparationState = { head, owners: new Set([token]) };
+  headPreparationStates.set(container, state);
+  container.insertBefore(head, container.firstChild);
+
+  let cleaned = false;
+  return {
+    head,
+    cleanup: () => {
+      if (cleaned) return;
+      cleaned = true;
+      const currentState = headPreparationStates.get(container);
+      if (currentState !== state || !currentState.owners.delete(token) || currentState.owners.size > 0) return;
+      if (head.parentNode === container) container.removeChild(head);
+      headPreparationStates.delete(container);
+    },
+  };
+}
+
+export function prepareSandboxContainerName(container: HTMLElement, appName: string): () => void {
+  let state = namePreparationStates.get(container);
+  if (!state) {
+    state = {
+      originalHadName: container.hasAttribute('data-name'),
+      originalName: container.getAttribute('data-name'),
+      owners: [],
+    };
+    namePreparationStates.set(container, state);
+  }
+  const token = Symbol('sandbox-container-name-owner');
+  state.owners.push({ appName, token });
+  container.dataset.name = appName;
+
+  let cleaned = false;
+  return () => {
+    if (cleaned) return;
+    cleaned = true;
+    const currentState = namePreparationStates.get(container);
+    if (currentState !== state) return;
+    const ownerIndex = currentState.owners.findIndex((owner) => owner.token === token);
+    if (ownerIndex < 0) return;
+    const wasCurrentOwner = ownerIndex === currentState.owners.length - 1;
+    currentState.owners.splice(ownerIndex, 1);
+    if (!wasCurrentOwner || container.dataset.name !== appName) {
+      if (!currentState.owners.length) namePreparationStates.delete(container);
+      return;
+    }
+
+    const previousOwner = currentState.owners.at(-1);
+    if (previousOwner) {
+      container.dataset.name = previousOwner.appName;
+      return;
+    }
+    if (currentState.originalHadName && currentState.originalName !== null) {
+      container.setAttribute('data-name', currentState.originalName);
+    } else {
+      container.removeAttribute('data-name');
+    }
+    namePreparationStates.delete(container);
+  };
+}
+
+/**
+ * Establish the DOM contract used by the standard sandbox preset.
+ *
+ * Cleanup only reverts state created by this call: an existing head is kept and
+ * a host update made after preparation is never overwritten.
+ */
+export function prepareSandboxContainer(container: HTMLElement, appName: string): SandboxContainerPreparation {
+  const cleanupName = prepareSandboxContainerName(container, appName);
+  const { cleanup: cleanupHead } = ensureSandboxContainerHead(container);
+  let cleaned = false;
+
+  return {
+    styleIsolation: createStyleIsolationOpts(appName),
+    cleanup: () => {
+      if (cleaned) return;
+      cleaned = true;
+      cleanupHead();
+      cleanupName();
+    },
+  };
+}

--- a/packages/sandbox/src/core/sandbox/index.ts
+++ b/packages/sandbox/src/core/sandbox/index.ts
@@ -2,7 +2,7 @@
  * @author Kuitos
  * @since 2019-04-11
  */
-import { nativeDocument, nativeGlobal } from '../../consts';
+import { nativeDocument, nativeGlobal, qiankunHeadTagName } from '../../consts';
 import { getDefaultIsolationPlugins } from '../../patchers';
 import type { Free, IsolationPlugin, IsolationPluginContext, Rebuild } from '../../patchers/types';
 import {
@@ -39,6 +39,11 @@ export interface CreateSandboxOptions {
   importHook?: ImportHook;
   loadHook?: ImportHook;
   plugins?: readonly IsolationPlugin[];
+  /**
+   * Enable runtime CSS isolation via @scope wrapping: all sandboxed styles are scoped to the
+   * container. Dynamically injected styles ride on the sandbox's DOM interception, which is
+   * why style isolation requires a configured container.
+   */
   styleIsolation?: boolean;
   fetch?: typeof window.fetch;
   nodeTransformer?: NodeTransformer;
@@ -118,7 +123,7 @@ export function createSandbox(appName: string, opts: CreateSandboxOptions = {}):
   } = opts;
   const hasContainer = containerOption !== undefined;
   if (styleIsolationEnabled && !hasContainer) {
-    throw new TypeError(`Sandbox ${appName} requires a container when style isolation is enabled`);
+    throw new QiankunError(`Sandbox ${appName} requires a container when style isolation is enabled`);
   }
 
   const hasTopLevelModuleHook = topLevelImportHook !== undefined || topLevelLoadHook !== undefined;
@@ -145,7 +150,7 @@ export function createSandbox(appName: string, opts: CreateSandboxOptions = {}):
   };
   const prepareContainerForMount = (container: HTMLElement): void => {
     prepareContainerName(container);
-    if (!container.querySelector('qiankun-head') && !containsLoaderStreamedNode(container)) {
+    if (!container.querySelector(qiankunHeadTagName) && !containsLoaderStreamedNode(container)) {
       const { cleanup } = ensureSandboxContainerHead(container);
       const cleanups = containerHeadCleanups.get(container) ?? [];
       cleanups.push(cleanup);
@@ -194,7 +199,8 @@ export function createSandbox(appName: string, opts: CreateSandboxOptions = {}):
     configuredNodeTransformer ??
     ((node, transformerOpts) => transpileAssets(node, nativeDocument.baseURI, transformerOpts));
   const nodeTransformer: NodeTransformer = (node, transformerOpts) => {
-    const container = getConfiguredContainer();
+    // The JS-only preset owns no container contract, even when a mount received one.
+    const container = hasContainer ? getConfiguredContainer() : undefined;
     if (container) prepareContainerName(container);
     return baseNodeTransformer(node, {
       ...transformerOpts,
@@ -307,7 +313,7 @@ export function createSandbox(appName: string, opts: CreateSandboxOptions = {}):
 
   const mount = async (container: HTMLElement | undefined): Promise<void> => {
     assertNotDisposed();
-    if (container) prepareContainerForMount(container);
+    if (hasContainer && container) prepareContainerForMount(container);
     /* ------------------------------------------ 因为有上下文依赖（window），以下代码执行顺序不能变 ------------------------------------------ */
 
     /* ------------------------------------------ 1. 启动/恢复 沙箱------------------------------------------ */

--- a/packages/sandbox/src/core/sandbox/index.ts
+++ b/packages/sandbox/src/core/sandbox/index.ts
@@ -2,17 +2,72 @@
  * @author Kuitos
  * @since 2019-04-11
  */
+import { nativeDocument, nativeGlobal } from '../../consts';
 import { getDefaultIsolationPlugins } from '../../patchers';
-import type { SandboxConfig } from '../../patchers/dynamicAppend/types';
 import type { Free, IsolationPlugin, IsolationPluginContext, Rebuild } from '../../patchers/types';
+import {
+  QiankunError,
+  transpileAssets,
+  type ImportHook,
+  type Modules,
+  type NodeTransformer,
+  type ResolveHook,
+  type StyleIsolationOpts,
+} from '@qiankunjs/shared';
 import type { CompartmentGlobals, CompartmentOptions } from '../compartment';
 import { StandardSandbox } from './StandardSandbox';
+import {
+  containsLoaderStreamedNode,
+  createStyleIsolationOpts,
+  ensureSandboxContainerHead,
+  prepareSandboxContainerName,
+} from './container';
 import type { Sandbox } from './types';
 
 export type { Sandbox };
+export { StandardSandbox } from './StandardSandbox';
+export { prepareSandboxContainer, type SandboxContainerPreparation } from './container';
+
+export interface CreateSandboxOptions {
+  /** Providing a container enables DOM containment and dynamic asset interception. */
+  container?: HTMLElement | (() => HTMLElement);
+  /** The host context that incubates this sandbox (see the ShadowRealm proposal's "incubator realm"). */
+  incubatorContext?: WindowProxy;
+  globals?: CompartmentGlobals;
+  modules?: Modules;
+  resolveHook?: ResolveHook;
+  importHook?: ImportHook;
+  loadHook?: ImportHook;
+  plugins?: readonly IsolationPlugin[];
+  styleIsolation?: boolean;
+  fetch?: typeof window.fetch;
+  nodeTransformer?: NodeTransformer;
+  /**
+   * Lower-level Compartment host configuration. Promoted top-level options take
+   * precedence when the same field is supplied in both places.
+   */
+  compartmentOptions?: Omit<CompartmentOptions, 'globals' | 'incubatorContext' | 'name'>;
+}
+
+export interface SandboxController {
+  instance: Sandbox;
+  /** The fully configured transformer shared by loaders and dynamic DOM interception. */
+  nodeTransformer: NodeTransformer;
+  styleIsolation?: StyleIsolationOpts;
+  mount(container?: HTMLElement): Promise<void>;
+  unmount(): Promise<void>;
+  dispose(): Promise<void>;
+}
 
 interface CapturedError {
   value: unknown;
+}
+
+function normalizeModuleHook(importHook?: ImportHook, loadHook?: ImportHook): ImportHook | undefined {
+  if (importHook && loadHook && importHook !== loadHook) {
+    throw new QiankunError('importHook and loadHook must reference the same hook when both are provided');
+  }
+  return importHook ?? loadHook;
 }
 
 function releaseSideEffects(frees: readonly Free[]): {
@@ -33,7 +88,11 @@ function releaseSideEffects(frees: readonly Free[]): {
   return { rebuilds, error: firstError };
 }
 
-async function rebuildSideEffects(rebuilds: Rebuild[], container: HTMLElement, afterEach?: () => void): Promise<void> {
+async function rebuildSideEffects(
+  rebuilds: Rebuild[],
+  container: HTMLElement | undefined,
+  afterEach?: () => void,
+): Promise<void> {
   while (rebuilds.length) {
     await rebuilds[0](container);
     rebuilds.shift();
@@ -41,50 +100,121 @@ async function rebuildSideEffects(rebuilds: Rebuild[], container: HTMLElement, a
   }
 }
 
-/**
- * @param appName
- * @param getContainer
- * @param opts
- */
-export function createSandboxContainer(
-  appName: string,
-  getContainer: () => HTMLElement,
-  opts: {
-    /** The host context that incubates this sandbox (see the ShadowRealm proposal's "incubator realm"). */
-    incubatorContext?: WindowProxy;
-    globals?: CompartmentGlobals;
-    plugins?: readonly IsolationPlugin[];
-    compartmentOptions?: Omit<CompartmentOptions, 'globals' | 'incubatorContext' | 'name'>;
-  } & Pick<SandboxConfig, 'fetch' | 'nodeTransformer' | 'styleIsolation'>,
-) {
-  const { compartmentOptions, incubatorContext, globals = {}, plugins = [], ...sandboxCfg } = opts;
+/** Create a lifecycle controller around the standard browser sandbox preset. */
+export function createSandbox(appName: string, opts: CreateSandboxOptions = {}): SandboxController {
+  const {
+    compartmentOptions = {},
+    container: containerOption,
+    fetch: configuredFetch,
+    globals = {},
+    importHook: topLevelImportHook,
+    incubatorContext = nativeGlobal,
+    loadHook: topLevelLoadHook,
+    modules = compartmentOptions.modules,
+    nodeTransformer: configuredNodeTransformer,
+    plugins = [],
+    resolveHook = compartmentOptions.resolveHook,
+    styleIsolation: styleIsolationEnabled = false,
+  } = opts;
+  const hasContainer = containerOption !== undefined;
+  if (styleIsolationEnabled && !hasContainer) {
+    throw new TypeError(`Sandbox ${appName} requires a container when style isolation is enabled`);
+  }
+
+  const hasTopLevelModuleHook = topLevelImportHook !== undefined || topLevelLoadHook !== undefined;
+  const moduleHook = normalizeModuleHook(
+    hasTopLevelModuleHook ? topLevelImportHook : compartmentOptions.importHook,
+    hasTopLevelModuleHook ? topLevelLoadHook : compartmentOptions.loadHook,
+  );
+  const fetch = configuredFetch ?? compartmentOptions.moduleHost?.fetch ?? nativeGlobal.fetch.bind(nativeGlobal);
+  const styleIsolation = styleIsolationEnabled ? createStyleIsolationOpts(appName) : undefined;
+  const containerNameCleanups = new Map<HTMLElement, () => void>();
+  const containerHeadCleanups = new Map<HTMLElement, Array<() => void>>();
+  let mountedContainer: HTMLElement | undefined;
+  const getConfiguredContainer = (): HTMLElement | undefined => {
+    if (mountedContainer) return mountedContainer;
+    if (typeof containerOption === 'function') return containerOption();
+    return containerOption;
+  };
+  const prepareContainerName = (container: HTMLElement): void => {
+    if (!containerNameCleanups.has(container)) {
+      containerNameCleanups.set(container, prepareSandboxContainerName(container, appName));
+    } else {
+      container.dataset.name = appName;
+    }
+  };
+  const prepareContainerForMount = (container: HTMLElement): void => {
+    prepareContainerName(container);
+    if (!container.querySelector('qiankun-head') && !containsLoaderStreamedNode(container)) {
+      const { cleanup } = ensureSandboxContainerHead(container);
+      const cleanups = containerHeadCleanups.get(container) ?? [];
+      cleanups.push(cleanup);
+      containerHeadCleanups.set(container, cleanups);
+    }
+  };
+  const cleanupPreparedContainers = (): void => {
+    containerHeadCleanups.forEach((cleanups) => {
+      cleanups
+        .slice()
+        .reverse()
+        .forEach((cleanup) => cleanup());
+    });
+    containerHeadCleanups.clear();
+    containerNameCleanups.forEach((cleanup) => cleanup());
+    containerNameCleanups.clear();
+  };
+
+  const initialContainer = getConfiguredContainer();
+  if (initialContainer) prepareContainerName(initialContainer);
+
+  const standardSandboxOptions = {
+    ...compartmentOptions,
+    importHook: moduleHook,
+    loadHook: moduleHook,
+    modules,
+    resolveHook,
+    moduleHost: {
+      ...compartmentOptions.moduleHost,
+      fetch,
+    },
+  };
+
   let sandbox: Sandbox;
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (window.Proxy) {
-    sandbox = new StandardSandbox(appName, globals, incubatorContext, compartmentOptions);
+    sandbox = new StandardSandbox(appName, globals, incubatorContext, standardSandboxOptions);
   } else {
     // TODO snapshot sandbox
-    sandbox = new StandardSandbox(appName, globals, incubatorContext, compartmentOptions);
+    sandbox = new StandardSandbox(appName, globals, incubatorContext, standardSandboxOptions);
   }
 
   const classicScriptTransformer = (source: string, sourceURL?: string) =>
     sandbox.transformClassicScript(source, sourceURL);
-  const pluginNodeTransformer: SandboxConfig['nodeTransformer'] = (node, transformerOpts) =>
-    sandboxCfg.nodeTransformer(node, {
+  const baseNodeTransformer: NodeTransformer =
+    configuredNodeTransformer ??
+    ((node, transformerOpts) => transpileAssets(node, nativeDocument.baseURI, transformerOpts));
+  const nodeTransformer: NodeTransformer = (node, transformerOpts) => {
+    const container = getConfiguredContainer();
+    if (container) prepareContainerName(container);
+    return baseNodeTransformer(node, {
       ...transformerOpts,
       classicScriptTransformer,
       compartment: sandbox,
+      fetch,
+      styleIsolation,
     });
+  };
   const pluginContext: IsolationPluginContext = {
     compartment: sandbox,
     appName,
-    getContainer,
+    getContainer: getConfiguredContainer,
     config: {
-      ...sandboxCfg,
-      nodeTransformer: pluginNodeTransformer,
+      fetch,
+      nodeTransformer,
+      styleIsolation,
     },
   };
-  const isolationPlugins = [...getDefaultIsolationPlugins(sandbox.type), ...plugins];
+  const isolationPlugins = [...getDefaultIsolationPlugins(sandbox.type, hasContainer), ...plugins];
 
   // Bootstrap plugins are installed before loadEntry starts evaluating application scripts.
   const bootstrappingFrees: Free[] = [];
@@ -98,6 +228,7 @@ export function createSandboxContainer(
     releaseSideEffects(bootstrappingFrees);
     sandbox.inactive();
     sandbox.dispose();
+    cleanupPreparedContainers();
     throw error;
   }
 
@@ -107,8 +238,10 @@ export function createSandboxContainer(
   let mountingRebuilds: Rebuild[] = [];
   let bootstrappingEffectsActive = bootstrappingFrees.length > 0;
   let mountingEffectsActive = false;
+  let mounted = false;
   let disposed = false;
   let mountingPromise: Promise<void> | undefined;
+  let unmountingPromise: Promise<void> | undefined;
   let disposePromise: Promise<void> | undefined;
 
   const disposedError = () => new TypeError(`Sandbox container for ${appName} has been disposed`);
@@ -122,6 +255,7 @@ export function createSandboxContainer(
     disposed = true;
 
     const pendingMount = mountingPromise;
+    const pendingUnmount = unmountingPromise;
     const pendingDispose = (async () => {
       // A mount hook can install effects before its promise yields the matching Free.
       // Wait for that operation to observe `disposed`, roll back its local frees, and
@@ -130,6 +264,11 @@ export function createSandboxContainer(
         await pendingMount;
       } catch {
         // The mount caller retains its own failure; disposal still has to finish.
+      }
+      try {
+        await pendingUnmount;
+      } catch {
+        // The unmount caller retains its own failure; disposal still has to finish.
       }
 
       const bootstrappingRelease = bootstrappingEffectsActive
@@ -148,6 +287,9 @@ export function createSandboxContainer(
 
       sandbox.inactive();
       sandbox.dispose();
+      cleanupPreparedContainers();
+      mountedContainer = undefined;
+      mounted = false;
 
       const firstError = bootstrappingRelease.error ?? mountingRelease.error;
       if (firstError) {
@@ -163,8 +305,9 @@ export function createSandboxContainer(
     }
   };
 
-  const mount = async (container: HTMLElement): Promise<void> => {
+  const mount = async (container: HTMLElement | undefined): Promise<void> => {
     assertNotDisposed();
+    if (container) prepareContainerForMount(container);
     /* ------------------------------------------ 因为有上下文依赖（window），以下代码执行顺序不能变 ------------------------------------------ */
 
     /* ------------------------------------------ 1. 启动/恢复 沙箱------------------------------------------ */
@@ -214,8 +357,50 @@ export function createSandboxContainer(
     }
   };
 
+  const unmount = async (): Promise<void> => {
+    if (disposed) return;
+
+    try {
+      await mountingPromise;
+    } catch {
+      // A failed mount already rolled back every effect it managed to install.
+    }
+    // `dispose()` can flip this flag while the mount promise above is pending.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (disposed) return;
+
+    // record the rebuilds of window side effects (event listeners or timers)
+    // note that the frees of mounting phase are one-off as it will be re-init at next mounting
+    // Only overwrite the captured rebuilds when this call actually released live effects.
+    // With inactive effects (a repeated unmount, or an unmount after a failed mount that
+    // already rolled back), the rebuilds captured earlier must survive for the next mount.
+    const bootstrappingRelease = bootstrappingEffectsActive ? releaseSideEffects(bootstrappingFrees) : undefined;
+    const mountingRelease = mountingEffectsActive ? releaseSideEffects(mountingFrees) : undefined;
+
+    if (bootstrappingRelease) {
+      bootstrappingRebuilds = bootstrappingRelease.rebuilds;
+      bootstrappingEffectsActive = false;
+    }
+    if (mountingRelease) {
+      mountingRebuilds = mountingRelease.rebuilds;
+      mountingFrees = [];
+      mountingEffectsActive = false;
+    }
+
+    sandbox.inactive();
+    mountedContainer = undefined;
+    mounted = false;
+
+    const firstError = bootstrappingRelease?.error ?? mountingRelease?.error;
+    if (firstError) {
+      throw firstError.value;
+    }
+  };
+
   return {
     instance: sandbox,
+    nodeTransformer,
+    styleIsolation,
 
     /** Permanently release plugin side effects and the underlying Compartment. */
     dispose,
@@ -225,14 +410,33 @@ export function createSandboxContainer(
      * 可能是从 bootstrap 状态进入的 mount
      * 也可能是从 unmount 之后再次唤醒进入 mount
      */
-    mount(container: HTMLElement) {
+    mount(container?: HTMLElement) {
+      if (disposed) {
+        return Promise.reject(disposedError());
+      }
       if (mountingPromise) {
         return Promise.reject(new TypeError(`Sandbox container for ${appName} is already mounting`));
       }
+      if (unmountingPromise) {
+        return Promise.reject(new TypeError(`Sandbox container for ${appName} is currently unmounting`));
+      }
+      if (mounted) {
+        return Promise.reject(new TypeError(`Sandbox container for ${appName} is already mounted`));
+      }
 
-      const trackedMount = mount(container).finally(() => {
-        if (mountingPromise === trackedMount) mountingPromise = undefined;
-      });
+      mountedContainer = container ?? getConfiguredContainer();
+      const trackedMount = mount(mountedContainer)
+        .then(() => {
+          mounted = true;
+        })
+        .catch((error: unknown) => {
+          mountedContainer = undefined;
+          mounted = false;
+          throw error;
+        })
+        .finally(() => {
+          if (mountingPromise === trackedMount) mountingPromise = undefined;
+        });
       mountingPromise = trackedMount;
       return trackedMount;
     },
@@ -240,42 +444,14 @@ export function createSandboxContainer(
     /**
      * 恢复 global 状态，使其能回到应用加载之前的状态
      */
-    async unmount() {
-      if (disposed) return;
+    unmount() {
+      if (unmountingPromise) return unmountingPromise;
 
-      try {
-        await mountingPromise;
-      } catch {
-        // A failed mount already rolled back every effect it managed to install.
-      }
-      // `dispose()` can flip this flag while the mount promise above is pending.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (disposed) return;
-
-      // record the rebuilds of window side effects (event listeners or timers)
-      // note that the frees of mounting phase are one-off as it will be re-init at next mounting
-      // Only overwrite the captured rebuilds when this call actually released live effects.
-      // With inactive effects (a repeated unmount, or an unmount after a failed mount that
-      // already rolled back), the rebuilds captured earlier must survive for the next mount.
-      const bootstrappingRelease = bootstrappingEffectsActive ? releaseSideEffects(bootstrappingFrees) : undefined;
-      const mountingRelease = mountingEffectsActive ? releaseSideEffects(mountingFrees) : undefined;
-
-      if (bootstrappingRelease) {
-        bootstrappingRebuilds = bootstrappingRelease.rebuilds;
-        bootstrappingEffectsActive = false;
-      }
-      if (mountingRelease) {
-        mountingRebuilds = mountingRelease.rebuilds;
-        mountingFrees = [];
-        mountingEffectsActive = false;
-      }
-
-      sandbox.inactive();
-
-      const firstError = bootstrappingRelease?.error ?? mountingRelease?.error;
-      if (firstError) {
-        throw firstError.value;
-      }
+      const trackedUnmount = unmount().finally(() => {
+        if (unmountingPromise === trackedUnmount) unmountingPromise = undefined;
+      });
+      unmountingPromise = trackedUnmount;
+      return trackedUnmount;
     },
   };
 }

--- a/packages/sandbox/src/patchers/dynamicAppend/__tests__/lifecycle.test.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/__tests__/lifecycle.test.ts
@@ -1,13 +1,14 @@
 import type { IsolationPluginConfig } from '../../types';
-import { createSandboxContainer } from '../../../core/sandbox';
+import { createSandbox } from '../../../core/sandbox';
 import { styleElementTargetSymbol } from '../common';
 import type { SandboxConfig } from '../types';
+import { markLoaderStreamedNode } from '@qiankunjs/shared';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const identityNodeTransformer: IsolationPluginConfig['nodeTransformer'] = (node) => node;
 
 let appSequence = 0;
-const controllers: Array<ReturnType<typeof createSandboxContainer>> = [];
+const controllers: Array<ReturnType<typeof createSandbox>> = [];
 const containers: HTMLElement[] = [];
 
 function createController() {
@@ -17,10 +18,11 @@ function createController() {
   document.body.appendChild(container);
   containers.push(container);
 
-  const controller = createSandboxContainer(appName, () => container, {
+  const controller = createSandbox(appName, {
+    container: () => container,
     fetch: window.fetch,
     nodeTransformer: identityNodeTransformer,
-    styleIsolation: { appName, scopeRoot: `[data-qiankun="${appName}"]` },
+    styleIsolation: true,
   });
   controllers.push(controller);
   return { container, controller };
@@ -94,6 +96,9 @@ describe.sequential('dynamic append patch lifecycle', () => {
     headStyle[styleElementTargetSymbol] = 'head';
     sandboxConfig.dynamicStyleSheetElements.push(headStyle);
     container.querySelector('qiankun-head')?.remove();
+    const streamedNode = document.createElement('div');
+    markLoaderStreamedNode(streamedNode);
+    container.appendChild(streamedNode);
 
     await expect(controller.mount(container)).rejects.toThrow(/not ready while rebuilding/);
 

--- a/packages/sandbox/src/patchers/dynamicAppend/forStandardSandbox.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/forStandardSandbox.ts
@@ -23,6 +23,14 @@ import type { SandboxConfig } from './types';
 type PluginCompartment = IsolationPluginContext['compartment'];
 type Unpatch = () => void;
 
+function getRequiredContainer(getContainer: IsolationPluginContext['getContainer'], appName: string): HTMLElement {
+  const container = getContainer();
+  if (!container) {
+    throw new QiankunError(`${appName} requires a container for DOM isolation`);
+  }
+  return container;
+}
+
 declare global {
   interface Window {
     __currentLockingSandbox__?: PluginCompartment;
@@ -90,8 +98,12 @@ const { containerOwners, elementConfigs, sandboxConfigs } = sharedState;
 const getSandboxConfig = (element: HTMLElement) => elementConfigs.get(element);
 const setSandboxConfig = (element: HTMLElement, config: SandboxConfig) => elementConfigs.set(element, config);
 
-function patchDocument(compartment: PluginCompartment, appName: string, getContainer: () => HTMLElement): Unpatch {
-  const container = getContainer();
+function patchDocument(
+  compartment: PluginCompartment,
+  appName: string,
+  getContainer: IsolationPluginContext['getContainer'],
+): Unpatch {
+  const container = getRequiredContainer(getContainer, appName);
   // dom container might be reused by multiple apps,
   // thus we check its attached sandbox is same with current to avoid duplicate patch
   if (containerOwners.get(container) === compartment) {
@@ -107,7 +119,7 @@ function patchDocument(compartment: PluginCompartment, appName: string, getConta
     }
   };
   const getDocumentHeadElement = () => {
-    const currentContainer = getContainer();
+    const currentContainer = getRequiredContainer(getContainer, appName);
     const containerHeadElement = getContainerHeadElement(currentContainer);
     if (!containerHeadElement) {
       throw new QiankunError(`${appName} head element not existed while accessing document.head!`);
@@ -115,7 +127,7 @@ function patchDocument(compartment: PluginCompartment, appName: string, getConta
     return containerHeadElement;
   };
   const getDocumentBodyElement = () => {
-    const currentContainer = getContainer();
+    const currentContainer = getRequiredContainer(getContainer, appName);
     return getContainerBodyElement(currentContainer);
   };
   const modificationFns: {
@@ -478,7 +490,12 @@ export function patchStandardSandbox(context: IsolationPluginContext): Free {
 
     // As now the sub app content all wrapped with a special id container,
     // the dynamic style sheet could be removed automatically while unmounting
-    return (container: HTMLElement) => attachRecordedStylesheets(appName, dynamicStyleSheetElements, container);
+    return (container?: HTMLElement) => {
+      if (!container) {
+        return Promise.reject(new QiankunError(`${appName} requires a container while rebuilding DOM side effects`));
+      }
+      return attachRecordedStylesheets(appName, dynamicStyleSheetElements, container);
+    };
   };
 }
 

--- a/packages/sandbox/src/patchers/index.ts
+++ b/packages/sandbox/src/patchers/index.ts
@@ -4,7 +4,6 @@
  */
 
 import { SandboxType } from '../core/sandbox/types';
-import { containsLoaderStreamedNode, ensureSandboxContainerHead } from '../core/sandbox/container';
 import { QiankunError } from '@qiankunjs/shared';
 import { patchStandardSandbox, reattachDynamicStylesheets } from './dynamicAppend';
 import patchHistoryListener from './historyListener';
@@ -34,9 +33,6 @@ const dynamicAppendPlugin: IsolationPlugin = {
     const container = context.getContainer();
     if (!container) {
       throw new QiankunError(`${context.appName} requires a container for DOM isolation`);
-    }
-    if (!container.querySelector('qiankun-head') && !containsLoaderStreamedNode(container)) {
-      ensureSandboxContainerHead(container);
     }
     const free = patchStandardSandbox(context);
     try {

--- a/packages/sandbox/src/patchers/index.ts
+++ b/packages/sandbox/src/patchers/index.ts
@@ -4,6 +4,8 @@
  */
 
 import { SandboxType } from '../core/sandbox/types';
+import { containsLoaderStreamedNode, ensureSandboxContainerHead } from '../core/sandbox/container';
+import { QiankunError } from '@qiankunjs/shared';
 import { patchStandardSandbox, reattachDynamicStylesheets } from './dynamicAppend';
 import patchHistoryListener from './historyListener';
 import patchInterval from './interval';
@@ -29,9 +31,16 @@ const dynamicAppendPlugin: IsolationPlugin = {
   name: 'dynamicAppend',
   bootstrap: (context) => patchStandardSandbox(context),
   mount: async (context) => {
+    const container = context.getContainer();
+    if (!container) {
+      throw new QiankunError(`${context.appName} requires a container for DOM isolation`);
+    }
+    if (!container.querySelector('qiankun-head') && !containsLoaderStreamedNode(container)) {
+      ensureSandboxContainerHead(container);
+    }
     const free = patchStandardSandbox(context);
     try {
-      await reattachDynamicStylesheets(context.compartment, context.getContainer());
+      await reattachDynamicStylesheets(context.compartment, container);
     } catch (error) {
       // The patch above is already live but its Free has not been handed to the
       // container yet — undo it here, otherwise a reattach failure would strand
@@ -54,8 +63,11 @@ export const defaultIsolationPlugins = {
   [SandboxType.Snapshot]: baseIsolationPlugins,
 } satisfies Record<SandboxType, readonly IsolationPlugin[]>;
 
-export function getDefaultIsolationPlugins(sandboxType: SandboxType): readonly IsolationPlugin[] {
-  return defaultIsolationPlugins[sandboxType];
+export function getDefaultIsolationPlugins(
+  sandboxType: SandboxType,
+  includeDomIsolation = true,
+): readonly IsolationPlugin[] {
+  return includeDomIsolation ? defaultIsolationPlugins[sandboxType] : baseIsolationPlugins;
 }
 
 export type { Free, IsolationPlugin, IsolationPluginConfig, IsolationPluginContext, Patch, Rebuild } from './types';

--- a/packages/sandbox/src/patchers/types.ts
+++ b/packages/sandbox/src/patchers/types.ts
@@ -5,7 +5,7 @@
 import type { BaseLoaderOpts, NodeTransformer, StyleIsolationOpts } from '@qiankunjs/shared';
 import type { Compartment } from '../core/compartment';
 
-export type Rebuild = (container: HTMLElement) => Promise<void>;
+export type Rebuild = (container?: HTMLElement) => Promise<void>;
 export type Free = () => Rebuild;
 export type Patch = () => Free;
 
@@ -19,7 +19,7 @@ export interface IsolationPluginContext {
   compartment: Compartment;
   appName: string;
   /** Always resolve the current container lazily so remounts can replace it. */
-  getContainer: () => HTMLElement;
+  getContainer: () => HTMLElement | undefined;
   config: IsolationPluginConfig;
 }
 


### PR DESCRIPTION
## Stack

4 / 5. Depends on #3160.

- #3155 — Compartment globals and classic scripts
- #3159 — Compartment module loading and benchmark
- #3160 — qiankun sandbox configuration and plugins
- **#3161 — standalone sandbox runtime (this PR)**
- #3162 — standalone guides, example, and CSP e2e

## Review scope

- Define the standalone sandbox contract in the RFC.
- Export the standalone sandbox controller from `@qiankunjs/sandbox`.
- Cover lifecycle, execution, module loading, DOM patching, cleanup, and package publication behavior.

## Out of scope

- End-user guides, runnable browser example, and CSP e2e acceptance (final PR).

## Validation

- Sandbox tests: 60 passed at this layer.
- qiankun `loadApp` tests: 6 passed at this layer.
- `pnpm run build:packages` passed.
- Sandbox package `pnpm pack --dry-run` passed.
