### PR TITLE
ci(release): fix the prerelease dist-tag and stop versioning private packages

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -23,6 +23,11 @@ Commits that touch no package (docs, `e2e/`, `examples/`, root config, CI) produ
 Each sub-package keeps its **own `CHANGELOG.md`** (the changeset default), so npm shows a per-package
 changelog. There is **no root changelog** — the single aggregated log lives only on the GitHub Release.
 
+Private workspace packages (`examples/*`, `benchmark/`, `e2e/`) are excluded from versioning entirely via
+`"privatePackages": false` in `config.json` — without it changesets bumps them and writes them a
+`CHANGELOG.md` just because they depend on a released package, which is pure noise for something that
+never reaches npm. (`config.json` is strict JSON and cannot carry the comment, hence this note.)
+
 ## Release flow (three stages)
 
 **A · Every PR merge — fully automatic.** CI derives changesets from the new commits; the changesets
@@ -38,6 +43,13 @@ before resetting or migrating the release workflow.
 **B · Merge the release PR — fully automatic.** CI runs `changeset publish` to release every changed
 sub-package to npm, then `scripts/generate-release-notes.mjs` aggregates the published packages'
 `CHANGELOG.md` entries into one set of notes and `gh release create` posts a **single GitHub Release**.
+
+Between those two, the workflow re-points the prerelease dist-tag at what it just published. `changeset
+publish` ignores `pre.json`'s tag for a package whose npm versions are _all_ that same prerelease — it
+treats "only ever released as `-rc.N`" as "never regularly released" and publishes to `latest` instead. Left
+alone, such a package's `rc` tag stays frozen at its first publish (this is how `@qiankunjs/react@rc` came to
+mean `0.0.1-rc.2` while `latest` was `0.0.1-rc.14`) and every `@rc` install command in the docs quietly
+resolves to a stale build.
 
 **C · Polish the release — optional, agent-assisted.** After publish, run the
 [`/release-changelog`](../.claude/skills/release-changelog/SKILL.md) skill to refine that GitHub Release's

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,6 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
+  "privatePackages": false,
   "baseBranch": "next",
   "updateInternalDependencies": "patch",
   "ignore": [],

--- a/.github/workflows/changeset-prerelease.yml
+++ b/.github/workflows/changeset-prerelease.yml
@@ -58,6 +58,34 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PNPM_CONFIG_PROVENANCE: true
 
+      # `changeset publish` sends a package to `latest` instead of the prerelease
+      # tag whenever EVERY version already on npm carries that same prerelease
+      # identifier: it reads that as "no regular release yet" and falls back
+      # (getReleaseTag in @changesets/cli). Packages that only ever shipped as
+      # -rc.N — the UI bindings, @qiankunjs/single-spa — therefore freeze their
+      # `rc` tag at the first publish while `latest` tracks the newest build, so
+      # the `@rc` install commands in the docs resolve to a stale version. Point
+      # the tag back at what was just published; a no-op for the packages
+      # changesets already tagged correctly.
+      - name: Re-point the prerelease dist-tag
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          PRE_MODE=$(jq -r '.mode // "exit"' .changeset/pre.json 2>/dev/null || echo exit)
+          if [ "${PRE_MODE}" != "pre" ]; then
+            echo "Not in prerelease mode (${PRE_MODE}) — publish already owns the tag."
+            exit 0
+          fi
+
+          PRE_TAG=$(jq -r '.tag' .changeset/pre.json)
+          echo '${{ steps.changesets.outputs.publishedPackages }}' \
+            | jq -r '.[] | "\(.name)@\(.version)"' \
+            | while read -r spec; do
+                echo "Tagging ${spec} as ${PRE_TAG}"
+                npm dist-tag add "${spec}" "${PRE_TAG}"
+              done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
       - name: Create Unified GitHub Release
         if: steps.changesets.outputs.published == 'true'
         run: |

--- a/skills/qiankun/SKILL.md
+++ b/skills/qiankun/SKILL.md
@@ -32,7 +32,7 @@ Package versions — until qiankun 3.0 stable ships, `rc` is the dist-tag for th
 | Package                               | Dist-tag | Goes in                                       |
 | ------------------------------------- | -------- | --------------------------------------------- |
 | `qiankun`                             | `rc`     | main app `dependencies`                       |
