### PR TITLE
refactor(sandbox): converge dynamic DOM attribution on the insertion point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ Build/release:
 - **NEVER** put more than one `entry` script in an HTML entry — the loader throws `QiankunError`.
 - **ALWAYS** unmount micro-apps; `loadMicroApp`/patchers return handles/`free()` — leaks break remount & multi-instance.
 - In sandbox code, **never touch the real `window`/`document.head`** — go through the proxied view.
+- The vendored `loader/src/writable-dom/` fork accepts **generic designs only** — never qiankun-coupled semantics; caller bookkeeping goes through its `assetTransformer` callback (see `packages/loader/AGENTS.md`).
 - Don't invert the package dependency graph above (e.g. `shared` must not import `sandbox`).
 - e2e: never `waitForTimeout`; use web-first assertions; all ports come from `e2e/ports.ts`.
 - Performance work is judged in this order: **proportional impact first** (does the win scale with asset size / network / app scale — e.g. eliminating a duplicate download), **readability second** (never trade it away for small wins), **constant absolute savings last** (fixed single-digit-ms pipeline costs are noise in real apps and rarely worth landing). Beware: the ~50ms benchmark fixture makes fixed milliseconds masquerade as percentages — convert to absolute ms against realistic load times before deciding. And fix root causes at the source, not with per-call-site markers/exemptions downstream.

--- a/docs/rfcs/insertion-point-ownership.md
+++ b/docs/rfcs/insertion-point-ownership.md
@@ -1,10 +1,11 @@
 # RFC: Insertion-Point Ownership for Dynamic DOM Attribution
 
-- **Status**: Draft
+- **Status**: Draft(已实现,见本分支:标记拆分 → 归属收敛 + 创建者机制退役 + CSSOM 位置解析,附归属契约单测)
 - **Author**: qiankun maintainers
 - **Created**: 2026-07-25
 - **Target Release**: qiankun v3.x
 - **Tracking Issue**: TBD
+- **Last Revision**: 2026-07-25(实现验证:全仓单测 295 例、Chromium e2e 38 例、eslint/prettier、本地性能基准全部通过;嵌套沙箱以「createElement 不再记账」契约测试覆盖,未建完整嵌套 harness)
 
 ## Summary
 

--- a/docs/rfcs/insertion-point-ownership.md
+++ b/docs/rfcs/insertion-point-ownership.md
@@ -5,7 +5,7 @@
 - **Created**: 2026-07-25
 - **Target Release**: qiankun v3.x
 - **Tracking Issue**: TBD
-- **Last Revision**: 2026-07-25(实现与验证完成:全仓单测、Chromium e2e、eslint/prettier、本地性能基准全部通过;嵌套沙箱补齐真实 e2e harness(`fixtures/sub-nested`,qiankun 套 qiankun),核心判别用例经变异测试确认可区分新旧归属语义)
+- **Last Revision**: 2026-07-25(实现与验证完成:全仓单测、Chromium e2e、eslint/prettier、本地性能基准全部通过;嵌套沙箱补齐真实 e2e harness(`fixtures/sub-nested`,qiankun 套 qiankun),核心判别用例经变异测试确认可区分新旧归属语义。review 收尾:Q1 定案为无条件 warn、unpatch 清除挂载点 stamp、S2/D5 补缓存边界、D2 补 cloneNode 已知限制)
 
 ## Summary
 
