### PR TITLE
ci(release): publish prereleases under the configured dist-tag without an npm token

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -44,11 +44,16 @@ before resetting or migrating the release workflow.
 sub-package to npm, then `scripts/generate-release-notes.mjs` aggregates the published packages'
 `CHANGELOG.md` entries into one set of notes and `gh release create` posts a **single GitHub Release**.
 
-In prerelease mode, `scripts/publish-packages.mjs` passes `pre.json`'s tag explicitly to `changeset
-publish`. This overrides Changesets' `only-pre` fallback, which otherwise sends a package to `latest` when
-every published version already has the same prerelease identifier. Publishing with `--tag rc` keeps the
-documented `@rc` install commands current and remains compatible with npm Trusted Publishing; outside
-prerelease mode, the script leaves the tag unspecified so stable releases continue to use `latest`.
+In prerelease mode, `scripts/publish-packages.mjs` runs `changeset publish --tag <pre.json tag>` with
+`pre.json` set aside for the duration of the publish, then restores it. Both halves are needed: Changesets
+refuses `--tag` outright while the pre-state says `mode: "pre"`, yet its own tag choice in that mode sends a
+package to `latest` whenever every version already on npm carries that same prerelease identifier (the
+`only-pre` fallback — how `@qiankunjs/react@rc` came to mean `0.0.1-rc.2` while `latest` was `0.0.1-rc.14`).
+Re-pointing the tag afterwards with `npm dist-tag add` is not an option either: it needs a long-lived npm
+token, which trusted publishing deliberately does not provide. The pre-state affects nothing else in the
+publish flow (which packages get published, git tagging, provenance), so hiding it is what makes the
+configured tag apply to every package. Outside prerelease mode, the script leaves the tag unspecified so
+stable releases continue to use `latest`.
 
 **C · Polish the release — optional, agent-assisted.** After publish, run the
 [`/release-changelog`](../.claude/skills/release-changelog/SKILL.md) skill to refine that GitHub Release's

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, renameSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -27,9 +27,33 @@ export function readPreState(filePath = PRE_STATE_PATH) {
   }
 }
 
-function publishPackages() {
+/**
+ * Runs `fn` with the changesets pre-state file set aside, then puts it back.
+ *
+ * `changeset publish` refuses `--tag` outright while `pre.json` says `mode: "pre"` ("Releasing under
+ * custom tag is not allowed in pre mode"), yet its own tag choice in that mode sends any package whose
+ * npm versions are *all* the same prerelease to `latest` instead (the `only-pre` fallback in
+ * `getReleaseTag`), freezing that package's prerelease dist-tag at its first publish. Re-pointing the
+ * tag afterwards with `npm dist-tag add` would need a long-lived npm token, which trusted publishing
+ * deliberately does not provide.
+ *
+ * The pre-state influences nothing else in the publish flow — not which packages get published, git
+ * tagging, or provenance — so hiding it for the duration of the publish is what lets the configured
+ * tag apply to every package. Callers must pass the tag explicitly (see `getPublishArgs`).
+ */
+export function withPreStateSetAside(fn, filePath = PRE_STATE_PATH) {
+  const parkedPath = `${filePath}.publishing`;
+  renameSync(filePath, parkedPath);
+  try {
+    return fn();
+  } finally {
+    renameSync(parkedPath, filePath);
+  }
+}
+
+function runChangesetPublish(args) {
   const changesetBin = fileURLToPath(import.meta.resolve('@changesets/cli/bin.js'));
-  const result = spawnSync(process.execPath, [changesetBin, ...getPublishArgs(readPreState())], {
+  const result = spawnSync(process.execPath, [changesetBin, ...args], {
     cwd: ROOT_DIR,
     stdio: 'inherit',
   });
@@ -38,6 +62,15 @@ function publishPackages() {
   if (result.signal) throw new Error(`Changesets publish terminated by ${result.signal}`);
 
   return result.status ?? 1;
+}
+
+function publishPackages() {
+  const preState = readPreState();
+  const args = getPublishArgs(preState);
+
+  if (preState?.mode !== 'pre') return runChangesetPublish(args);
+
+  return withPreStateSetAside(() => runChangesetPublish(args));
 }
 
 if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {

--- a/scripts/publish-packages.test.mjs
+++ b/scripts/publish-packages.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
 
-import { getPublishArgs } from './publish-packages.mjs';
+import { getPublishArgs, withPreStateSetAside } from './publish-packages.mjs';
 
 test('publishes prereleases under the configured prerelease tag', () => {
   assert.deepEqual(getPublishArgs({ mode: 'pre', tag: 'rc' }), ['publish', '--tag', 'rc']);
@@ -15,3 +18,39 @@ test('uses the default tag outside prerelease mode', () => {
 test('rejects prerelease mode without a tag', () => {
   assert.throws(() => getPublishArgs({ mode: 'pre', tag: '' }), /Prerelease mode requires a non-empty tag/);
 });
+
+function withTempPreState(t, run) {
+  const dir = mkdtempSync(join(tmpdir(), 'qiankun-pre-state-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const filePath = join(dir, 'pre.json');
+  const content = JSON.stringify({ mode: 'pre', tag: 'rc' });
+  writeFileSync(filePath, content);
+
+  return run({ dir, filePath, content });
+}
+
+test('hides the pre-state only while the callback runs and returns its result', (t) =>
+  withTempPreState(t, ({ dir, filePath, content }) => {
+    const result = withPreStateSetAside(() => {
+      assert.equal(existsSync(filePath), false, 'pre.json must be absent during publish');
+      return 42;
+    }, filePath);
+
+    assert.equal(result, 42);
+    assert.equal(readFileSync(filePath, 'utf8'), content, 'pre.json must be restored verbatim');
+    assert.equal(existsSync(join(dir, 'pre.json.publishing')), false, 'no parked copy may be left behind');
+  }));
+
+test('restores the pre-state even when the callback throws', (t) =>
+  withTempPreState(t, ({ filePath, content }) => {
+    assert.throws(
+      () =>
+        withPreStateSetAside(() => {
+          throw new Error('publish failed');
+        }, filePath),
+      /publish failed/,
+    );
+
+    assert.equal(readFileSync(filePath, 'utf8'), content);
+  }));


### PR DESCRIPTION
## Why

Merging #3152 did not publish rc.22: the [Changesets run](https://github.com/umijs/qiankun/actions/runs/33312676490/job/99260428688) died at the very first line of `pnpm ci:publish`:

```
$ node scripts/publish-packages.mjs
🦋  error Releasing under custom tag is not allowed in pre mode
🦋  To resolve this exit the pre mode by running `changeset pre exit`
```

Nothing reached npm (`qiankun@rc` is still `3.0.0-rc.21`, no rc.22 git tags), while `next` already carries the rc.22 version numbers and consumed changesets — so the next push to `next` goes straight down the publish path once this is fixed.

Two things went wrong in sequence:

1. The release branch of #3152 squashed in `4b4ce7de`, which replaced #3177's post-publish `npm dist-tag add` step with `changeset publish --tag rc`. Changesets rejects `--tag` in pre mode unconditionally ([`publish.ts`](https://github.com/changesets/changesets/blob/main/packages/cli/src/commands/publish/index.ts)) — the unit test only checked argument assembly, not that Changesets accepts it.
2. Simply reverting to #3177 would fail differently: `npm dist-tag add` needs a long-lived token, and **`NPM_AUTH_TOKEN` does not exist** at the repo, org or `changeset-release` environment level (#3177 assumed it did from a stale reference in `publish-latest.yml`). The workflow publishes via OIDC trusted publishing, which only covers `npm publish`.

## What

`scripts/publish-packages.mjs` now sets `.changeset/pre.json` aside for the duration of `changeset publish --tag <pre.json tag>` and restores it afterwards (also on failure). In Changesets' publish flow the pre-state only drives the `--tag` refusal, the `only-pre` → `latest` fallback and log wording — not which packages get published, git tagging or provenance — so hiding it is exactly what makes the configured tag apply to every package, token-free. Outside pre mode the script still runs a plain `changeset publish` (→ `latest`).

`.changeset/README.md` explains the mechanism and why neither alternative works; the tests cover the set-aside/restore contract.

## Verification

- `pnpm run test:release-scripts` — 8/8 pass; prettier clean.
- Reproduced the CI failure locally (`changeset publish --tag rc` with `pre.json` present → same error).
- Ran the fixed script against an unreachable registry (`npm_config_registry=http://127.0.0.1:9`, not logged in): it passes the gate (`Packages will be released under the rc tag`), enumerates exactly the 9 publishable packages (no private ones), then stops at `npm info` with `ECONNREFUSED` as designed; `pre.json` restored, working tree clean.

After merge, worth a glance at `npm view @qiankunjs/react dist-tags` — `rc` should read `0.0.1-rc.15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