-| `@qiankunjs/react` / `@qiankunjs/vue` | `latest` | main app `dependencies` (optional UI binding) |
+| `@qiankunjs/react` / `@qiankunjs/vue` | `rc`     | main app `dependencies` (optional UI binding) |
 | `@qiankunjs/bundler-plugin`           | `rc`     | sub app `devDependencies`                     |
 
 ## Key facts

--- a/skills/qiankun/references/create-main-app.md
+++ b/skills/qiankun/references/create-main-app.md
@@ -6,7 +6,7 @@ Prerequisites: the shared facts in [SKILL.md](../SKILL.md) — app name, framewo
 
    ```bash
    pnpm create vite <main-app-name> --template react-ts
-   pnpm add qiankun@rc @qiankunjs/react@latest   # vue shell: @qiankunjs/vue@latest
+   pnpm add qiankun@rc @qiankunjs/react@rc   # vue shell: @qiankunjs/vue@rc
    ```
 
    Pin the port in `vite.config.ts` (`server: { port: 7099, strictPort: true }`).


### PR DESCRIPTION
Two release-pipeline defects found while preparing rc.22.

## 1 · `rc` is not the tag the prerelease packages actually get

`changeset publish` ignores `pre.json`'s tag for a package whose npm versions are *all* that same prerelease — [`getReleaseTag`](https://github.com/changesets/changesets/blob/main/packages/cli/src/commands/publish/npm-utils.ts) reads "only ever released as `-rc.N`" as "never regularly released" and publishes to `latest` instead. The packages that exist only as release candidates therefore had their `rc` tag frozen at their first publish:

| Package | `rc` | `latest` |
| --- | --- | --- |
| `@qiankunjs/react` | **0.0.1-rc.2** | 0.0.1-rc.14 |
| `@qiankunjs/vue` | **0.0.1-rc.0** | 0.0.1-rc.2 |
| `@qiankunjs/ui-shared` | **0.0.1-rc.0** | 0.0.1-rc.1 |
| `@qiankunjs/single-spa` | 0.0.1-rc.0 | 0.0.1-rc.0 |

`qiankun`/`loader`/`sandbox`/`shared` escape it because they have a non-`rc` version on npm (`2.x`, `-alpha.4`), and `bundler-plugin` because of its `0.0.0` — the `.every()` is false for them, so those tags are correct.

The consequence is in the docs: `npm install @qiankunjs/vue@rc qiankun@rc` pairs an rc.0 binding with an rc.22 core, and `skills/qiankun/references/create-main-app.md` was written against `@latest` precisely to dodge this.

So: re-point the tag right after publishing, guarded on pre mode so a later `changeset pre exit` leaves it alone. It needs `NODE_AUTH_TOKEN` (the publish step's OIDC trusted publishing doesn't cover `dist-tag`); `secrets.NPM_AUTH_TOKEN` already exists for `publish-latest.yml`. The skill's dependency table and install command ask for `@rc` again.

## 2 · Private packages were being versioned

`examples/main`, `examples/vue-host`, `examples/standalone-sandbox` and `benchmark/` get bumped to `0.0.1-rc.0` and handed a fresh `CHANGELOG.md` in the current release PR (#3152), purely because they depend on a released package. They are `private: true` and never reach npm. `"privatePackages": false` drops them from the release plan.

`scripts/sanitize-pre-state.mjs` is still needed and unchanged: changesets populates `pre.json`'s `initialVersions` by walking every workspace package regardless of the release plan, so those 10 private entries are still removed after the fact. The two are complementary.

## Verification

`generate-changesets.mjs` + `pnpm ci:version` run locally against this branch:

- `examples/*`, `benchmark/`, `e2e/` `package.json` untouched, no CHANGELOG written
- the 8 publishable packages land on exactly the versions #3152 already has (`qiankun@3.0.0-rc.22`, `loader@0.1.0-rc.22`, `sandbox@0.1.0-rc.18`, `shared@0.1.0-rc.14`, `single-spa@0.1.0-rc.1`, `react@0.0.1-rc.15`, `vue@0.0.1-rc.3`, `ui-shared@0.1.0-rc.2`) — noise removed, release contents unchanged

The dist-tag step was exercised for all three paths: `mode: pre` emits the right `npm dist-tag add` calls, `mode: exit` and a missing `pre.json` both skip cleanly.

## Merge order

This first, so CI rebuilds #3152 without the private-package noise; then merge #3152 to publish rc.22, which is when the `rc` tags actually catch up. Worth a glance at `npm view @qiankunjs/react dist-tags` afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