@@ -104,6 +104,8 @@ const sandboxConfig = isTranspiledNode(element) ? undefined : getSandboxConfig(t
 
 loader 对流式元素两个都打;Compartment 只打效果位 —— 出处契约的污染消除,容器占用检测不再依赖短路顺序保命。两个符号均用 `Symbol.for` 注册,跨 `@qiankunjs/shared` 副本契约保持(现状同)。doc comment(`shared/src/common.ts:5-12`)按两个契约分别重写。
 
+已知限制(现状同,非本 RFC 引入):symbol 标记不随 `cloneNode` 复制 —— 克隆一个已转译节点再插入会重新进管线(样式可能被二次 `@scope` 包裹)。单一 `loaderStreamedNode` 时代行为相同,记录备查。
+
 ### D3 创建者机制退役
 
 删除:`attachElementToSandbox`(`forStandardSandbox.ts:115-120`)、`__currentLockingSandbox__` 全部(`:34-48` 声明与 defineProperty、`:163-177` createElement 锁逻辑)。`proxyDocument` 的 `createElement` get 保留 override 通道(`modificationFns`)但不再做任何归属动作;`createElement`/`querySelector` 的 set/get 配对结构不动(防写泄漏)。
@@ -126,6 +128,8 @@ const config = elementConfigs.get(ownerNode) ?? resolveConfigByPosition(ownerNod
 
 这与插入点模型同构(「样式现在活在谁的容器里」),并顺带修正现状的不一致:今天深插 style 的**文本规则不 scope、insertRule 规则却按创建者 scope**,若元素被挪出容器 insertRule 仍继续 scope(错误);按位置解析后两者行为统一且随位置正确。上溯只在无 stamp 的首次 `insertRule` 发生一次,之后走缓存 —— CSS-in-JS 高频 insertRule 路径无持续开销。
 
+缓存同时划定了修正的边界:首次解析后归属被钉在元素上,之后元素再被挪出容器,后续 `insertRule` 仍沿用缓存归属 —— 深插元素不经过 patched removeChild,缓存没有失效时机。这与 S3 属同类已知限制,不因缓存恶化(旧创建者 stamp 同样不随移动失效)。
+
 ### 不变量保持对照
 
 样式账本调查提炼的 9 条不变量逐条对照(编号见调查底稿,此处收录结论):
@@ -144,7 +148,7 @@ const config = elementConfigs.get(ownerNode) ?? resolveConfigByPosition(ownerNod
 
 **S1 — 跨实例直插**:B 用直接 DOM 引用把自建元素插进 A 的挂载点,归属从 B(创建者)变为 A(插入点)。评估:正常编排不可达(F2)、零测试依赖、与 F5 既定不变量更一致。**接受**,并在 Phase 3 用测试把新语义钉成契约。
 
-**S2 — 沙箱内创建、未经挂载点插入的 style 的 `insertRule` scoping**:归属来源从创建者 stamp 变为位置解析(D5)。容器内深插:行为不变(解析到同一 app);被挪出容器:从「继续 scope(错)」变为「不再 scope(对)」。**属修正而非回归**。
+**S2 — 沙箱内创建、未经挂载点插入的 style 的 `insertRule` scoping**:归属来源从创建者 stamp 变为位置解析(D5)。容器内深插:行为不变(解析到同一 app);首次 `insertRule` 解析前被挪出容器:从「继续 scope(错)」变为「不再 scope(对)」;首次解析后再挪出:沿用缓存归属(D5 缓存边界)。**属修正而非回归**,修正范围以首次解析为界。
 
 **S3 — 重插入即重归属**(D1 收养语义):元素跨挂载点移动后,removeChild/CSSOM 按最后插入点结算。跨容器移动在两种模型下账本层面都有未定义行为(直接 append 触发的隐式 detach 不经过旧容器的 patched removeChild,旧账本残留 —— 现状同病),不因本 RFC 恶化,记为已知限制。
 
@@ -172,10 +176,11 @@ const config = elementConfigs.get(ownerNode) ?? resolveConfigByPosition(ownerNod
 
 ## 附带清理项(顺路,不阻塞)
 
-- `forStandardSandbox.ts:289`:body `insertBefore` 误传 `document.head.insertBefore` 为原生函数(与 `Node.prototype.insertBefore` 同引用故无功能差异,但捕获自实例属性有被宿主实例级 patch 污染的理论风险),统一改为从 prototype 捕获。
+- `forStandardSandbox.ts:289`:body `insertBefore` 误传 `document.head.insertBefore` 为原生函数(与 `Node.prototype.insertBefore` 同引用故无功能差异,但捕获自实例属性有被宿主实例级 patch 污染的理论风险),统一改为从 prototype 捕获。子应用自行 wrap 它所见的挂载点 `appendChild`(业务 monkey-patch 常态)不受影响:wrapper 遮蔽实例级 patch 方法并委托之,管线在 wrapper 之下照常运行 —— 由新增 e2e(`sub-classic-patched-append`)钉住。
 - `shared/src/common.ts:5-12` doc comment 随 D2 重写为双契约表述。
+- unpatch 时清除挂载点自己的 stamp(守卫同主 config,共享容器接力时不误删后来者的 tag):防止 D5 位置解析把已卸载 app 判为陈旧归属;归属契约单测钉住。
 
 ## Open Questions
 
-- **Q1**:S3 的「一律 stamp」是否需要 dev 模式下对「元素携带异 app config 被重归属」发 warning(调试辅助)?倾向:加,成本一行。
+- **Q1(已定案)**:重归属 warning 无条件发,不做 dev gating —— 与 detached-container warning 的既有处理一致;该场景正常编排下不可达(F2),噪音风险可忽略。
 - **Q2**:D5 位置解析是否需要处理 Shadow DOM 边界(`getRootNode()` 跨越)?现状 qiankun 容器不使用 shadow root,倾向:不处理,遇到即视为无归属。

--- a/docs/rfcs/insertion-point-ownership.md
+++ b/docs/rfcs/insertion-point-ownership.md
@@ -5,7 +5,7 @@
 - **Created**: 2026-07-25
 - **Target Release**: qiankun v3.x
 - **Tracking Issue**: TBD
-- **Last Revision**: 2026-07-25(实现验证:全仓单测 295 例、Chromium e2e 38 例、eslint/prettier、本地性能基准全部通过;嵌套沙箱以「createElement 不再记账」契约测试覆盖,未建完整嵌套 harness)
+- **Last Revision**: 2026-07-25(实现与验证完成:全仓单测、Chromium e2e、eslint/prettier、本地性能基准全部通过;嵌套沙箱补齐真实 e2e harness(`fixtures/sub-nested`,qiankun 套 qiankun),核心判别用例经变异测试确认可区分新旧归属语义)
 
 ## Summary
 
@@ -154,7 +154,13 @@ const config = elementConfigs.get(ownerNode) ?? resolveConfigByPosition(ownerNod
 
 **Phase 2 — 归属收敛**:D1(决策行 + 一律 stamp + fragment 简化)、D3(死代码删除)、D5(CSSOM 位置解析)。回归重点:`stylesheet-ledger.test.ts` 全部、`style-isolation.spec.ts:68`(jQuery fragment)、`router-mode.spec.ts:46-63`(共享容器接力竞态)、multi-instance 与 standalone 全套。
 
-**Phase 3 — 测试补账**(补历史空白 + 钉新契约):嵌套沙箱归属单测(现状为零覆盖,先钉旧行为再随 Phase 2 更新)、跨实例直插归属契约测试(钉 S1 新语义)、`StyleSheetManager` 式容器内自定义注入点的 insertRule scoping 单测(钉 D5)、容器占用检测在 Compartment blob script 存续期间不误判的单测(钉 D2 出处位纯度)。
+**Phase 3 — 测试补账**(补历史空白 + 钉新契约):跨实例直插归属契约单测(钉 S1)、`StyleSheetManager` 式容器内自定义注入点的 insertRule scoping 单测(钉 D5)、容器占用检测不被 Compartment blob script 误导的单测(钉 D2 出处位纯度)、以及**嵌套沙箱 e2e**(历史零覆盖):新增 `e2e/fixtures/sub-nested` —— 一个自带 qiankun 副本、在自己 DOM 内再挂一个子应用的 classic 应用,配 `e2e/tests/nested-sandbox.spec.ts`。
+
+### 嵌套与 evaluateScript 的覆盖实证(变异测试结论)
+
+- **嵌套归属**:`nested-sandbox` 中「外层应用创建、交给内层容器」的节点用例是新旧语义的**真判别式** —— 变异回创建者归属后,该用例精确失败于 `@scope ([data-name="sub-nested"])`(错误归属外层)。其余三条(各自容器内的样式归属、两层全局不外泄、外层卸载连带内层)在新旧模型下都应成立,作用是给已退役的 `__currentLockingSandbox__` 嵌套锁补上回归护栏。该 fixture 同时顺带验证了跨 qiankun 副本的 `Symbol.for` 契约(内外层是两份独立打包的 qiankun)。
+- **evaluateScript 的效果位**:已被现有 `standalone-sandbox` e2e 兜住 —— 去掉 `markNodeTranspiled(script)` 后该用例失败(控制器进入 `failed`,blob script 被二次转译)。
+- **evaluateScript 的出处位**:端到端**不可达**,已实证 —— 把拆分前的 `markLoaderStreamedNode(script)` 加回去,全部 e2e 依旧通过。原因是双重结构保护:blob script 始终位于 `<qiankun-head>` 内(占用检测的第一个条件因此为 false),且求值 settle 后即被移除。故出处位纯度由单测精确钉住,e2e 覆盖其可达邻域:新增「同容器在一次 classic 求值生命周期后由新控制器重新准备」用例(`standalone-sandbox.spec.ts`),断言虚拟头恰好重建一次、隔离对第二个控制器依然成立。
 
 各 Phase 独立成 conventional commit,`pnpm run ci` + Chromium e2e 全绿为 gate;Phase 2 附带跑一次性能门禁(D5 上溯为冷路径,预期无感,须实证)。
 

--- a/docs/rfcs/insertion-point-ownership.md
+++ b/docs/rfcs/insertion-point-ownership.md
@@ -1,0 +1,174 @@
+# RFC: Insertion-Point Ownership for Dynamic DOM Attribution
+
+- **Status**: Draft
+- **Author**: qiankun maintainers
+- **Created**: 2026-07-25
+- **Target Release**: qiankun v3.x
+- **Tracking Issue**: TBD
+
+## Summary
+
+把 dynamicAppend patcher 的元素归属(attribution)规则从「**创建者优先、插入点兜底**」收敛为「**插入点唯一**」:
+
+> 凡是插入某 app 已 patch 挂载点(容器 body / `<qiankun-head>`)的可劫持标签(script/link/style),即归属该 app、进入其管线 —— 除非节点带「已转译」效果位。
+
+同时把现有单一 `loaderStreamedNode` 标记按语义拆成两个:
+
+- **效果位** `transpiledNode`:「此节点已完成管线加工,动态插入管线必须原生放行」。loader 流式走读与 Compartment 内部 blob script 都打它;dynamicAppend 只消费它。
+- **出处位** `loaderStreamedNode`:「此节点由 HTML entry 流式加载产出」。仅 loader 打;仅容器占用检测(`containsLoaderStreamedNode`)消费。
+
+创建者归属机制(`attachElementToSandbox` + `__currentLockingSandbox__` 嵌套锁)整体退役。CSSOM `insertRule` 的 config 解析改为**按 DOM 位置**(向上找已 tag 的容器),与插入点模型自洽。
+
+## Motivation
+
+### 历史:两套归属模型的叠加
+
+v2 时代归属只有一条规则:沙箱代理的 `document.createElement` 在创建时刻给元素挂 config(创建者归属),patcher 里「无 config → 原生放行」。
+
+#3138(`dcc42ae4`)修复 jQuery/innerHTML 场景时发现:**parser 产出的 DOM**(`innerHTML`、`insertAdjacentHTML`、`cloneNode`、`DOMParser`、jQuery `buildFragment`)从不经过 createElement,无 config 却是不折不扣的应用动态插入 —— 样式因此完全绕过 `@scope` 隔离泄漏到主页面。修复方式是给挂载点打 config(`tagMountPoint`,`forStandardSandbox.ts:233`),无主元素落上来时继承(插入点归属)。
+
+补丁没有替换旧模型,而是叠在上面,产生了一批胶水逻辑:
+
+| 胶水 | 位置 |
+| --- | --- |
+| 创建者优先 + 插入点兜底的三元决策 | `common.ts:147-148` |
+| fragment 分解分支的 `getSandboxConfig(child) ?? ownerConfig` | `common.ts:123` |
+| `isLoaderStreamedNode` 排除位散布 | `common.ts:122/132/148` |
+| 嵌套沙箱创建锁 | `forStandardSandbox.ts:44-48, 162-177` |
+| Compartment 内部 blob script 语义透支(见下) | `core/compartment/index.ts:183` |
+
+### 语义透支的具体化
+
+`loaderStreamedNode` 目前同时承载两个契约:
+
+1. **效果契约**(dynamicAppend 三处消费):「已转译,放行」—— 与出处无关;
+2. **出处契约**(`containsLoaderStreamedNode`,`container.ts:27` → `sandbox/index.ts:153`):「容器持有 entry 流式内容」—— 只有 loader 有资格声明。
+
+Compartment `evaluateScript` 给内部 blob script 打此标记(`compartment/index.ts:183`)在效果契约下是对的,但污染了出处契约:blob script 挂着标记待在容器里,理论上会让容器被误判为「已被流式占用」。今天不出事仅仅因为 `sandbox/index.ts:153` 的 `&&` 短路顺序 —— blob script 必然位于 qiankun-head 内,第一个条件已经 false。靠条件排列的巧合掩护,不是靠语义正确。
+
+### 目标
+
+- **G1 单一归属规则**:插入点唯一,消灭创建者/插入点双模型与全部胶水。
+- **G2 标记语义诚实**:效果位与出处位分离,每个消费者读到它真正想问的问题。
+- **G3 死代码退役**:`attachElementToSandbox`、`__currentLockingSandbox__` 及 createElement 锁整体删除。
+- **G4 为 patcher 插件化铺路**:归属规则收敛是 Compartment Alignment RFC(G3 扩展开放)中 dynamicAppend 插件化的前置项 —— 插件契约里只需要「插入点 + 效果位」两个概念。
+
+## 事实底账(2026-07-25 全量核实)
+
+以下事实是本 RFC 风险结论的基础,均已在源码/测试中逐一核对。
+
+**F1 — 挂载点必然被 tag,归属变更不改变「进管线的集合」。** `patchStandardSandbox` 先创建 SandboxConfig(`forStandardSandbox.ts:458-469`)再 `patchDocument`(`:474`),故 `tagMountPoint`(`:233-236`,在 `:246/:281` 调用)总能取到 config。因此在 patched 挂载点上,可劫持、非流式元素**今天就总能解析出 config**(自带的或挂载点兜底的),总会进管线。收敛为插入点唯一后,进管线的集合完全不变;唯一可能变化的是**绑定到哪个 app 的 config**,且仅当「创建方 ≠ 插入方」。这直接排除了「原本原生放行的外部同步 script 新进入 deferred 链」一类风险 —— 该场景在挂载点上今天就不存在。
+
+**F2 — 「创建方 ≠ 插入方」在正常编排下不可达。**
+- `loadMicroApp` 多实例:每实例独立容器(`e2e/fixtures/main/src/main.ts:61-72`,`multi-instance.spec.ts:9-46`),互不交叉;
+- `registerMicroApps` 共享容器:顺序接力,`initContainer`/`clearContainer` 在 init/remount/unmount 时清空容器(`loadApp.ts:278-308`),互斥 `activeRule` 保证不同时活跃(`register.ts:4-26`);
+- sandbox 层 `containerOwners` 是单 owner、last-writer-wins(`forStandardSandbox.ts:109/220/262/297`),本就不支持多租户;双向 unpatch 顺序已核实安全(先释放方的 cleanup 因方法引用不匹配而 no-op)。
+- 仓库内**没有任何测试钉住创建者归属行为**;嵌套锁 `__currentLockingSandbox__` 的测试覆盖为零。现有测试(`stylesheet-ledger.test.ts:70-87`、`style-isolation.spec.ts:68`)钉住的恰恰是插入点收养路径。
+
+**F3 — 重挂载回放与归属正交。** 回放走模块加载时捕获的原生 `rawHeadInsertBefore`/`rawHeadAppendChild`(`forStandardSandbox.ts:412-413, 543-551`),完全绕开 patch,不重新注册、不重进账本。归属变更只影响「首挂载时哪些元素入谁的账本」,不触碰回放机制。
+
+**F4 — 宿主从不向容器内插节点。** ui-bindings 的 loader/error UI 渲染在 wrapper(容器的兄弟层),容器引用原样交给 `mountMicroApp`(`MicroApp.tsx:111-119`、`MicroApp.ts:182-233`);无 portal。e2e/fixtures 中宿主对容器只有清空与属性写,从无可劫持节点插入。
+
+**F5 — 既有 RFC 已定「元素归属按实例、随物理容器」。** esm-sandbox RFC 拒绝共享 blob 的理由正是「dynamicAppend 元素归属错到 A 的容器」(`esm-sandbox.md:581`)。插入点归属把「元素在谁的容器里」与「归属谁」钉成同一件事,与该不变量**更**一致;反而是现行创建者优先规则允许 B 的元素在 A 的容器里仍归 B。
+
+**F6 — 管线下游对 config 是不透明消费。** 转译、账本(`dynamicStyleSheetElements`)、deferred 队列(`dynamicExternalSyncScriptDeferredList`)、样式记录各分支只读 `sandboxConfig` 的字段,不关心 config 从哪来。唯一的实质决策点就是 `common.ts:147-148`。
+
+## Design
+
+### D1 归属规则:插入点唯一
+
+`common.ts:147-148` 改为:
+
+```ts
+// before
+const sandboxConfig =
+  getSandboxConfig(element) ?? (isLoaderStreamedNode(element) ? undefined : getSandboxConfig(this));
+
+// after
+const sandboxConfig = isTranspiledNode(element) ? undefined : getSandboxConfig(this);
+```
+
+**收养语义**:进入管线的元素**一律** `setSandboxConfig(element, sandboxConfig)`(去掉 `common.ts:158` 的 `!getSandboxConfig(element)` 守卫)。含义:重插入即重归属 —— 元素被挪到谁的挂载点就归谁,与插入点模型自洽,也让 removeChild(`common.ts:306`)与 CSSOM 读到的永远是「最后一次插入的归属」。
+
+**fragment 分支简化**(`common.ts:114-141`):`shouldDecompose` 从「child 自有 config ?? ownerConfig 的三元」简化为「存在可劫持且非 transpiled 的 child」;分解时对每个 child 直接 stamp `ownerConfig`(去掉 `:132-133` 两个守卫)。
+
+### D2 标记拆分
+
+`packages/shared/src/common.ts`:
+
+| 标记 | Symbol | 生产者 | 消费者 |
+| --- | --- | --- | --- |
+| 效果位 | `Symbol.for('qiankun.transpiledNode')` | loader 流式走读(`writable-dom/index.ts:195`)、Compartment blob script(`compartment/index.ts:183`) | dynamicAppend(`common.ts:122/132/148` 对应处) |
+| 出处位 | `Symbol.for('qiankun.loaderStreamedNode')`(保留) | 仅 loader 流式走读 | 仅 `containsLoaderStreamedNode`(`container.ts:27`) |
+
+loader 对流式元素两个都打;Compartment 只打效果位 —— 出处契约的污染消除,容器占用检测不再依赖短路顺序保命。两个符号均用 `Symbol.for` 注册,跨 `@qiankunjs/shared` 副本契约保持(现状同)。doc comment(`shared/src/common.ts:5-12`)按两个契约分别重写。
+
+### D3 创建者机制退役
+
+删除:`attachElementToSandbox`(`forStandardSandbox.ts:115-120`)、`__currentLockingSandbox__` 全部(`:34-48` 声明与 defineProperty、`:163-177` createElement 锁逻辑)。`proxyDocument` 的 `createElement` get 保留 override 通道(`modificationFns`)但不再做任何归属动作;`createElement`/`querySelector` 的 set/get 配对结构不动(防写泄漏)。
+
+### D4 嵌套沙箱:插入点天然区分
+
+嵌套锁存在的唯一理由是消歧「createElement 链上谁是真正的创建者」(B 的代理委托 A 的代理再委托原生,无锁则最内层 attach 胜出、归属错乱)。插入点模型下归属在插入时刻由挂载点决定:B 的容器与 A 的容器是不同元素、各自持有实例级 patch,插到谁的挂载点就命中谁的 patch、绑谁的 config —— 无需任何创建时刻协调。锁连同它保护的问题一起消失。
+
+### D5 CSSOM `insertRule`:按位置解析
+
+现状 `forStandardSandbox.ts:422` 读 `elementConfigs.get(ownerNode)`,依赖元素身上的 stamp。经挂载点插入的元素(styled-components/emotion/JSS 均注入代理 `document.head` → qiankun-head → 挂载点)在 D1 收养下照常有 stamp,不受影响。
+
+对**未经挂载点**插入的 style(如 `StyleSheetManager target` 指向容器深处的 div),今天靠创建者 stamp 才能 scope。改为按位置解析:
+
+```ts
+const config = elementConfigs.get(ownerNode) ?? resolveConfigByPosition(ownerNode);
+// resolveConfigByPosition: 沿 parentElement 上溯,首个命中 elementConfigs 的祖先
+//(挂载点必然被 tag,F1)即为归属;命中后回写 stamp 到 ownerNode 作缓存。
+```
+
+这与插入点模型同构(「样式现在活在谁的容器里」),并顺带修正现状的不一致:今天深插 style 的**文本规则不 scope、insertRule 规则却按创建者 scope**,若元素被挪出容器 insertRule 仍继续 scope(错误);按位置解析后两者行为统一且随位置正确。上溯只在无 stamp 的首次 `insertRule` 发生一次,之后走缓存 —— CSS-in-JS 高频 insertRule 路径无持续开销。
+
+### 不变量保持对照
+
+样式账本调查提炼的 9 条不变量逐条对照(编号见调查底稿,此处收录结论):
+
+1. **入账⇔摘账对称**(push 进账本的元素必须可被 removeChild 识别摘除,否则复活 #3163 修掉的账本堵塞):D1 的「一律 stamp」在直插、fragment、转译替换(`common.ts:203-204`)三条路径统一保证,比现状(守卫式补 stamp)更强。钉住测试:`stylesheet-ledger.test.ts:70-87`。
+2. hint link 转译但不入账(`common.ts:175-182`):不动。
+3. 已转译节点放行:由效果位承接(D2),语义不变。
+4. 回放原生、不重注册:不动(F3)。
+5. `styleElementTargetSymbol`/`refNodeNo` 顺序元数据:不动;插入点模型下 target symbol 的含义(「插入的挂载点」)反而名实相符。
+6. 账本数组与 `elementConfigs` 跨挂载持久:不动。
+7. 原生放行 script 不误入 deferred 链:F1 证明挂载点上不存在该集合变化。
+8. 挂载失败回滚(`lifecycle.test.ts:82-110`):不动。
+9. realm 级原型 patch 引用计数:不动。
+
+## 语义变更清单(诚实列举)
+
+**S1 — 跨实例直插**:B 用直接 DOM 引用把自建元素插进 A 的挂载点,归属从 B(创建者)变为 A(插入点)。评估:正常编排不可达(F2)、零测试依赖、与 F5 既定不变量更一致。**接受**,并在 Phase 3 用测试把新语义钉成契约。
+
+**S2 — 沙箱内创建、未经挂载点插入的 style 的 `insertRule` scoping**:归属来源从创建者 stamp 变为位置解析(D5)。容器内深插:行为不变(解析到同一 app);被挪出容器:从「继续 scope(错)」变为「不再 scope(对)」。**属修正而非回归**。
+
+**S3 — 重插入即重归属**(D1 收养语义):元素跨挂载点移动后,removeChild/CSSOM 按最后插入点结算。跨容器移动在两种模型下账本层面都有未定义行为(直接 append 触发的隐式 detach 不经过旧容器的 patched removeChild,旧账本残留 —— 现状同病),不因本 RFC 恶化,记为已知限制。
+
+## Implementation Plan
+
+**Phase 1 — 标记拆分**(独立可先行,风险低):shared 增 `transpiledNode` 标记对;loader 双打;Compartment 改打效果位;dynamicAppend 三处消费换效果位;`container.ts` 保持出处位。现有测试全量回归(`lifecycle.test.ts:100` 的出处位用法不变)。
+
+**Phase 2 — 归属收敛**:D1(决策行 + 一律 stamp + fragment 简化)、D3(死代码删除)、D5(CSSOM 位置解析)。回归重点:`stylesheet-ledger.test.ts` 全部、`style-isolation.spec.ts:68`(jQuery fragment)、`router-mode.spec.ts:46-63`(共享容器接力竞态)、multi-instance 与 standalone 全套。
+
+**Phase 3 — 测试补账**(补历史空白 + 钉新契约):嵌套沙箱归属单测(现状为零覆盖,先钉旧行为再随 Phase 2 更新)、跨实例直插归属契约测试(钉 S1 新语义)、`StyleSheetManager` 式容器内自定义注入点的 insertRule scoping 单测(钉 D5)、容器占用检测在 Compartment blob script 存续期间不误判的单测(钉 D2 出处位纯度)。
+
+各 Phase 独立成 conventional commit,`pnpm run ci` + Chromium e2e 全绿为 gate;Phase 2 附带跑一次性能门禁(D5 上溯为冷路径,预期无感,须实证)。
+
+## Non-Goals
+
+- 不支持两个活跃 app 共享一个容器(现状即不生成该场景,`containerOwners` 维持单 owner)。
+- 不改回放机制、账本数据结构、deferred 队列机制。
+- 不移除「已转译放行」效果位本身 —— 它是流式管线与动态管线并存的必要契约,本 RFC 只让它名实相符。
+
+## 附带清理项(顺路,不阻塞)
+
+- `forStandardSandbox.ts:289`:body `insertBefore` 误传 `document.head.insertBefore` 为原生函数(与 `Node.prototype.insertBefore` 同引用故无功能差异,但捕获自实例属性有被宿主实例级 patch 污染的理论风险),统一改为从 prototype 捕获。
+- `shared/src/common.ts:5-12` doc comment 随 D2 重写为双契约表述。
+
+## Open Questions
+
+- **Q1**:S3 的「一律 stamp」是否需要 dev 模式下对「元素携带异 app config 被重归属」发 warning(调试辅助)?倾向:加,成本一行。
+- **Q2**:D5 位置解析是否需要处理 Shadow DOM 边界(`getRootNode()` 跨越)?现状 qiankun 容器不使用 shadow root,倾向:不处理,遇到即视为无归属。

--- a/docs/rfcs/insertion-point-ownership.md
+++ b/docs/rfcs/insertion-point-ownership.md
@@ -5,17 +5,17 @@
 - **Created**: 2026-07-25
 - **Target Release**: qiankun v3.x
 - **Tracking Issue**: TBD
-- **Last Revision**: 2026-07-25(实现与验证完成:全仓单测、Chromium e2e、eslint/prettier、本地性能基准全部通过;嵌套沙箱补齐真实 e2e harness(`fixtures/sub-nested`,qiankun 套 qiankun),核心判别用例经变异测试确认可区分新旧归属语义。review 收尾:Q1 定案为无条件 warn、unpatch 清除挂载点 stamp、S2/D5 补缓存边界、D2 补 cloneNode 已知限制)
+- **Last Revision**: 2026-07-25(实现与验证完成:全仓单测、Chromium e2e、eslint/prettier、本地性能基准全部通过;嵌套沙箱补齐真实 e2e harness(`fixtures/sub-nested`,qiankun 套 qiankun),核心判别用例经变异测试确认可区分新旧归属语义。review 收尾:Q1 定案为无条件 warn、unpatch 清除挂载点 stamp、S2/D5 补缓存边界、D2 补 cloneNode 已知限制;二轮 review:效果位更名 `nativePassthroughNode` 以名实相符,盖章点从 writable-dom fork 移入 `loadEntry` 闭包,fork 不再感知 qiankun 语义)
 
 ## Summary
 
 把 dynamicAppend patcher 的元素归属(attribution)规则从「**创建者优先、插入点兜底**」收敛为「**插入点唯一**」:
 
-> 凡是插入某 app 已 patch 挂载点(容器 body / `<qiankun-head>`)的可劫持标签(script/link/style),即归属该 app、进入其管线 —— 除非节点带「已转译」效果位。
+> 凡是插入某 app 已 patch 挂载点(容器 body / `<qiankun-head>`)的可劫持标签(script/link/style),即归属该 app、进入其管线 —— 除非节点带「原生放行」效果位。
 
 同时把现有单一 `loaderStreamedNode` 标记按语义拆成两个:
 
-- **效果位** `transpiledNode`:「此节点已完成管线加工,动态插入管线必须原生放行」。loader 流式走读与 Compartment 内部 blob script 都打它;dynamicAppend 只消费它。
+- **效果位** `nativePassthroughNode`:「此节点由 qiankun 自有管线插入,动态插入管线必须原生放行」。loader 流式管线与 Compartment 内部 blob script 都打它;dynamicAppend 只消费它。
 - **出处位** `loaderStreamedNode`:「此节点由 HTML entry 流式加载产出」。仅 loader 打;仅容器占用检测(`containsLoaderStreamedNode`)消费。
 
 创建者归属机制(`attachElementToSandbox` + `__currentLockingSandbox__` 嵌套锁)整体退役。CSSOM `insertRule` 的 config 解析改为**按 DOM 位置**(向上找已 tag 的容器),与插入点模型自洽。
@@ -86,12 +86,12 @@ const sandboxConfig =
   getSandboxConfig(element) ?? (isLoaderStreamedNode(element) ? undefined : getSandboxConfig(this));
 
 // after
-const sandboxConfig = isTranspiledNode(element) ? undefined : getSandboxConfig(this);
+const sandboxConfig = isNativePassthroughNode(element) ? undefined : getSandboxConfig(this);
 ```
 
 **收养语义**:进入管线的元素**一律** `setSandboxConfig(element, sandboxConfig)`(去掉 `common.ts:158` 的 `!getSandboxConfig(element)` 守卫)。含义:重插入即重归属 —— 元素被挪到谁的挂载点就归谁,与插入点模型自洽,也让 removeChild(`common.ts:306`)与 CSSOM 读到的永远是「最后一次插入的归属」。
 
-**fragment 分支简化**(`common.ts:114-141`):`shouldDecompose` 从「child 自有 config ?? ownerConfig 的三元」简化为「存在可劫持且非 transpiled 的 child」;分解时对每个 child 直接 stamp `ownerConfig`(去掉 `:132-133` 两个守卫)。
+**fragment 分支简化**(`common.ts:114-141`):`shouldDecompose` 从「child 自有 config ?? ownerConfig 的三元」简化为「存在可劫持且非原生放行的 child」;分解时对每个 child 直接 stamp `ownerConfig`(去掉 `:132-133` 两个守卫)。
 
 ### D2 标记拆分
 
@@ -99,12 +99,14 @@ const sandboxConfig = isTranspiledNode(element) ? undefined : getSandboxConfig(t
 
 | 标记 | Symbol | 生产者 | 消费者 |
 | --- | --- | --- | --- |
-| 效果位 | `Symbol.for('qiankun.transpiledNode')` | loader 流式走读(`writable-dom/index.ts:195`)、Compartment blob script(`compartment/index.ts:183`) | dynamicAppend(`common.ts:122/132/148` 对应处) |
-| 出处位 | `Symbol.for('qiankun.loaderStreamedNode')`(保留) | 仅 loader 流式走读 | 仅 `containsLoaderStreamedNode`(`container.ts:27`) |
+| 效果位 | `Symbol.for('qiankun.nativePassthroughNode')` | loader 流式管线(`loadEntry` 的 transformer 闭包,`loader/src/index.ts`)、Compartment blob script(`compartment/index.ts:183`) | dynamicAppend(`common.ts:122/132/148` 对应处) |
+| 出处位 | `Symbol.for('qiankun.loaderStreamedNode')`(保留) | 仅 loader 流式管线(同上闭包) | 仅 `containsLoaderStreamedNode`(`container.ts:27`) |
 
 loader 对流式元素两个都打;Compartment 只打效果位 —— 出处契约的污染消除,容器占用检测不再依赖短路顺序保命。两个符号均用 `Symbol.for` 注册,跨 `@qiankunjs/shared` 副本契约保持(现状同)。doc comment(`shared/src/common.ts:5-12`)按两个契约分别重写。
 
-已知限制(现状同,非本 RFC 引入):symbol 标记不随 `cloneNode` 复制 —— 克隆一个已转译节点再插入会重新进管线(样式可能被二次 `@scope` 包裹)。单一 `loaderStreamedNode` 时代行为相同,记录备查。
+**盖章点归 loader 集成层,不归 writable-dom fork。** vendored 的 writable-dom 不感知任何 qiankun 下游语义(不 import `@qiankunjs/shared`),它的契约止步于「每个待插入 element 在插入前必经 `assetTransformer` 回调」;两个标记由 `loadEntry` 传入的闭包盖章。回调的调用范围恰好等于「walk 经手的节点」,故语义与在 walk 内盖章等价,唯一差异是 preload hint(blocked 期间的预扫描分支也走回调)从「不带标记、插入被 patch 容器时被二次转译」变为「带标记、原生放行」—— 属良性修正:hint 是 walk 自己插入、`onload` 后自己移除的瞬态节点;且 preload 分支仅在 walk 被 blocking 元素卡住时运行,容器中必已存在带出处位的元素,`containsLoaderStreamedNode` 判定不受影响。标记形态必须维持 symbol 属性而非 DOM attribute:attribute 会随 `cloneNode` 复制、可被应用代码伪造,效果位若可克隆/可伪造即成沙箱逃逸通道(symbol 属性两者皆不会)。
+
+已知限制(现状同,非本 RFC 引入):symbol 标记不随 `cloneNode` 复制 —— 克隆一个带效果位的节点再插入会重新进管线(样式可能被二次 `@scope` 包裹)。单一 `loaderStreamedNode` 时代行为相同,记录备查。
 
 ### D3 创建者机制退役
 
@@ -136,7 +138,7 @@ const config = elementConfigs.get(ownerNode) ?? resolveConfigByPosition(ownerNod
 
 1. **入账⇔摘账对称**(push 进账本的元素必须可被 removeChild 识别摘除,否则复活 #3163 修掉的账本堵塞):D1 的「一律 stamp」在直插、fragment、转译替换(`common.ts:203-204`)三条路径统一保证,比现状(守卫式补 stamp)更强。钉住测试:`stylesheet-ledger.test.ts:70-87`。
 2. hint link 转译但不入账(`common.ts:175-182`):不动。
-3. 已转译节点放行:由效果位承接(D2),语义不变。
+3. 管线节点原生放行:由效果位承接(D2),语义不变。
 4. 回放原生、不重注册:不动(F3)。
 5. `styleElementTargetSymbol`/`refNodeNo` 顺序元数据:不动;插入点模型下 target symbol 的含义(「插入的挂载点」)反而名实相符。
 6. 账本数组与 `elementConfigs` 跨挂载持久:不动。
@@ -154,7 +156,7 @@ const config = elementConfigs.get(ownerNode) ?? resolveConfigByPosition(ownerNod
 
 ## Implementation Plan
 
-**Phase 1 — 标记拆分**(独立可先行,风险低):shared 增 `transpiledNode` 标记对;loader 双打;Compartment 改打效果位;dynamicAppend 三处消费换效果位;`container.ts` 保持出处位。现有测试全量回归(`lifecycle.test.ts:100` 的出处位用法不变)。
+**Phase 1 — 标记拆分**(独立可先行,风险低):shared 增 `nativePassthroughNode` 标记对;loader 双打(盖章点在 `loadEntry` 闭包,见 D2);Compartment 改打效果位;dynamicAppend 三处消费换效果位;`container.ts` 保持出处位。现有测试全量回归(`lifecycle.test.ts:100` 的出处位用法不变)。
 
 **Phase 2 — 归属收敛**:D1(决策行 + 一律 stamp + fragment 简化)、D3(死代码删除)、D5(CSSOM 位置解析)。回归重点:`stylesheet-ledger.test.ts` 全部、`style-isolation.spec.ts:68`(jQuery fragment)、`router-mode.spec.ts:46-63`(共享容器接力竞态)、multi-instance 与 standalone 全套。
 
@@ -163,7 +165,7 @@ const config = elementConfigs.get(ownerNode) ?? resolveConfigByPosition(ownerNod
 ### 嵌套与 evaluateScript 的覆盖实证(变异测试结论)
 
 - **嵌套归属**:`nested-sandbox` 中「外层应用创建、交给内层容器」的节点用例是新旧语义的**真判别式** —— 变异回创建者归属后,该用例精确失败于 `@scope ([data-name="sub-nested"])`(错误归属外层)。其余三条(各自容器内的样式归属、两层全局不外泄、外层卸载连带内层)在新旧模型下都应成立,作用是给已退役的 `__currentLockingSandbox__` 嵌套锁补上回归护栏。该 fixture 同时顺带验证了跨 qiankun 副本的 `Symbol.for` 契约(内外层是两份独立打包的 qiankun)。
-- **evaluateScript 的效果位**:已被现有 `standalone-sandbox` e2e 兜住 —— 去掉 `markNodeTranspiled(script)` 后该用例失败(控制器进入 `failed`,blob script 被二次转译)。
+- **evaluateScript 的效果位**:已被现有 `standalone-sandbox` e2e 兜住 —— 去掉 `markNodeForNativePassthrough(script)` 后该用例失败(控制器进入 `failed`,blob script 被二次转译)。
 - **evaluateScript 的出处位**:端到端**不可达**,已实证 —— 把拆分前的 `markLoaderStreamedNode(script)` 加回去,全部 e2e 依旧通过。原因是双重结构保护:blob script 始终位于 `<qiankun-head>` 内(占用检测的第一个条件因此为 false),且求值 settle 后即被移除。故出处位纯度由单测精确钉住,e2e 覆盖其可达邻域:新增「同容器在一次 classic 求值生命周期后由新控制器重新准备」用例(`standalone-sandbox.spec.ts`),断言虚拟头恰好重建一次、隔离对第二个控制器依然成立。
 
 各 Phase 独立成 conventional commit,`pnpm run ci` + Chromium e2e 全绿为 gate;Phase 2 附带跑一次性能门禁(D5 上溯为冷路径,预期无感,须实证)。
@@ -172,7 +174,7 @@ const config = elementConfigs.get(ownerNode) ?? resolveConfigByPosition(ownerNod
 
 - 不支持两个活跃 app 共享一个容器(现状即不生成该场景,`containerOwners` 维持单 owner)。
 - 不改回放机制、账本数据结构、deferred 队列机制。
-- 不移除「已转译放行」效果位本身 —— 它是流式管线与动态管线并存的必要契约,本 RFC 只让它名实相符。
+- 不移除「原生放行」效果位本身 —— 它是流式管线与动态管线并存的必要契约,本 RFC 只让它名实相符。
 
 ## 附带清理项(顺路,不阻塞)
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -17,7 +17,9 @@ e2e/
 │   ├── sub-classic/     # classic global-lifecycle sub app (the UMD shape), no build step
 │   ├── sub-esm/         # native ESM sub app with a multi-module graph, no build step;
 │   │                    # preload.html variant carries a <link rel="modulepreload"> (vite output shape)
-│   └── sub-misbehaving/ # deliberately bad app: mount errors + leaked intervals (via props)
+│   ├── sub-misbehaving/ # deliberately bad app: mount errors + leaked intervals (via props)
+│   └── sub-nested/      # vite-built classic app that is itself a qiankun host: it bundles its own
+│                        # copy of qiankun and mounts sub-classic-bodyless inside its own DOM
 └── tests/               # suites organized by framework invariants, not by pages
 ```
 
@@ -33,6 +35,7 @@ Suites map to qiankun's core promises:
 - `style-isolation` — `@scope` based CSS isolation, with a control test documenting the unisolated leak
 - `error-handling` — 404 entries and throwing mounts reject cleanly without breaking the main app
 - `multi-instance` — same app twice in independent sandboxes, mixed classic + esm coexistence
+- `nested-sandbox` — qiankun inside qiankun: DOM ownership under chained document proxies (each app owns what its own container receives, including a node the outer app hands to the inner container)
 - `router-mode` — route-driven mount/unmount/switch including history back
 - `standalone-sandbox` — direct package use without qiankun/loader, including the no-`unsafe-eval` CSP path
 
@@ -56,7 +59,7 @@ pnpm run test:e2e:ui     # playwright UI mode for debugging
 
 First time only: `npx playwright install chromium` (or `--with-deps` on linux).
 
-Sub-app fixtures are served directly from source. `fixtures/main` and `examples/standalone-sandbox` need builds (`pnpm run build:fixtures`, done automatically by the test scripts). After changing any `packages/*` source, rebuild the packages and both built fixtures, since they bundle the local workspace code.
+Sub-app fixtures are served directly from source. `fixtures/main`, `fixtures/sub-nested`, and `examples/standalone-sandbox` need builds (`pnpm run build:fixtures`, done automatically by the test scripts). Note that `ports.ts` is bundled into the built fixtures, so changing it requires rebuilding them. After changing any `packages/*` source, rebuild the packages and both built fixtures, since they bundle the local workspace code.
 
 ## Rules (anti-flake discipline)
 

--- a/e2e/fixtures/sub-classic/entry-patched-append.js
+++ b/e2e/fixtures/sub-classic/entry-patched-append.js
@@ -1,0 +1,54 @@
+(function (global) {
+  var mounted = false;
+  var observed = [];
+
+  // The business monkey-patch shape: wrap the appendChild you can see, remember the original,
+  // delegate to it. Apps (and SDKs they ship) do this to observe or decorate DOM insertions;
+  // the sandbox pipeline must keep such a wrapper effective instead of bypassing it.
+  function wrapAppendChild(target, label) {
+    var original = target.appendChild;
+    target.appendChild = function (node) {
+      observed.push(label + ':' + (node.tagName || '').toLowerCase());
+      return original.call(this, node);
+    };
+  }
+
+  function appendStyle(targetElement, testId, cssText) {
+    var style = document.createElement('style');
+    style.setAttribute('data-testid', testId);
+    style.textContent = cssText;
+    targetElement.appendChild(style);
+  }
+
+  global['sub-classic-patched-append'] = {
+    bootstrap: function () {
+      return Promise.resolve();
+    },
+    mount: function () {
+      if (!mounted) {
+        wrapAppendChild(document.head, 'head');
+        wrapAppendChild(document.body, 'body');
+
+        appendStyle(
+          document.head,
+          'patched-append-head-style',
+          '.patched-append-head-target { color: rgb(61, 62, 63) }',
+        );
+        appendStyle(
+          document.body,
+          'patched-append-body-style',
+          '.patched-append-body-target { color: rgb(71, 72, 73) }',
+        );
+        mounted = true;
+      }
+
+      var report = document.querySelector('[data-testid="patched-append-observed"]');
+      if (report) report.textContent = observed.join(',');
+
+      return Promise.resolve();
+    },
+    unmount: function () {
+      return Promise.resolve();
+    },
+  };
+})(window);

--- a/e2e/fixtures/sub-classic/patched-append.html
+++ b/e2e/fixtures/sub-classic/patched-append.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>sub-classic-patched-append</title>
+  </head>
+  <body>
+    <main id="patched-append-root">
+      <p class="patched-append-head-target" data-testid="patched-append-head-target">head style target</p>
+      <p class="patched-append-body-target" data-testid="patched-append-body-target">body style target</p>
+      <!-- filled by the app with what its own appendChild wrappers observed -->
+      <p data-testid="patched-append-observed"></p>
+    </main>
+    <script src="./entry-patched-append.js" entry></script>
+  </body>
+</html>

--- a/e2e/fixtures/sub-nested/public/index.html
+++ b/e2e/fixtures/sub-nested/public/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>sub-nested</title>
+  </head>
+  <body>
+    <div id="nested-root">
+      <p class="nested-outer-target" data-testid="nested-outer-target">outer app style target</p>
+      <!-- the inner qiankun app is mounted here, inside the outer app's own DOM -->
+      <div id="nested-inner-container"></div>
+    </div>
+    <script src="./entry.js" entry></script>
+  </body>
+</html>

--- a/e2e/fixtures/sub-nested/src/main.ts
+++ b/e2e/fixtures/sub-nested/src/main.ts
@@ -1,0 +1,67 @@
+/**
+ * Nested sub app: a classic (UMD-shaped) app that is itself a qiankun host — it bundles its own
+ * copy of qiankun and loads another sub app into a container inside its own DOM.
+ *
+ * The point of the fixture is attribution under nesting: every DOM API this app and its inner app
+ * touch goes through a *chain* of proxied documents (inner sandbox → outer sandbox → real), so the
+ * styles each one injects must still be owned by the app whose container receives them.
+ */
+import { loadMicroApp, type MicroApp } from 'qiankun';
+import { SUB_APP_ENTRIES } from '../../../ports';
+
+// pollute the outer app's sandboxed window; must stay invisible to the main realm
+(window as unknown as Record<string, unknown>).__NESTED_OUTER_POLLUTION__ = 'from-sub-nested';
+
+const INNER_APP_NAME = 'nested-inner';
+
+let innerApp: MicroApp | undefined;
+let outerStyleInjected = false;
+
+function injectOuterStyle(): void {
+  if (outerStyleInjected) return;
+  // created through the outer sandbox's document and appended to the outer virtual head
+  const style = document.createElement('style');
+  style.setAttribute('data-testid', 'nested-outer-style');
+  style.textContent = '.nested-outer-target { color: rgb(41, 42, 43) }';
+  document.head.appendChild(style);
+  outerStyleInjected = true;
+}
+
+const lifecycles = {
+  bootstrap(): Promise<void> {
+    return Promise.resolve();
+  },
+  async mount(): Promise<void> {
+    injectOuterStyle();
+
+    const container = document.querySelector<HTMLElement>('#nested-inner-container');
+    if (!container) throw new Error('nested inner container was not found');
+
+    innerApp = loadMicroApp(
+      { name: INNER_APP_NAME, entry: SUB_APP_ENTRIES['sub-classic-bodyless'], container },
+      { sandbox: { styleIsolation: true } },
+    );
+    await innerApp.mountPromise;
+
+    // Created in the OUTER app's realm, then handed to the INNER app's container — the shape a
+    // host takes when it decorates a child app's mount node. Ownership must follow the container
+    // that receives the node, so this rule has to be scoped to the inner app, not to this one.
+    const crossTarget = document.createElement('p');
+    crossTarget.className = 'nested-cross-target';
+    crossTarget.setAttribute('data-testid', 'nested-cross-target');
+    crossTarget.textContent = 'inserted by the outer app into the inner container';
+    container.appendChild(crossTarget);
+
+    const crossStyle = document.createElement('style');
+    crossStyle.setAttribute('data-testid', 'nested-cross-style');
+    crossStyle.textContent = '.nested-cross-target { color: rgb(51, 52, 53) }';
+    container.appendChild(crossStyle);
+  },
+  async unmount(): Promise<void> {
+    await innerApp?.unmount();
+    innerApp = undefined;
+  },
+};
+
+// must stay the last global write of the entry script: the sandbox reports it as the app's export
+(window as unknown as Record<string, unknown>)['sub-nested'] = lifecycles;

--- a/e2e/fixtures/sub-nested/vite.config.ts
+++ b/e2e/fixtures/sub-nested/vite.config.ts
@@ -1,0 +1,23 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  // library mode leaves process.env.NODE_ENV to the consumer; this bundle runs straight in a
+  // browser (inside the outer sandbox), so it has to be resolved at build time
+  define: { 'process.env.NODE_ENV': '"production"' },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    // keep the bundle readable when debugging trace snapshots
+    minify: false,
+    sourcemap: true,
+    lib: {
+      entry: fileURLToPath(new URL('src/main.ts', import.meta.url)),
+      // classic script output: the outer app must load this as a UMD-shaped `entry` script,
+      // which is what exercises the classic evaluation path of the outer sandbox
+      formats: ['iife'],
+      name: '__subNestedBundle',
+      fileName: () => 'entry.js',
+    },
+  },
+});

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "build:fixtures": "tsc -p tsconfig.json --noEmit && vite build fixtures/main && pnpm --filter @qiankunjs/example-standalone-sandbox run build",
+    "build:fixtures": "tsc -p tsconfig.json --noEmit && vite build fixtures/main && vite build fixtures/sub-nested && pnpm --filter @qiankunjs/example-standalone-sandbox run build",
     "test:e2e": "pnpm run build:fixtures && playwright test --project=chromium",
     "test:e2e:all": "pnpm run build:fixtures && playwright test",
     "test:e2e:ui": "pnpm run build:fixtures && playwright test --ui"

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -42,6 +42,11 @@ export default defineConfig({
       reuseExistingServer: !CI,
     },
     {
+      command: `node servers/serve.mjs fixtures/sub-nested/dist ${PORTS['sub-nested']}`,
+      url: `http://localhost:${PORTS['sub-nested']}`,
+      reuseExistingServer: !CI,
+    },
+    {
       command: `node servers/serve.mjs ../examples/standalone-sandbox/dist ${PORTS['standalone-sandbox']}`,
       url: `http://localhost:${PORTS['standalone-sandbox']}`,
       reuseExistingServer: !CI,

--- a/e2e/ports.ts
+++ b/e2e/ports.ts
@@ -7,6 +7,7 @@ export const PORTS = {
   'sub-esm': 7502,
   'sub-misbehaving': 7503,
   'standalone-sandbox': 7504,
+  'sub-nested': 7505,
 } as const;
 
 export const SUB_APP_ENTRIES = {
@@ -20,6 +21,8 @@ export const SUB_APP_ENTRIES = {
   // same server, dedicated page whose HTML carries a <link rel="modulepreload">
   'sub-esm-preload': `http://localhost:${PORTS['sub-esm']}/preload.html`,
   'sub-misbehaving': `http://localhost:${PORTS['sub-misbehaving']}`,
+  // a classic app that is itself a qiankun host: it loads sub-classic-bodyless inside its own DOM
+  'sub-nested': `http://localhost:${PORTS['sub-nested']}`,
   // resolves to a 404 on purpose: the error-handling suite asserts the failure path
   'sub-missing': `http://localhost:${PORTS['sub-misbehaving']}/missing/`,
 } as const;

--- a/e2e/ports.ts
+++ b/e2e/ports.ts
@@ -17,6 +17,8 @@ export const SUB_APP_ENTRIES = {
   // explicit <head>, intentionally no <body>: exercises the fragment parsing + sandbox body facade
   'sub-classic-bodyless': `http://localhost:${PORTS['sub-classic']}/bodyless.html`,
   'sub-classic-broken-asset': `http://localhost:${PORTS['sub-classic']}/broken-asset.html`,
+  // the app monkey-patches the document.head/body appendChild it sees before injecting styles
+  'sub-classic-patched-append': `http://localhost:${PORTS['sub-classic']}/patched-append.html`,
   'sub-esm': `http://localhost:${PORTS['sub-esm']}`,
   // same server, dedicated page whose HTML carries a <link rel="modulepreload">
   'sub-esm-preload': `http://localhost:${PORTS['sub-esm']}/preload.html`,

--- a/e2e/tests/nested-sandbox.spec.ts
+++ b/e2e/tests/nested-sandbox.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from '@playwright/test';
+import { loadApp, readMainRealmGlobal, unmountApp } from './helpers';
+
+const OUTER_STYLE = 'rgb(41, 42, 43)';
+const INNER_HEAD_STYLE = 'rgb(21, 22, 23)';
+const INNER_BODY_STYLE = 'rgb(31, 32, 33)';
+const CROSS_STYLE = 'rgb(51, 52, 53)';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test.describe('nested sandboxes (a sub app hosting its own sub app)', () => {
+  test('each app owns the nodes its own container receives, not the ones its realm created', async ({ page }) => {
+    await loadApp(page, 'sub-nested', { sandbox: { styleIsolation: true } });
+
+    const outerContainer = page.locator('[data-name="sub-nested"]');
+    const innerContainer = page.locator('[data-name="nested-inner"]');
+    await expect(outerContainer).toHaveCount(1);
+    // the inner app is mounted inside the outer app's own DOM
+    await expect(outerContainer.locator('[data-name="nested-inner"]')).toHaveCount(1);
+
+    // Every element below was created through a chain of proxied documents (inner sandbox
+    // delegating to the outer one), so creator identity is ambiguous by construction. Ownership
+    // must follow the container that received the node.
+    const outerStyle = outerContainer.locator(':scope > qiankun-head > style[data-testid="nested-outer-style"]');
+    const innerHeadStyle = innerContainer.locator(
+      ':scope > qiankun-head > style[data-testid="bodyless-dynamic-head-style"]',
+    );
+    const innerBodyStyle = innerContainer.locator(':scope > style[data-testid="bodyless-dynamic-body-style"]');
+    await expect(outerStyle).toHaveCount(1);
+    await expect(innerHeadStyle).toHaveCount(1);
+    await expect(innerBodyStyle).toHaveCount(1);
+
+    const preludes = await Promise.all(
+      [outerStyle, innerHeadStyle, innerBodyStyle].map((style) =>
+        style.evaluate((element) => (element.textContent ?? '').trim().split('{')[0].trim()),
+      ),
+    );
+    expect(preludes).toEqual([
+      '@scope ([data-name="sub-nested"])',
+      '@scope ([data-name="nested-inner"])',
+      '@scope ([data-name="nested-inner"])',
+    ]);
+
+    // and the scoped rules really apply to the app that owns them
+    await expect(page.getByTestId('nested-outer-target')).toHaveCSS('color', OUTER_STYLE);
+    await expect(page.getByTestId('bodyless-dynamic-head-target')).toHaveCSS('color', INNER_HEAD_STYLE);
+    await expect(page.getByTestId('bodyless-dynamic-body-target')).toHaveCSS('color', INNER_BODY_STYLE);
+  });
+
+  test('a node created by the outer app but inserted into the inner container belongs to the inner app', async ({
+    page,
+  }) => {
+    await loadApp(page, 'sub-nested', { sandbox: { styleIsolation: true } });
+
+    const innerContainer = page.locator('[data-name="nested-inner"]');
+    const crossStyle = innerContainer.locator(':scope > style[data-testid="nested-cross-style"]');
+    await expect(crossStyle).toHaveCount(1);
+
+    // The creator realm (outer) and the receiving container (inner) disagree here — the container
+    // wins, so the rule carries the inner app's scope root and applies inside it.
+    const prelude = await crossStyle.evaluate((element) => (element.textContent ?? '').trim().split('{')[0].trim());
+    expect(prelude).toBe('@scope ([data-name="nested-inner"])');
+    await expect(page.getByTestId('nested-cross-target')).toHaveCSS('color', CROSS_STYLE);
+  });
+
+  test('neither nesting level leaks its globals into the main realm', async ({ page }) => {
+    await loadApp(page, 'sub-nested', { sandbox: { styleIsolation: true } });
+    await expect(page.getByTestId('bodyless-dynamic-head-target')).toBeVisible();
+
+    expect(await readMainRealmGlobal(page, '__NESTED_OUTER_POLLUTION__')).toBeUndefined();
+    // the lifecycle globals of both levels stay inside their own sandbox
+    const exposedLifecycles = await page.evaluate(() => ({
+      outer: Reflect.has(window, 'sub-nested'),
+      inner: Reflect.has(window, 'sub-classic-bodyless'),
+    }));
+    expect(exposedLifecycles).toEqual({ outer: false, inner: false });
+  });
+
+  test('unmounting the outer app tears the inner one down with it', async ({ page }) => {
+    await loadApp(page, 'sub-nested', { sandbox: { styleIsolation: true } });
+    await expect(page.locator('[data-name="nested-inner"]')).toHaveCount(1);
+
+    await unmountApp(page, 'sub-nested');
+
+    await expect(page.locator('[data-name="nested-inner"]')).toHaveCount(0);
+    await expect(page.getByTestId('bodyless-dynamic-head-target')).toHaveCount(0);
+    await expect(page.getByTestId('nested-outer-target')).toHaveCount(0);
+    expect(await readMainRealmGlobal(page, '__NESTED_OUTER_POLLUTION__')).toBeUndefined();
+  });
+});

--- a/e2e/tests/standalone-sandbox.spec.ts
+++ b/e2e/tests/standalone-sandbox.spec.ts
@@ -61,3 +61,44 @@ test('standalone package isolates classic, ESM, DOM, styles, and side effects wi
   await page.evaluate(() => window.dispatchEvent(new Event('standalone-widget:ping')));
   await expect(page.locator('[data-metric="acks"]')).toHaveText('1');
 });
+
+/**
+ * A second controller taking over the same caller-owned container after a full classic-script
+ * evaluation lifecycle. The container preparation of that second mount has to see a plain host
+ * element again: nodes the compartment itself puts in the container while evaluating (its internal
+ * blob script) are pipeline-internal, and must never make the container look like it already holds
+ * streamed entry content — which would skip creating the virtual head the app then mounts into.
+ */
+test('a fresh controller re-prepares the same container after a classic evaluation', async ({ browserName, page }) => {
+  test.fail(browserName === 'firefox', FIREFOX_IMPORT_MAP_LIMITATION);
+
+  await page.goto(`${STANDALONE_ORIGIN}/`);
+
+  const state = page.locator('[data-controller-state]');
+  const container = page.locator('#sandbox-container');
+  const widget = container.locator('.third-party-widget');
+  await expect(state).toHaveAttribute('data-state', 'running');
+  await expect(container.locator('qiankun-head')).toHaveCount(1);
+
+  await page.locator('[data-action="dispose"]').click();
+  await expect(state).toHaveAttribute('data-state', 'disposed');
+  await expect(container.locator('qiankun-head')).toHaveCount(0);
+
+  await page.locator('[data-action="run"]').click();
+  await expect(state).toHaveAttribute('data-state', 'running');
+
+  // exactly one virtual head — neither skipped nor duplicated — and the widget is live again
+  await expect(container.locator('qiankun-head')).toHaveCount(1);
+  await expect(widget).toBeVisible();
+  await expect(widget).toHaveAttribute('data-dynamic-script', 'contained');
+  await expect(container).toHaveAttribute('data-esm-status', 'esm-graph-ready:true');
+
+  // and isolation still holds for the second controller
+  const isolatedStyle = container.locator('qiankun-head style');
+  await expect.poll(async () => isolatedStyle.textContent()).toContain('@scope ([data-name="pulseboard-widget"])');
+  const realmState = await page.evaluate(() => ({
+    classic: Reflect.has(window, '__STANDALONE_WIDGET__'),
+    esm: Reflect.has(window, '__STANDALONE_ESM__'),
+  }));
+  expect(realmState).toEqual({ classic: false, esm: false });
+});

--- a/e2e/tests/style-isolation.spec.ts
+++ b/e2e/tests/style-isolation.spec.ts
@@ -88,6 +88,36 @@ test.describe('runtime style isolation (@scope)', () => {
     expect(bodyBg).not.toBe(INJECTED);
   });
 
+  test('an app wrapping its own appendChild keeps its patch effective while styles stay piped and scoped', async ({
+    page,
+  }) => {
+    const HEAD = 'rgb(61, 62, 63)';
+    const BODY = 'rgb(71, 72, 73)';
+
+    await loadApp(page, 'sub-classic-patched-append', { sandbox: { styleIsolation: true } });
+
+    // the app wrapped the document.head/body appendChild it sees before injecting its styles —
+    // the sandbox pipeline must run *underneath* that wrapper, not bypass it: both insertions
+    // were observed by the app's own patch logic
+    await expect(page.getByTestId('patched-append-observed')).toHaveText('head:style,body:style');
+
+    // and delegating to the wrapped original still routed both styles through the pipeline
+    const container = page.locator('[data-name="sub-classic-patched-append"]');
+    const headStyle = container.locator(':scope > qiankun-head > style[data-testid="patched-append-head-style"]');
+    const bodyStyle = container.locator(':scope > style[data-testid="patched-append-body-style"]');
+    await expect(headStyle).toHaveCount(1);
+    await expect(bodyStyle).toHaveCount(1);
+    const scopedStyles = await Promise.all(
+      [headStyle, bodyStyle].map((style) =>
+        style.evaluate((element) => (element.textContent ?? '').trim().startsWith('@scope')),
+      ),
+    );
+    expect(scopedStyles).toEqual([true, true]);
+
+    await expect(page.getByTestId('patched-append-head-target')).toHaveCSS('color', HEAD);
+    await expect(page.getByTestId('patched-append-body-target')).toHaveCSS('color', BODY);
+  });
+
   test('a dynamically injected chunk-CSS link fires its load event and stays scoped', async ({ page }) => {
     const LAZY = 'rgb(4, 5, 6)';
 

--- a/packages/loader/AGENTS.md
+++ b/packages/loader/AGENTS.md
@@ -53,9 +53,14 @@ isDeferScript; // external + [defer]  → ordered via shared prepareDeferredQueu
 
 Nodes are parsed/transformed in a detached document first, then moved to live DOM — this prevents premature script execution before the transpiler has rewritten the node.
 
+### writable-dom fork discipline
+
+`writable-dom/` is vendored from marko-js/writable-dom and periodically re-synced; every deviation carries a `[qiankun]` comment so syncs can re-apply them mechanically. Changes there demand deliberate thought and must stay **generic**: general-purpose hooks or upstream bug fixes only — never qiankun-specific semantics coupled to other packages (no `@qiankunjs/*` imports, no sandbox marks, no downstream contract knowledge). The fork's one integration seam is the `assetTransformer` callback (every element passes through it right before insertion); downstream bookkeeping — e.g. the pipeline marks the sandbox patcher consumes — belongs in the callback `loadEntry` provides (`index.ts`), on the caller's side of that seam.
+
 ## ANTI-PATTERNS
 
 - **NEVER** include more than one `entry` script per HTML entry (throws `QiankunError`).
+- **NEVER** add qiankun-coupled logic inside `writable-dom/` — generic designs only; hang caller bookkeeping on the `assetTransformer` callback in `loadEntry` (see the fork discipline above).
 - **FIXME** (in code): non-standard HTML chunks that lack a `<head>` tag.
 
 ## EXPORTS (`src/index.ts`)

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -5,7 +5,13 @@ import type {
   NodeTransformer,
   ScriptTranspilerOpts,
 } from '@qiankunjs/shared';
-import { Deferred, prepareDeferredQueue, QiankunError } from '@qiankunjs/shared';
+import {
+  Deferred,
+  markLoaderStreamedNode,
+  markNodeForNativePassthrough,
+  prepareDeferredQueue,
+  QiankunError,
+} from '@qiankunjs/shared';
 import { createTagTransformStream } from './TagTransformStream';
 import WritableDOMStream from './writable-dom';
 
@@ -112,6 +118,17 @@ export async function loadEntry<T>(
       )
       .pipeTo(
         new WritableDOMStream(container, null, (clone) => {
+          /*
+           * Every element the walk is about to insert flows through this callback, which makes it
+           * the loader-side seam for the qiankun pipeline marks (writable-dom itself stays free of
+           * downstream knowledge): the effect mark tells the sandbox's patched container methods
+           * to let the node through natively; the provenance mark lets the sandbox detect that a
+           * container holds streamed entry content. Preload hints stamped here pass the patched
+           * methods untouched too — they are the walk's own transient nodes.
+           */
+          markNodeForNativePassthrough(clone);
+          markLoaderStreamedNode(clone);
+
           let transformerOpts: AssetsTranspilerOpts = {
             classicScriptTransformer,
             compartment,

--- a/packages/loader/src/writable-dom/index.ts
+++ b/packages/loader/src/writable-dom/index.ts
@@ -3,19 +3,16 @@
  *
  * Keep this file in sync with upstream: every qiankun-specific deviation is marked with a
  * `[qiankun]` comment so periodic syncs can re-apply them mechanically. The deviations are:
- * - the `assetTransformer` parameter: transpiles every node in place right before insertion
- *   (enforced by assertInPlaceTransform), including inline script/style text via a grafted host
+ * - the `assetTransformer` parameter: transforms every element in place right before insertion
+ *   (enforced by assertInPlaceTransform), including inline script/style text via a grafted host.
+ *   The callback is the walk's only integration seam — callers hang their own bookkeeping
+ *   (e.g. marking nodes) on it, this file stays free of downstream knowledge
  * - `isSyncScript` + `clone.async = false`: preserve document order for non-blocking external
  *   scripts (see https://github.com/marko-js/writable-dom/issues/7)
- * - `markNodeTranspiled` + `markLoaderStreamedNode`: the effect mark lets the sandbox's patched
- *   container methods pass already-transpiled nodes through natively; the provenance mark lets
- *   the sandbox detect that a container holds streamed entry content
  * - preload hints read the raw attributes (getAttribute) instead of the resolved properties, so
  *   the transformer can resolve them against the app entry rather than the host document
  * - an href-less stylesheet link is inert and must not block the walk
  */
-import { markLoaderStreamedNode, markNodeTranspiled } from '@qiankunjs/shared';
-
 enum NodeType {
   ELEMENT_NODE = 1,
   TEXT_NODE = 3,
@@ -190,12 +187,6 @@ function writableDOM(
           if (isSyncScript(clone)) {
             clone.async = false;
           }
-
-          // [qiankun] effect mark: this walk transpiles the node below, the sandbox's patched
-          // container methods must pass it through natively. Provenance mark: the sandbox's
-          // container protocol detects streamed entry content by it.
-          markNodeTranspiled(clone);
-          markLoaderStreamedNode(clone);
 
           // [qiankun] transpile the node in place right before insertion. The blocking bookkeeping
           // above stays wired to it; a transformer that also listens for load/error (e.g. the

--- a/packages/loader/src/writable-dom/index.ts
+++ b/packages/loader/src/writable-dom/index.ts
@@ -7,13 +7,14 @@
  *   (enforced by assertInPlaceTransform), including inline script/style text via a grafted host
  * - `isSyncScript` + `clone.async = false`: preserve document order for non-blocking external
  *   scripts (see https://github.com/marko-js/writable-dom/issues/7)
- * - `markLoaderStreamedNode`: lets the sandbox's patched container methods tell streamed
- *   (already-transpiled) nodes apart from dynamic insertions made by app code
+ * - `markNodeTranspiled` + `markLoaderStreamedNode`: the effect mark lets the sandbox's patched
+ *   container methods pass already-transpiled nodes through natively; the provenance mark lets
+ *   the sandbox detect that a container holds streamed entry content
  * - preload hints read the raw attributes (getAttribute) instead of the resolved properties, so
  *   the transformer can resolve them against the app entry rather than the host document
  * - an href-less stylesheet link is inert and must not block the walk
  */
-import { markLoaderStreamedNode } from '@qiankunjs/shared';
+import { markLoaderStreamedNode, markNodeTranspiled } from '@qiankunjs/shared';
 
 enum NodeType {
   ELEMENT_NODE = 1,
@@ -190,8 +191,10 @@ function writableDOM(
             clone.async = false;
           }
 
-          // [qiankun] let the sandbox's patched container methods tell streamed nodes (already
-          // transpiled by this walk) apart from dynamic insertions made by app code
+          // [qiankun] effect mark: this walk transpiles the node below, the sandbox's patched
+          // container methods must pass it through natively. Provenance mark: the sandbox's
+          // container protocol detects streamed entry content by it.
+          markNodeTranspiled(clone);
           markLoaderStreamedNode(clone);
 
           // [qiankun] transpile the node in place right before insertion. The blocking bookkeeping

--- a/packages/sandbox/src/core/compartment/index.ts
+++ b/packages/sandbox/src/core/compartment/index.ts
@@ -1,6 +1,6 @@
 import {
   EsmSandboxEngine,
-  markLoaderStreamedNode,
+  markNodeTranspiled,
   QiankunError,
   type DocumentModule,
   type ModuleNamespace,
@@ -180,7 +180,7 @@ export class Compartment implements CompartmentLoaderFacade {
 
     // The script is already transformed. Prevent the dynamic-append pipeline from
     // fetching and wrapping this internal blob a second time.
-    markLoaderStreamedNode(script);
+    markNodeTranspiled(script);
     script.async = false;
 
     await new Promise<void>((resolve, reject) => {

--- a/packages/sandbox/src/core/compartment/index.ts
+++ b/packages/sandbox/src/core/compartment/index.ts
@@ -1,6 +1,6 @@
 import {
   EsmSandboxEngine,
-  markNodeTranspiled,
+  markNodeForNativePassthrough,
   QiankunError,
   type DocumentModule,
   type ModuleNamespace,
@@ -180,7 +180,7 @@ export class Compartment implements CompartmentLoaderFacade {
 
     // The script is already transformed. Prevent the dynamic-append pipeline from
     // fetching and wrapping this internal blob a second time.
-    markNodeTranspiled(script);
+    markNodeForNativePassthrough(script);
     script.async = false;
 
     await new Promise<void>((resolve, reject) => {

--- a/packages/sandbox/src/patchers/dynamicAppend/__tests__/attribution.test.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/__tests__/attribution.test.ts
@@ -95,6 +95,23 @@ describe.sequential('insertion-point attribution', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('re-attributed'));
   });
 
+  it('clears the mount-point stamps once the sandbox is disposed', async () => {
+    const { container, controller } = createController();
+    await controller.mount(container);
+
+    const headElement = container.querySelector<HTMLElement>('qiankun-head');
+    if (!headElement) throw new Error('virtual head was not prepared');
+    const config = getSandboxConfigOf(controller);
+    expect(getSharedState().elementConfigs.get(container)).toBe(config);
+    expect(getSharedState().elementConfigs.get(headElement)).toBe(config);
+
+    await controller.dispose();
+
+    // a disposed sandbox must no longer be resolvable as a style owner by DOM position
+    expect(getSharedState().elementConfigs.get(container)).toBeUndefined();
+    expect(getSharedState().elementConfigs.get(headElement)).toBeUndefined();
+  });
+
   it('passes pipeline-transpiled nodes through natively', async () => {
     const transformedNodes: Node[] = [];
     const { container, controller } = createController((node) => {

--- a/packages/sandbox/src/patchers/dynamicAppend/__tests__/attribution.test.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/__tests__/attribution.test.ts
@@ -1,0 +1,170 @@
+import type { IsolationPluginConfig } from '../../types';
+import { createSandbox } from '../../../core/sandbox';
+import { containsLoaderStreamedNode } from '../../../core/sandbox/container';
+import type { SandboxConfig } from '../types';
+import { markLoaderStreamedNode, markNodeTranspiled } from '@qiankunjs/shared';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const identityNodeTransformer: IsolationPluginConfig['nodeTransformer'] = (node) => node;
+
+let appSequence = 0;
+const controllers: Array<ReturnType<typeof createSandbox>> = [];
+const containers: HTMLElement[] = [];
+
+function createController(nodeTransformer: IsolationPluginConfig['nodeTransformer'] = identityNodeTransformer) {
+  const appName = `attribution-${String(appSequence++)}`;
+  const container = document.createElement('div');
+  container.innerHTML = '<qiankun-head></qiankun-head>';
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const controller = createSandbox(appName, {
+    container: () => container,
+    fetch: window.fetch,
+    nodeTransformer,
+    styleIsolation: true,
+  });
+  controllers.push(controller);
+  return { container, controller };
+}
+
+function getSharedState() {
+  return Reflect.get(window, Symbol.for('qiankun.dynamicAppend.sharedState')) as {
+    sandboxConfigs: WeakMap<object, SandboxConfig>;
+    elementConfigs: WeakMap<HTMLElement, SandboxConfig>;
+  };
+}
+
+function getSandboxConfigOf(controller: ReturnType<typeof createSandbox>): SandboxConfig {
+  const config = getSharedState().sandboxConfigs.get(controller.instance);
+  if (!config) throw new Error('sandbox config was not registered at bootstrap');
+  return config;
+}
+
+describe.sequential('insertion-point attribution', () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(controllers.splice(0).map(async (controller) => controller.dispose()));
+    containers.splice(0).forEach((container) => container.remove());
+  });
+
+  it('no longer stamps ownership at createElement time', async () => {
+    const { container, controller } = createController();
+    await controller.mount(container);
+
+    const script = controller.instance.globalThis.document.createElement('script');
+    expect(getSharedState().elementConfigs.get(script)).toBeUndefined();
+  });
+
+  it('attributes a hijackable element to its insertion point regardless of creator', async () => {
+    const a = createController();
+    const b = createController();
+    await a.controller.mount(a.container);
+    await b.controller.mount(b.container);
+
+    // created through B's sandboxed document, inserted into A's container
+    const stylesheet = b.controller.instance.globalThis.document.createElement('link');
+    stylesheet.rel = 'stylesheet';
+    stylesheet.setAttribute('href', 'data:text/css,.cross{}');
+    a.container.appendChild(stylesheet);
+
+    const configA = getSandboxConfigOf(a.controller);
+    expect(getSharedState().elementConfigs.get(stylesheet)).toBe(configA);
+    expect(configA.dynamicStyleSheetElements).toContain(stylesheet);
+    expect(getSandboxConfigOf(b.controller).dynamicStyleSheetElements).not.toContain(stylesheet);
+  });
+
+  it('re-attributes an element moved across mount points and warns about it', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const a = createController();
+    const b = createController();
+    await a.controller.mount(a.container);
+    await b.controller.mount(b.container);
+
+    const stylesheet = document.createElement('link');
+    stylesheet.rel = 'stylesheet';
+    stylesheet.setAttribute('href', 'data:text/css,.moved{}');
+    a.container.appendChild(stylesheet);
+    a.container.removeChild(stylesheet);
+    expect(getSandboxConfigOf(a.controller).dynamicStyleSheetElements).not.toContain(stylesheet);
+
+    b.container.appendChild(stylesheet);
+
+    expect(getSharedState().elementConfigs.get(stylesheet)).toBe(getSandboxConfigOf(b.controller));
+    expect(getSandboxConfigOf(b.controller).dynamicStyleSheetElements).toContain(stylesheet);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('re-attributed'));
+  });
+
+  it('passes pipeline-transpiled nodes through natively', async () => {
+    const transformedNodes: Node[] = [];
+    const { container, controller } = createController((node) => {
+      transformedNodes.push(node);
+      return node;
+    });
+    await controller.mount(container);
+
+    const stylesheet = document.createElement('link');
+    stylesheet.rel = 'stylesheet';
+    stylesheet.setAttribute('href', 'data:text/css,.transpiled{}');
+    markNodeTranspiled(stylesheet);
+    container.appendChild(stylesheet);
+
+    expect(container.contains(stylesheet)).toBe(true);
+    expect(transformedNodes).not.toContain(stylesheet);
+    expect(getSharedState().elementConfigs.get(stylesheet)).toBeUndefined();
+    expect(getSandboxConfigOf(controller).dynamicStyleSheetElements).not.toContain(stylesheet);
+  });
+
+  it('keeps the transpiled effect mark invisible to streamed-content detection', async () => {
+    const { container, controller } = createController();
+    await controller.mount(container);
+
+    // an internal pipeline node (e.g. a compartment blob script) is transpiled but not streamed
+    const blobScript = document.createElement('script');
+    markNodeTranspiled(blobScript);
+    container.appendChild(blobScript);
+    expect(containsLoaderStreamedNode(container)).toBe(false);
+
+    const streamedNode = document.createElement('div');
+    markNodeTranspiled(streamedNode);
+    markLoaderStreamedNode(streamedNode);
+    container.appendChild(streamedNode);
+    expect(containsLoaderStreamedNode(container)).toBe(true);
+  });
+
+  it('scopes insertRule by the stylesheet current DOM position', async () => {
+    const { container, controller } = createController();
+    await controller.mount(container);
+    const config = getSandboxConfigOf(controller);
+
+    // injected below a non-mount-point insertion target, as CSS-in-JS custom targets do
+    const deepTarget = document.createElement('div');
+    container.appendChild(deepTarget);
+    const style = document.createElement('style');
+    deepTarget.appendChild(style);
+    expect(getSharedState().elementConfigs.get(style)).toBeUndefined();
+
+    // happy-dom sheets carry no ownerNode, so drive the patched prototype with an explicit one;
+    // ownership resolution runs before the native insertRule call, which may reject the fake sheet
+    const { insertRule } = CSSStyleSheet.prototype;
+    const sheetOf = (ownerNode: HTMLElement) => ({ ownerNode }) as unknown as CSSStyleSheet;
+    try {
+      insertRule.call(sheetOf(style), '.deep { color: red; }', 0);
+    } catch {
+      /* resolution already happened */
+    }
+    // ownership resolved by position (nearest tagged ancestor is the container mount point)
+    expect(getSharedState().elementConfigs.get(style)).toBe(config);
+
+    // a stylesheet living outside any tagged container resolves to no owner and stays unscoped
+    const outsideStyle = document.createElement('style');
+    document.body.appendChild(outsideStyle);
+    try {
+      insertRule.call(sheetOf(outsideStyle), '.outside { color: red; }', 0);
+    } catch {
+      /* resolution already happened */
+    }
+    expect(getSharedState().elementConfigs.get(outsideStyle)).toBeUndefined();
+    outsideStyle.remove();
+  });
+});

--- a/packages/sandbox/src/patchers/dynamicAppend/__tests__/attribution.test.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/__tests__/attribution.test.ts
@@ -2,7 +2,7 @@ import type { IsolationPluginConfig } from '../../types';
 import { createSandbox } from '../../../core/sandbox';
 import { containsLoaderStreamedNode } from '../../../core/sandbox/container';
 import type { SandboxConfig } from '../types';
-import { markLoaderStreamedNode, markNodeTranspiled } from '@qiankunjs/shared';
+import { markLoaderStreamedNode, markNodeForNativePassthrough } from '@qiankunjs/shared';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const identityNodeTransformer: IsolationPluginConfig['nodeTransformer'] = (node) => node;
@@ -112,7 +112,7 @@ describe.sequential('insertion-point attribution', () => {
     expect(getSharedState().elementConfigs.get(headElement)).toBeUndefined();
   });
 
-  it('passes pipeline-transpiled nodes through natively', async () => {
+  it('passes pipeline-marked nodes through natively', async () => {
     const transformedNodes: Node[] = [];
     const { container, controller } = createController((node) => {
       transformedNodes.push(node);
@@ -123,7 +123,7 @@ describe.sequential('insertion-point attribution', () => {
     const stylesheet = document.createElement('link');
     stylesheet.rel = 'stylesheet';
     stylesheet.setAttribute('href', 'data:text/css,.transpiled{}');
-    markNodeTranspiled(stylesheet);
+    markNodeForNativePassthrough(stylesheet);
     container.appendChild(stylesheet);
 
     expect(container.contains(stylesheet)).toBe(true);
@@ -132,18 +132,18 @@ describe.sequential('insertion-point attribution', () => {
     expect(getSandboxConfigOf(controller).dynamicStyleSheetElements).not.toContain(stylesheet);
   });
 
-  it('keeps the transpiled effect mark invisible to streamed-content detection', async () => {
+  it('keeps the passthrough effect mark invisible to streamed-content detection', async () => {
     const { container, controller } = createController();
     await controller.mount(container);
 
-    // an internal pipeline node (e.g. a compartment blob script) is transpiled but not streamed
+    // an internal pipeline node (e.g. a compartment blob script) carries the effect mark only
     const blobScript = document.createElement('script');
-    markNodeTranspiled(blobScript);
+    markNodeForNativePassthrough(blobScript);
     container.appendChild(blobScript);
     expect(containsLoaderStreamedNode(container)).toBe(false);
 
     const streamedNode = document.createElement('div');
-    markNodeTranspiled(streamedNode);
+    markNodeForNativePassthrough(streamedNode);
     markLoaderStreamedNode(streamedNode);
     container.appendChild(streamedNode);
     expect(containsLoaderStreamedNode(container)).toBe(true);

--- a/packages/sandbox/src/patchers/dynamicAppend/__tests__/stylesheet-ledger.test.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/__tests__/stylesheet-ledger.test.ts
@@ -67,11 +67,11 @@ describe.sequential('dynamic stylesheet ledger', () => {
     expect(container.querySelector('link[rel="preload"]')).toBeNull();
   });
 
-  it('settles a fallback-adopted stylesheet when the app removes it again', async () => {
+  it('settles an insertion-adopted stylesheet when the app removes it again', async () => {
     const { container, controller } = createController((node) => node);
     await controller.mount(container);
 
-    // created outside the sandboxed createElement — adopted via the mount-point fallback
+    // created outside the sandboxed createElement — adopted at its insertion point
     const stylesheet = document.createElement('link');
     stylesheet.rel = 'stylesheet';
     stylesheet.setAttribute('href', 'data:text/css,.removed{}');

--- a/packages/sandbox/src/patchers/dynamicAppend/common.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/common.ts
@@ -4,7 +4,7 @@ import type { AssetsTranspilerOpts, ScriptTranspilerOpts } from '@qiankunjs/shar
  * @author Kuitos
  * @since 2019-10-21
  */
-import { isTranspiledNode, prepareDeferredQueue, warn } from '@qiankunjs/shared';
+import { isNativePassthroughNode, prepareDeferredQueue, warn } from '@qiankunjs/shared';
 import { qiankunHeadTagName } from '../../consts';
 import type { SandboxConfig } from './types';
 
@@ -109,14 +109,14 @@ export function getOverwrittenAppendChildOrInsertBefore(
     // jQuery-style insertions wrap nodes in a DocumentFragment, which would smuggle style/script
     // elements past the per-tag hijacking below — decompose such a fragment and route every child
     // through the same pipeline (a fragment empties on insertion natively, so per-child appends
-    // keep the same end state and order). Nodes a qiankun pipeline already transpiled (the
-    // loader's walk batches them into fragments for insertion performance) must pass through
-    // natively, never through the pipeline again.
+    // keep the same end state and order). Nodes marked for native passthrough (the loader's
+    // pipeline batches its processed nodes into fragments for insertion performance) must pass
+    // through untouched, never through the pipeline again.
     if (element.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
       const fragment = newChild as unknown as DocumentFragment;
       const shouldDecompose =
         !!getSandboxConfig(this) &&
-        Array.from(fragment.children).some((child) => isHijackingTag(child.tagName) && !isTranspiledNode(child));
+        Array.from(fragment.children).some((child) => isHijackingTag(child.tagName) && !isNativePassthroughNode(child));
       if (shouldDecompose) {
         Array.from(fragment.childNodes).forEach((child) => {
           appendChildInSandbox.call(this, child, refChild);
@@ -127,9 +127,9 @@ export function getOverwrittenAppendChildOrInsertBefore(
 
     // insertion-point ownership: a hijackable element landing on a patched mount point belongs to
     // the app owning that mount point, no matter who created it — except nodes a qiankun pipeline
-    // already transpiled, which must pass through untouched.
+    // marked for native passthrough, which must pass through untouched.
     // See docs/rfcs/insertion-point-ownership.md.
-    const sandboxConfig = isTranspiledNode(element) ? undefined : getSandboxConfig(this);
+    const sandboxConfig = isNativePassthroughNode(element) ? undefined : getSandboxConfig(this);
 
     if (!isHijackingTag(element.tagName) || !sandboxConfig) {
       return appendChild.call(this, element, refChild) as T;

--- a/packages/sandbox/src/patchers/dynamicAppend/common.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/common.ts
@@ -4,7 +4,7 @@ import type { AssetsTranspilerOpts, ScriptTranspilerOpts } from '@qiankunjs/shar
  * @author Kuitos
  * @since 2019-10-21
  */
-import { isLoaderStreamedNode, prepareDeferredQueue, warn } from '@qiankunjs/shared';
+import { isTranspiledNode, prepareDeferredQueue, warn } from '@qiankunjs/shared';
 import { qiankunHeadTagName } from '../../consts';
 import type { SandboxConfig } from './types';
 
@@ -114,12 +114,13 @@ export function getOverwrittenAppendChildOrInsertBefore(
     if (element.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
       const fragment = newChild as unknown as DocumentFragment;
       const ownerConfig = getSandboxConfig(this);
-      // nodes streamed by the loader's walk are already transpiled and batched into fragments for
-      // insertion performance — they must pass through natively, never through the pipeline again
+      // nodes a qiankun pipeline already transpiled (the loader's walk batches them into
+      // fragments for insertion performance) must pass through natively, never through the
+      // pipeline again
       const shouldDecompose = Array.from(fragment.children).some(
         (child) =>
           isHijackingTag(child.tagName) &&
-          !isLoaderStreamedNode(child) &&
+          !isTranspiledNode(child) &&
           (getSandboxConfig(child as HTMLElement) ?? ownerConfig),
       );
       if (shouldDecompose) {
@@ -129,7 +130,7 @@ export function getOverwrittenAppendChildOrInsertBefore(
             ownerConfig &&
             setSandboxConfig &&
             isHijackingTag(childElement.tagName) &&
-            !isLoaderStreamedNode(childElement) &&
+            !isTranspiledNode(childElement) &&
             !getSandboxConfig(childElement)
           ) {
             setSandboxConfig(childElement, ownerConfig);
@@ -142,10 +143,9 @@ export function getOverwrittenAppendChildOrInsertBefore(
 
     // elements parsed via innerHTML (e.g. jQuery's buildFragment) never went through the sandboxed
     // createElement and carry no config of their own — inherit the one attached to the patched
-    // mount point, except for nodes inserted by the loader's streaming walk, which are already
-    // transpiled and must pass through untouched
-    const sandboxConfig =
-      getSandboxConfig(element) ?? (isLoaderStreamedNode(element) ? undefined : getSandboxConfig(this));
+    // mount point, except for nodes a qiankun pipeline already transpiled, which must pass
+    // through untouched
+    const sandboxConfig = getSandboxConfig(element) ?? (isTranspiledNode(element) ? undefined : getSandboxConfig(this));
 
     // no attached sandbox config means the element is not created from the sandbox environment
     if (!isHijackingTag(element.tagName) || !sandboxConfig) {

--- a/packages/sandbox/src/patchers/dynamicAppend/common.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/common.ts
@@ -109,55 +109,42 @@ export function getOverwrittenAppendChildOrInsertBefore(
     // jQuery-style insertions wrap nodes in a DocumentFragment, which would smuggle style/script
     // elements past the per-tag hijacking below — decompose such a fragment and route every child
     // through the same pipeline (a fragment empties on insertion natively, so per-child appends
-    // keep the same end state and order). Children parsed via innerHTML never went through the
-    // sandboxed createElement, so they inherit the config attached to the patched mount point.
+    // keep the same end state and order). Nodes a qiankun pipeline already transpiled (the
+    // loader's walk batches them into fragments for insertion performance) must pass through
+    // natively, never through the pipeline again.
     if (element.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
       const fragment = newChild as unknown as DocumentFragment;
-      const ownerConfig = getSandboxConfig(this);
-      // nodes a qiankun pipeline already transpiled (the loader's walk batches them into
-      // fragments for insertion performance) must pass through natively, never through the
-      // pipeline again
-      const shouldDecompose = Array.from(fragment.children).some(
-        (child) =>
-          isHijackingTag(child.tagName) &&
-          !isTranspiledNode(child) &&
-          (getSandboxConfig(child as HTMLElement) ?? ownerConfig),
-      );
+      const shouldDecompose =
+        !!getSandboxConfig(this) &&
+        Array.from(fragment.children).some((child) => isHijackingTag(child.tagName) && !isTranspiledNode(child));
       if (shouldDecompose) {
         Array.from(fragment.childNodes).forEach((child) => {
-          const childElement = child as HTMLElement;
-          if (
-            ownerConfig &&
-            setSandboxConfig &&
-            isHijackingTag(childElement.tagName) &&
-            !isTranspiledNode(childElement) &&
-            !getSandboxConfig(childElement)
-          ) {
-            setSandboxConfig(childElement, ownerConfig);
-          }
           appendChildInSandbox.call(this, child, refChild);
         });
         return newChild;
       }
     }
 
-    // elements parsed via innerHTML (e.g. jQuery's buildFragment) never went through the sandboxed
-    // createElement and carry no config of their own — inherit the one attached to the patched
-    // mount point, except for nodes a qiankun pipeline already transpiled, which must pass
-    // through untouched
-    const sandboxConfig = getSandboxConfig(element) ?? (isTranspiledNode(element) ? undefined : getSandboxConfig(this));
+    // insertion-point ownership: a hijackable element landing on a patched mount point belongs to
+    // the app owning that mount point, no matter who created it — except nodes a qiankun pipeline
+    // already transpiled, which must pass through untouched.
+    // See docs/rfcs/insertion-point-ownership.md.
+    const sandboxConfig = isTranspiledNode(element) ? undefined : getSandboxConfig(this);
 
-    // no attached sandbox config means the element is not created from the sandbox environment
     if (!isHijackingTag(element.tagName) || !sandboxConfig) {
       return appendChild.call(this, element, refChild) as T;
     }
 
-    // An element adopted through the mount-point fallback above (innerHTML-parsed, no config of
-    // its own) must be registered like the fragment branch does — otherwise the patched
-    // removeChild can never recognize it and its ledger entry would replay on every remount.
-    if (setSandboxConfig && !getSandboxConfig(element)) {
-      setSandboxConfig(element, sandboxConfig);
+    // Register the element under its insertion owner so the patched removeChild and the CSSOM
+    // patch can recognize it later — otherwise its ledger entry would replay on every remount.
+    // Re-insertion re-attributes: an element moved across mount points follows its new owner.
+    const previousConfig = getSandboxConfig(element);
+    if (previousConfig && previousConfig !== sandboxConfig) {
+      warn(
+        `Element ${element.tagName.toLowerCase()} previously owned by ${previousConfig.appName} is re-attributed to ${sandboxConfig.appName} as it is inserted into the latter's container`,
+      );
     }
+    setSandboxConfig?.(element, sandboxConfig);
 
     if (element.tagName) {
       switch (element.tagName) {

--- a/packages/sandbox/src/patchers/dynamicAppend/forStandardSandbox.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/forStandardSandbox.ts
@@ -111,9 +111,12 @@ const resolveStyleOwnerConfig = (ownerNode: HTMLElement): SandboxConfig | undefi
   return undefined;
 };
 
-// FIXME should not capture at module load, should get it every time it is used, otherwise it may miss the business itself monkey patch logic.
-// Captured from the prototype rather than an instance lookup (document.head.appendChild), which
-// could pick up a host page's instance-level patch and leak it into container operations.
+// Deliberately captured from Node.prototype at module load: an instance lookup like
+// document.head.appendChild could pick up a host page's instance-level patch and leak it into
+// container operations with the wrong receiver. An app monkey-patching the appendChild *it*
+// sees stays effective regardless — its wrapper shadows our patched instance method on the
+// mount point and delegates to it, so the pipeline runs underneath the wrapper (pinned by the
+// patched-append e2e). Only prototype patches installed after this module loads are bypassed.
 const nativeAppendChild = Node.prototype.appendChild;
 const nativeInsertBefore = Node.prototype.insertBefore;
 const nativeRemoveChild = Node.prototype.removeChild;
@@ -238,6 +241,13 @@ function patchDocumentHeadAndBodyMethods(container: HTMLElement, compartment: Pl
     const sandboxConfig = sandboxConfigs.get(compartment);
     if (sandboxConfig) setSandboxConfig(mountPoint, sandboxConfig);
   };
+  // A follow-up app may have re-tagged a shared mount point, so only clear this app's own stamp —
+  // otherwise a disposed sandbox could still be resolved as a style owner by DOM position.
+  const untagMountPoint = (mountPoint: HTMLElement) => {
+    if (elementConfigs.get(mountPoint) === sandboxConfigs.get(compartment)) {
+      elementConfigs.delete(mountPoint);
+    }
+  };
 
   let patchedHeadMethods:
     | {
@@ -307,6 +317,7 @@ function patchDocumentHeadAndBodyMethods(container: HTMLElement, compartment: Pl
       if (containerHeadElement.removeChild === patchedHeadMethods.removeChild) {
         Reflect.deleteProperty(containerHeadElement, 'removeChild');
       }
+      untagMountPoint(containerHeadElement);
     }
 
     if (containerBodyElement.appendChild === patchedBodyMethods.appendChild) {
@@ -318,6 +329,7 @@ function patchDocumentHeadAndBodyMethods(container: HTMLElement, compartment: Pl
     if (containerBodyElement.removeChild === patchedBodyMethods.removeChild) {
       Reflect.deleteProperty(containerBodyElement, 'removeChild');
     }
+    untagMountPoint(containerBodyElement);
   };
 }
 

--- a/packages/sandbox/src/patchers/dynamicAppend/forStandardSandbox.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/forStandardSandbox.ts
@@ -32,20 +32,10 @@ function getRequiredContainer(getContainer: IsolationPluginContext['getContainer
 }
 
 declare global {
-  interface Window {
-    __currentLockingSandbox__?: PluginCompartment;
-  }
-
   interface Document {
     [p: string]: unknown;
   }
 }
-
-Object.defineProperty(nativeGlobal, '__currentLockingSandbox__', {
-  enumerable: false,
-  writable: true,
-  configurable: true,
-});
 
 interface DOMPrototypePatchState {
   refCount: number;
@@ -98,6 +88,36 @@ const { containerOwners, elementConfigs, sandboxConfigs } = sharedState;
 const getSandboxConfig = (element: HTMLElement) => elementConfigs.get(element);
 const setSandboxConfig = (element: HTMLElement, config: SandboxConfig) => elementConfigs.set(element, config);
 
+/**
+ * Ownership follows the stylesheet's current DOM position, consistent with the insertion-point
+ * attribution model: a style inserted through a patched mount point already carries its config,
+ * while one injected deeper inside a container (e.g. a CSS-in-JS custom insertion target)
+ * resolves to the nearest tagged ancestor — the mount points are always tagged. The resolution
+ * is cached back onto the element, so insertRule-heavy CSS-in-JS paths walk at most once.
+ */
+const resolveStyleOwnerConfig = (ownerNode: HTMLElement): SandboxConfig | undefined => {
+  const attachedConfig = elementConfigs.get(ownerNode);
+  if (attachedConfig) return attachedConfig;
+
+  let ancestor = ownerNode.parentElement;
+  while (ancestor) {
+    const ancestorConfig = elementConfigs.get(ancestor);
+    if (ancestorConfig) {
+      elementConfigs.set(ownerNode, ancestorConfig);
+      return ancestorConfig;
+    }
+    ancestor = ancestor.parentElement;
+  }
+  return undefined;
+};
+
+// FIXME should not capture at module load, should get it every time it is used, otherwise it may miss the business itself monkey patch logic.
+// Captured from the prototype rather than an instance lookup (document.head.appendChild), which
+// could pick up a host page's instance-level patch and leak it into container operations.
+const nativeAppendChild = Node.prototype.appendChild;
+const nativeInsertBefore = Node.prototype.insertBefore;
+const nativeRemoveChild = Node.prototype.removeChild;
+
 function patchDocument(
   compartment: PluginCompartment,
   appName: string,
@@ -112,12 +132,6 @@ function patchDocument(
 
   const unpatch = patchDocumentHeadAndBodyMethods(container, compartment);
 
-  const attachElementToSandbox = (element: HTMLElement) => {
-    const sandboxConfig = sandboxConfigs.get(compartment);
-    if (sandboxConfig) {
-      elementConfigs.set(element, sandboxConfig);
-    }
-  };
   const getDocumentHeadElement = () => {
     const currentContainer = getRequiredContainer(getContainer, appName);
     const containerHeadElement = getContainerHeadElement(currentContainer);
@@ -158,22 +172,12 @@ function patchDocument(
     get: (target, p, receiver) => {
       switch (p) {
         case 'createElement': {
-          // Must store the original createElement function to avoid error in nested sandbox
+          // Ownership is decided at insertion time (insertion-point attribution), so creation
+          // needs no bookkeeping anymore — only the app-level override recorded by the paired
+          // setter must keep being honored.
           const targetCreateElement = modificationFns.createElement || target.createElement;
           return function createElement(...args: Parameters<typeof document.createElement>) {
-            if (!nativeGlobal.__currentLockingSandbox__) {
-              nativeGlobal.__currentLockingSandbox__ = compartment;
-            }
-
-            const element = targetCreateElement.call(target, ...args);
-
-            // only record the element which is created by the current sandbox, thus we can avoid the element created by nested sandboxes
-            if (nativeGlobal.__currentLockingSandbox__ === compartment) {
-              attachElementToSandbox(element);
-              delete nativeGlobal.__currentLockingSandbox__;
-            }
-
-            return element;
+            return targetCreateElement.call(target, ...args);
           };
         }
 
@@ -246,18 +250,18 @@ function patchDocumentHeadAndBodyMethods(container: HTMLElement, compartment: Pl
     tagMountPoint(headElement);
     patchedHeadMethods = {
       appendChild: getOverwrittenAppendChildOrInsertBefore(
-        document.head.appendChild,
+        nativeAppendChild,
         getSandboxConfig,
         'head',
         setSandboxConfig,
       ),
       insertBefore: getOverwrittenAppendChildOrInsertBefore(
-        document.head.insertBefore,
+        nativeInsertBefore,
         getSandboxConfig,
         'head',
         setSandboxConfig,
       ),
-      removeChild: getNewRemoveChild(document.head.removeChild, getSandboxConfig),
+      removeChild: getNewRemoveChild(nativeRemoveChild, getSandboxConfig),
     };
     Object.assign(headElement, patchedHeadMethods);
   };
@@ -280,19 +284,14 @@ function patchDocumentHeadAndBodyMethods(container: HTMLElement, compartment: Pl
   const containerBodyElement = container;
   tagMountPoint(containerBodyElement);
   const patchedBodyMethods = {
-    appendChild: getOverwrittenAppendChildOrInsertBefore(
-      document.body.appendChild,
-      getSandboxConfig,
-      'body',
-      setSandboxConfig,
-    ),
+    appendChild: getOverwrittenAppendChildOrInsertBefore(nativeAppendChild, getSandboxConfig, 'body', setSandboxConfig),
     insertBefore: getOverwrittenAppendChildOrInsertBefore(
-      document.head.insertBefore,
+      nativeInsertBefore,
       getSandboxConfig,
       'body',
       setSandboxConfig,
     ),
-    removeChild: getNewRemoveChild(document.body.removeChild, getSandboxConfig),
+    removeChild: getNewRemoveChild(nativeRemoveChild, getSandboxConfig),
   };
   Object.assign(containerBodyElement, patchedBodyMethods);
 
@@ -408,10 +407,6 @@ function patchDOMPrototypeFns(): Unpatch {
   };
 }
 
-// FIXME should not use global variable, should get it every time it is used, otherwise it may miss the runtime container or the business itself monkey patch logic
-const rawHeadInsertBefore = HTMLHeadElement.prototype.insertBefore;
-const rawHeadAppendChild = HTMLHeadElement.prototype.appendChild;
-
 function patchCSSOM(): Unpatch {
   let state = sharedState.cssomPatch;
   if (!state) {
@@ -419,7 +414,7 @@ function patchCSSOM(): Unpatch {
     const patchedInsertRule = function insertRule(this: CSSStyleSheet, rule: string, index?: number): number {
       const ownerNode = this.ownerNode as HTMLElement | null;
       if (ownerNode) {
-        const config = elementConfigs.get(ownerNode);
+        const config = resolveStyleOwnerConfig(ownerNode);
         if (config?.styleIsolation) {
           const scopedRule = transpileStyleRule(rule, config.styleIsolation);
           return nativeInsertRule.call(this, scopedRule, index);
@@ -545,9 +540,9 @@ async function attachRecordedStylesheets(
           // the reference node may be dynamic script comment which is not rebuilt while remounting thus reference node no longer exists
           // in this case, we should append the style element to the end of mountDom
           const refNode = mountDom.childNodes[refNo];
-          rawHeadInsertBefore.call(mountDom, styleElement, refNode);
+          nativeInsertBefore.call(mountDom, styleElement, refNode);
         } else {
-          rawHeadAppendChild.call(mountDom, styleElement);
+          nativeAppendChild.call(mountDom, styleElement);
         }
 
         return deferred.promise;

--- a/packages/shared/src/common.ts
+++ b/packages/shared/src/common.ts
@@ -4,30 +4,32 @@ export type BaseLoaderOpts = {
 
 /**
  * Effect contract between qiankun's processing pipelines and the sandbox's dynamic-append
- * patcher: a node that already went through a qiankun pipeline (the loader's streaming walk, the
- * compartment's internal blob-script evaluation) is marked as transpiled, so the patched
- * container head/body methods pass it through natively instead of routing it through the dynamic
- * transpilation pipeline a second time.
+ * patcher: a node inserted by a qiankun-owned pipeline (the loader's entry streaming pipeline,
+ * the compartment's internal blob-script evaluation) is marked for native passthrough, so the
+ * patched container head/body methods let it through untouched instead of routing it into the
+ * dynamic transpilation pipeline. The mark is stamped by the pipeline that owns the insertion —
+ * never by the transpiler, which also serves the dynamic pipeline whose output must NOT carry it.
  * A registered symbol (Symbol.for), so the contract survives duplicated @qiankunjs/shared
  * instances in a dependency tree.
  */
-export const transpiledNode = Symbol.for('qiankun.transpiledNode');
+export const nativePassthroughNode = Symbol.for('qiankun.nativePassthroughNode');
 
-export function markNodeTranspiled(node: Node): void {
-  (node as unknown as Record<symbol, unknown>)[transpiledNode] = true;
+export function markNodeForNativePassthrough(node: Node): void {
+  (node as unknown as Record<symbol, unknown>)[nativePassthroughNode] = true;
 }
 
-export function isTranspiledNode(node: Node): boolean {
-  return !!(node as unknown as Record<symbol, unknown>)[transpiledNode];
+export function isNativePassthroughNode(node: Node): boolean {
+  return !!(node as unknown as Record<symbol, unknown>)[nativePassthroughNode];
 }
 
 /**
- * Provenance contract between the loader's writable-dom walk and the sandbox's container
- * protocol: only nodes inserted by the entry html streaming walk carry this mark, so the sandbox
- * can tell whether a container already holds streamed entry content (containsLoaderStreamedNode).
- * Streamed nodes are additionally marked transpiled; internal pipeline nodes (e.g. compartment
- * blob scripts) are only transpiled — the two marks answer different questions and must not be
- * conflated. Registered symbol for the same cross-copy reason as above.
+ * Provenance contract between the loader's entry streaming pipeline and the sandbox's container
+ * protocol: only nodes inserted by the entry html streaming pipeline carry this mark, so the
+ * sandbox can tell whether a container already holds streamed entry content
+ * (containsLoaderStreamedNode). Streamed nodes additionally carry the passthrough effect mark;
+ * internal pipeline nodes (e.g. compartment blob scripts) only carry the effect mark — the two
+ * marks answer different questions and must not be conflated. Registered symbol for the same
+ * cross-copy reason as above.
  */
 export const loaderStreamedNode = Symbol.for('qiankun.loaderStreamedNode');
 

--- a/packages/shared/src/common.ts
+++ b/packages/shared/src/common.ts
@@ -3,12 +3,31 @@ export type BaseLoaderOpts = {
 };
 
 /**
- * Cross-package contract between the loader's writable-dom walk and the sandbox's dynamic-append
- * patcher: nodes inserted by the entry html streaming walk are marked with this symbol, so the
- * patched container head/body methods can tell them apart from genuinely dynamic insertions made
- * by app code (which may need on-the-fly transpilation the streamed nodes already received).
+ * Effect contract between qiankun's processing pipelines and the sandbox's dynamic-append
+ * patcher: a node that already went through a qiankun pipeline (the loader's streaming walk, the
+ * compartment's internal blob-script evaluation) is marked as transpiled, so the patched
+ * container head/body methods pass it through natively instead of routing it through the dynamic
+ * transpilation pipeline a second time.
  * A registered symbol (Symbol.for), so the contract survives duplicated @qiankunjs/shared
  * instances in a dependency tree.
+ */
+export const transpiledNode = Symbol.for('qiankun.transpiledNode');
+
+export function markNodeTranspiled(node: Node): void {
+  (node as unknown as Record<symbol, unknown>)[transpiledNode] = true;
+}
+
+export function isTranspiledNode(node: Node): boolean {
+  return !!(node as unknown as Record<symbol, unknown>)[transpiledNode];
+}
+
+/**
+ * Provenance contract between the loader's writable-dom walk and the sandbox's container
+ * protocol: only nodes inserted by the entry html streaming walk carry this mark, so the sandbox
+ * can tell whether a container already holds streamed entry content (containsLoaderStreamedNode).
+ * Streamed nodes are additionally marked transpiled; internal pipeline nodes (e.g. compartment
+ * blob scripts) are only transpiled — the two marks answer different questions and must not be
+ * conflated. Registered symbol for the same cross-copy reason as above.
  */
 export const loaderStreamedNode = Symbol.for('qiankun.loaderStreamedNode');
 


### PR DESCRIPTION
## Why

`dynamicAppend` has been carrying **two attribution models stacked on top of each other**. The original one stamps a config at sandboxed `document.createElement` time (creator attribution). #3138 then added mount-point tagging with inheritance (insertion-point attribution) to fix parser-produced DOM — `innerHTML`, `insertAdjacentHTML`, `cloneNode`, jQuery's `buildFragment` — which never goes through `createElement` and was therefore bypassing `@scope` isolation entirely.

That patch did not replace the old model, it layered on top of it, and the glue spread: a creator-first/insertion-fallback ternary, guards inside the fragment branch, a nested-creation lock, and a marker symbol whose meaning was overloaded along the way.

This PR collapses the two models into one rule:

> A hijackable element landing on a patched mount point belongs to the app owning that mount point — no matter who created it — unless a qiankun pipeline already transpiled it.

## What changes

**1. The marker symbol is split by meaning** (`6f53e1ec`)

`loaderStreamedNode` was answering two unrelated questions: *"already transpiled, pass through"* (effect) and *"this container holds streamed entry content"* (provenance). The compartment's internal blob scripts only need the former but were stamped with the latter, so container-occupation detection stayed correct only through the incidental `&&` short-circuit order in `prepareContainerForMount`.

- `transpiledNode` — effect. Set by the loader walk **and** compartment blob evaluation; consumed by `dynamicAppend`.
- `loaderStreamedNode` — provenance. Set only by the loader walk; consumed only by `containsLoaderStreamedNode`.

**2. Attribution converges on the insertion point** (`ee6c558a`)

- the creator machinery retires entirely: `attachElementToSandbox`, the `__currentLockingSandbox__` nested lock, and the `createElement` bookkeeping are gone — nesting is naturally disambiguated because each container carries its own instance-level patch
- adoption always re-stamps the insertion owner (warning when an element migrates between apps), preserving push/splice ledger symmetry on every path
- the CSSOM `insertRule` patch resolves ownership by DOM position (nearest tagged ancestor, cached), which keeps CSS-in-JS custom insertion targets scoped and stops scoping stylesheets moved out of a container
- native container methods are captured from `Node.prototype` instead of instance lookups, fixing the body `insertBefore` capture that mistakenly read `document.head.insertBefore`

**Note that the set of elements entering the pipeline does not change.** `patchStandardSandbox` creates the config before `patchDocument`, so mount points are always tagged, which means a hijackable non-transpiled element on a mount point already resolved to *some* config today. Only *which app* a foreign-created element binds to changes — and it now follows the container, matching the per-instance attribution invariant the ESM sandbox RFC already relies on.

## Semantic changes (full list)

| | Change | Assessment |
|---|---|---|
| S1 | Cross-instance direct insertion re-attributes to the receiving container | Unreachable through normal orchestration (distinct containers per instance; shared containers hand off sequentially through a wipe); zero tests depended on the old behavior. **Now pinned as a contract.** |
| S2 | `insertRule` scoping resolves by position instead of creator stamp | A fix: deep-injected styles previously kept scoping even after being moved out of the container |
| S3 | Re-insertion re-attributes | Cross-container moves have undefined ledger behavior under *both* models (an implicit detach skips the old container's patched `removeChild`); not made worse here |

## Testing

Unit: 295 pass. Chromium e2e: 43 pass (5 new). eslint/prettier clean. Local perf benchmark healthy — the ancestor walk in D5 is a cold path, as expected.

**Every claim above about coverage was verified by mutation testing, not assumed:**

- **The nested case discriminates.** Reverting to creator attribution makes the new "outer app creates a node, hands it to the inner container" test fail with exactly the wrong scope root (`@scope ([data-name="sub-nested"])`). The other three nested tests hold under either model and exist as regression guards for the retired lock, which previously had *zero* coverage.
- **`evaluateScript`'s effect mark is already guarded end-to-end.** Removing `markNodeTranspiled(script)` makes the existing standalone spec fail — the blob gets transpiled a second time.
- **`evaluateScript`'s provenance purity is unreachable end-to-end.** Re-introducing the pre-split `markLoaderStreamedNode(script)` leaves the whole suite green: the blob script always lives inside `<qiankun-head>` (so occupation detection short-circuits) and is removed once evaluation settles. It stays pinned by unit tests, and the new e2e covers the reachable neighbour — a second controller re-preparing the same container after a full classic evaluation.

New e2e fixture `sub-nested` is a classic app that bundles **its own copy of qiankun** and mounts another sub app inside its own DOM, so every DOM call travels through chained proxied documents and the two levels exercise the cross-copy `Symbol.for` contract.

## Design doc

`docs/rfcs/insertion-point-ownership.md` — includes the verified fact base (F1–F6) behind the risk assessment, the 9 stylesheet-ledger invariants the change had to preserve, and the mutation-testing results above.

Two open questions are called out there: whether the re-attribution warning should be dev-only, and whether position resolution should cross Shadow DOM boundaries (currently: no, qiankun containers don't use shadow roots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
