### PR TITLE
fix(examples): negotiate the streamed language up front and slow the pacing

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -50,8 +50,11 @@ The **streaming** app demonstrates something none of the others can: its loading
 delays — the way a server-side renderer emits markup as data becomes ready. qiankun's loader pipes
 the response through the same streaming parser the browser uses for a top-level document, so each
 chunk paints the moment it lands: the critical section is readable while the entry script has not
-even been *requested* yet. Inline marks stamp every chunk's arrival, and the entry script — flushed
-last on purpose — draws the resulting waterfall. Loaders that buffer the whole entry before
+even been _requested_ yet. Inline marks stamp every chunk's arrival, and the entry script — flushed
+last on purpose — draws the resulting waterfall. The server also negotiates the initial language
+from `Accept-Language`: streamed content must speak the visitor's language from the first byte,
+because the host's props can only arrive with the entry script, seconds later — props stay
+authoritative once they do (switching the shell's language still reaches the app via `update`). Loaders that buffer the whole entry before
 rendering can only show a spinner for that window, which is why this app is also the one whose
 stage swaps the covering veil for a corner tag. Remounts replay from qiankun's warm cache and
 render at once; reload the page to watch the cold stream again.

--- a/examples/streaming/entry.js
+++ b/examples/streaming/entry.js
@@ -9,7 +9,10 @@
   var stream = global.__QK_STREAM__;
   // captured at evaluation time, not at mount: this is the honest "entry arrived" moment
   var entryAt = stream ? stream.now() : 0;
-  var locale = 'en';
+  // adopt the language the server negotiated from Accept-Language for the streamed markup, so
+  // mounting does not flip it; props remain authoritative when they carry a different choice
+  var streamedRoot = document.querySelector('.streaming-app');
+  var locale = streamedRoot && streamedRoot.getAttribute('data-locale') === 'zh' ? 'zh' : 'en';
 
   /**
    * This app's own copy. The host hands `locale` over through qiankun's props channel and

--- a/examples/streaming/index.html
+++ b/examples/streaming/index.html
@@ -297,7 +297,7 @@
       <script>
         window.__QK_STREAM__.mark('critical');
       </script>
-      <!--#flush:500-->
+      <!--#flush:1000-->
       <section class="card">
         <h2>
           <span lang="en">Deferred: orders ledger</span>
@@ -332,7 +332,7 @@
       <script>
         window.__QK_STREAM__.mark('orders');
       </script>
-      <!--#flush:500-->
+      <!--#flush:1000-->
       <section class="card">
         <h2>
           <span lang="en">Deferred: activity feed</span>
@@ -362,7 +362,7 @@
       <script>
         window.__QK_STREAM__.mark('activity');
       </script>
-      <!--#flush:600-->
+      <!--#flush:1000-->
       <section class="card" data-summary-card>
         <h2>
           <span lang="en">The waterfall, as it actually happened</span>

--- a/examples/streaming/pages-function.mjs
+++ b/examples/streaming/pages-function.mjs
@@ -12,7 +12,10 @@ export async function onRequestGet(context) {
   // ASSETS bypasses functions, so fetching the canonical URL yields the static file this
   // function shadows. Not `/index.html`: Pages answers the non-canonical spelling with a 308.
   const asset = await context.env.ASSETS.fetch(new URL('/apps/streaming/', context.request.url));
-  const parts = (await asset.text()).split(FLUSH_MARKER);
+  // same Accept-Language negotiation as server.mjs: the first chunk must already speak the
+  // visitor's language — the host's props only arrive with the entry script, seconds later
+  const locale = (context.request.headers.get('accept-language') ?? '').toLowerCase().startsWith('zh') ? 'zh' : 'en';
+  const parts = (await asset.text()).replace('data-locale="en"', `data-locale="${locale}"`).split(FLUSH_MARKER);
 
   const encoder = new TextEncoder();
   const { readable, writable } = new TransformStream();

--- a/examples/streaming/server.mjs
+++ b/examples/streaming/server.mjs
@@ -62,7 +62,12 @@ const server = createServer((request, response) => {
   // no Content-Length → Node switches to chunked transfer, and each write() is a flush
   response.writeHead(200, baseHeaders('text/html; charset=utf-8'));
   const parts = chunkedHtml();
-  response.write(parts[0]);
+  // SSR-style language negotiation: streamed content must speak the visitor's language from the
+  // first byte — the host's props can only arrive with the entry script, seconds from now, and
+  // repainting on mount would flash the wrong language for the whole stream. Props stay
+  // authoritative once they do arrive (a manual language switch reaches the app via `update`).
+  const locale = (request.headers['accept-language'] ?? '').toLowerCase().startsWith('zh') ? 'zh' : 'en';
+  response.write(parts[0].replace('data-locale="en"', `data-locale="${locale}"`));
 
   let elapsed = 0;
   const timers = [];


### PR DESCRIPTION
Follow-up to #3171, from watching the demo with real eyes.

## Streamed content flipped language mid-demo

The streamed markup always started as English and switched to the shell's language only when props arrived with the entry script — for a Chinese-system visitor that meant seconds of English, then a whole-page flip to Chinese right in the middle of the demo.

Fixed the way real streaming SSR does it: both servers (`server.mjs` and the Pages Function) negotiate the initial `data-locale` from the request's `Accept-Language`, so the first byte already speaks the visitor's language. `entry.js` adopts the negotiated value instead of hardcoding `en` (standalone visits stay correct too), and props remain authoritative once they arrive — switching the shell's language still reaches the app via `update`.

## Pacing didn't feel streamed

500ms chunk gaps read as "fast page", not "streamed page". Now one second per chunk (~3s total): measured in-browser, the entry script trails first paint by ~2.7s and sections visibly land batch by batch (card count sampled per second: 1 → 2 → 3 → 4).

## Verification

9/9 Playwright checks: zh-CN visitor streams in Chinese from first paint with the `data-locale` mutation history staying `["zh"]` (no flip, both shells + standalone), en visitor stays English, manual language switch still works after mount, entry lead ≥2.5s. Pages Function verified under `wrangler pages dev`: `Accept-Language: zh` → `data-locale="zh"`, chunks at +26/+1026/+2027/+3029ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)