### PR TITLE
fix(sandbox): patch virtual head before document access

### DIFF
--- a/e2e/fixtures/sub-classic/early-head.css
+++ b/e2e/fixtures/sub-classic/early-head.css
@@ -1,0 +1,4 @@
+#host-probe,
+.early-head-link-target {
+  background-color: rgb(91, 92, 93);
+}

--- a/e2e/fixtures/sub-classic/early-head.html
+++ b/e2e/fixtures/sub-classic/early-head.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>sub-classic-early-head</title>
+  </head>
+  <script>
+    (function (global) {
+      // No external asset or async boundary may precede this first head access: the entire
+      // entry arrives in one stream chunk, before the head observer gets its first callback.
+      var head = document.head;
+      var patchedOnFirstAccess = ['appendChild', 'insertBefore', 'removeChild'].every(function (method) {
+        return Object.prototype.hasOwnProperty.call(head, method);
+      });
+      var style = document.createElement('style');
+      style.dataset.testid = 'early-head-style';
+      style.textContent = '#host-probe, .early-head-style-target { color: rgb(81, 82, 83) }';
+      head.appendChild(style);
+      var scopedOnAppend = style.textContent.trim().startsWith('@scope');
+
+      var link = document.createElement('link');
+      link.dataset.testid = 'early-head-link';
+      link.rel = 'stylesheet';
+      link.href = './early-head.css';
+      head.appendChild(link);
+
+      var bootstrapCount = 0;
+      var mountCount = 0;
+      global['sub-classic-early-head'] = {
+        bootstrap: function () {
+          bootstrapCount++;
+          return Promise.resolve();
+        },
+        mount: function () {
+          mountCount++;
+          var report = document.querySelector('[data-testid="early-head-status"]');
+          report.textContent =
+            'patched:' +
+            patchedOnFirstAccess +
+            ',scoped:' +
+            scopedOnAppend +
+            ',bootstrap:' +
+            bootstrapCount +
+            ',mount:' +
+            mountCount;
+          return Promise.resolve();
+        },
+        unmount: function () {
+          // qiankun owns stylesheet cleanup and restoration; app code never reinjects them.
+          return Promise.resolve();
+        },
+      };
+    })(window);
+  </script>
+  <body>
+    <p class="early-head-style-target" data-testid="early-head-style-target">inline style target</p>
+    <p class="early-head-link-target" data-testid="early-head-link-target">relative stylesheet target</p>
+    <p data-testid="early-head-status"></p>
+  </body>
+</html>

--- a/e2e/ports.ts
+++ b/e2e/ports.ts
@@ -19,6 +19,8 @@ export const SUB_APP_ENTRIES = {
   'sub-classic-broken-asset': `http://localhost:${PORTS['sub-classic']}/broken-asset.html`,
   // the app monkey-patches the document.head/body appendChild it sees before injecting styles
   'sub-classic-patched-append': `http://localhost:${PORTS['sub-classic']}/patched-append.html`,
+  // inline script immediately after </head>, before MutationObserver can patch the virtual head
+  'sub-classic-early-head': `http://localhost:${PORTS['sub-classic']}/early-head.html`,
   'sub-esm': `http://localhost:${PORTS['sub-esm']}`,
   // same server, dedicated page whose HTML carries a <link rel="modulepreload">
   'sub-esm-preload': `http://localhost:${PORTS['sub-esm']}/preload.html`,

--- a/e2e/tests/early-head.spec.ts
+++ b/e2e/tests/early-head.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from '@playwright/test';
+import { SUB_APP_ENTRIES } from '../ports';
+import { type E2EWindow, loadApp, unmountApp } from './helpers';
+
+const APP_NAME = 'sub-classic-early-head';
+const ENTRY_URL = SUB_APP_ENTRIES[APP_NAME];
+const STYLESHEET_URL = new URL('./early-head.css', ENTRY_URL).href;
+
+test('the first document.head access in a single-chunk entry already isolates and records styles', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => {
+    const probe = document.createElement('h1');
+    probe.id = 'host-probe';
+    probe.textContent = 'host style probe';
+    document.body.appendChild(probe);
+  });
+  const hostProbe = page.locator('#host-probe');
+  await expect(hostProbe).toHaveCSS('color', 'rgb(0, 0, 255)');
+  await expect(hostProbe).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+
+  const stylesheetRequests: string[] = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/early-head.css') stylesheetRequests.push(request.url());
+  });
+
+  const status = await page.evaluate(
+    async ({ appName, entryURL }) => {
+      const nativeFetch = window.fetch.bind(window);
+      return (window as unknown as E2EWindow).__E2E__.load(appName, {
+        sandbox: { styleIsolation: true },
+        fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+          const response = await nativeFetch(input, init);
+          if (String(input) !== entryURL) return response;
+          // A server's single res.end() can still become multiple network chunks. Buffer the
+          // real fixture response, then deliver exactly one chunk to the streaming loader.
+          const bytes = new Uint8Array(await response.arrayBuffer());
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(bytes);
+                controller.close();
+              },
+            }),
+            { headers: response.headers, status: response.status, statusText: response.statusText },
+          );
+        },
+      });
+    },
+    { appName: APP_NAME, entryURL: ENTRY_URL },
+  );
+  expect(status).toBe('MOUNTED');
+
+  const container = page.locator(`[data-name="${APP_NAME}"]`);
+  const head = container.locator(':scope > qiankun-head');
+  const style = head.getByTestId('early-head-style');
+  const link = head.getByTestId('early-head-link');
+  const scopePrefix = `@scope ([data-name="${APP_NAME}"])`;
+
+  await expect(page.getByTestId('early-head-status')).toHaveText('patched:true,scoped:true,bootstrap:1,mount:1');
+  await expect(style).toHaveCount(1);
+  await expect.poll(() => style.textContent()).toContain(scopePrefix);
+  await expect(link).toHaveCount(1);
+  await expect(link).toHaveAttribute('data-href', STYLESHEET_URL);
+  await expect(link).toHaveAttribute('href', /^blob:/);
+  expect(
+    await link.evaluate(async (element) => {
+      const href = (element as HTMLLinkElement).href;
+      return (await fetch(href)).text();
+    }),
+  ).toContain(scopePrefix);
+  expect(stylesheetRequests).toEqual([STYLESHEET_URL]);
+  await expect(page.getByTestId('early-head-style-target')).toHaveCSS('color', 'rgb(81, 82, 83)');
+  await expect(page.getByTestId('early-head-link-target')).toHaveCSS('background-color', 'rgb(91, 92, 93)');
+  await expect(hostProbe).toHaveCSS('color', 'rgb(0, 0, 255)');
+  await expect(hostProbe).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+
+  expect(await unmountApp(page, APP_NAME)).toBe('NOT_MOUNTED');
+  await expect(container).toBeEmpty();
+  await expect(page.getByTestId('early-head-style')).toHaveCount(0);
+  await expect(page.getByTestId('early-head-link')).toHaveCount(0);
+
+  expect(await loadApp(page, APP_NAME, { sandbox: { styleIsolation: true } })).toBe('MOUNTED');
+  // Only cached lifecycles run on remount: the inline script cannot recreate either style.
+  await expect(page.getByTestId('early-head-status')).toHaveText('patched:true,scoped:true,bootstrap:1,mount:2');
+  await expect(style).toHaveCount(1);
+  await expect.poll(() => style.textContent()).toContain(scopePrefix);
+  await expect(link).toHaveCount(1);
+  await expect(link).toHaveAttribute('data-href', STYLESHEET_URL);
+  await expect(link).toHaveAttribute('href', /^blob:/);
+  await expect(page.getByTestId('early-head-style-target')).toHaveCSS('color', 'rgb(81, 82, 83)');
+  await expect(page.getByTestId('early-head-link-target')).toHaveCSS('background-color', 'rgb(91, 92, 93)');
+  await expect(hostProbe).toHaveCSS('color', 'rgb(0, 0, 255)');
+  await expect(hostProbe).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+
+  expect(await unmountApp(page, APP_NAME)).toBe('NOT_MOUNTED');
+  await expect(container).toBeEmpty();
+});

--- a/packages/sandbox/src/patchers/dynamicAppend/__tests__/head-patching.test.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/__tests__/head-patching.test.ts
@@ -1,0 +1,174 @@
+import { createSandbox } from '../../../core/sandbox';
+import { type IsolationPluginConfig } from '../../types';
+import { type SandboxConfig } from '../types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+let appSequence = 0;
+const controllers: Array<ReturnType<typeof createSandbox>> = [];
+const containers: HTMLElement[] = [];
+
+function createController() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  containers.push(container);
+  const nodeTransformer = vi.fn<IsolationPluginConfig['nodeTransformer']>((node) => node);
+  const controller = createSandbox(`head-patching-${String(appSequence++)}`, {
+    container,
+    provisionContainerHead: false,
+    nodeTransformer,
+    fetch: window.fetch,
+  });
+  controllers.push(controller);
+  const sharedState = Reflect.get(window, Symbol.for('qiankun.dynamicAppend.sharedState')) as {
+    sandboxConfigs: WeakMap<object, SandboxConfig>;
+  };
+  const config = sharedState.sandboxConfigs.get(controller.instance);
+  if (!config) throw new Error('sandbox config was not registered at bootstrap');
+  return { container, controller, nodeTransformer, config, sandboxDocument: controller.instance.globalThis.document };
+}
+
+describe.sequential('virtual head patching', () => {
+  afterEach(async () => {
+    await Promise.all(controllers.splice(0).map(async (controller) => controller.dispose()));
+    containers.splice(0).forEach((container) => container.remove());
+  });
+
+  it.each(['head', 'querySelector'] as const)('patches a newly inserted head before %s returns it', (accessor) => {
+    const { container, sandboxDocument, nodeTransformer, config } = createController();
+    const readHead = () => (accessor === 'head' ? sandboxDocument.head : sandboxDocument.querySelector('head'));
+    expect(readHead).toThrow(/head element not existed/);
+
+    const head = document.createElement('qiankun-head');
+    container.appendChild(head);
+    // Stay in the insertion task: MutationObserver has not delivered the new head yet.
+    expect(Object.hasOwn(head, 'appendChild')).toBe(false);
+    expect(readHead()).toBe(head);
+    for (const method of ['appendChild', 'insertBefore', 'removeChild']) {
+      expect(Object.hasOwn(head, method)).toBe(true);
+    }
+
+    const style = sandboxDocument.createElement('style');
+    const link = sandboxDocument.createElement('link');
+    link.rel = 'stylesheet';
+    head.appendChild(style);
+    head.insertBefore(link, style);
+    const script = sandboxDocument.createElement('script');
+    head.appendChild(script);
+
+    expect(nodeTransformer.mock.calls.map(([node]) => node)).toEqual([style, link, script]);
+    expect(config.dynamicStyleSheetElements).toEqual([style, link]);
+    head.removeChild(style);
+    expect(config.dynamicStyleSheetElements).toEqual([link]);
+  });
+
+  it('preserves app method wrappers across repeated reads and observer delivery', async () => {
+    const { container, controller, sandboxDocument, nodeTransformer, config } = createController();
+    const head = document.createElement('qiankun-head');
+    container.appendChild(head);
+    expect(sandboxDocument.head).toBe(head);
+    const appendChild = head.appendChild.bind(head);
+    const wrapper = vi.fn(appendChild);
+    head.appendChild = wrapper;
+
+    // A separate observer proves that delivery has occurred without relying on a timer.
+    await new Promise<void>((resolve) => {
+      const observer = new MutationObserver(() => {
+        observer.disconnect();
+        resolve();
+      });
+      observer.observe(head, { childList: true });
+      head.appendChild(document.createComment('deliver observers'));
+    });
+    expect(sandboxDocument.head).toBe(head);
+    expect(sandboxDocument.querySelector('head')).toBe(head);
+    expect(head.appendChild).toBe(wrapper);
+
+    const style = sandboxDocument.createElement('style');
+    head.appendChild(style);
+    expect(nodeTransformer).toHaveBeenCalledTimes(1);
+    expect(config.dynamicStyleSheetElements).toEqual([style]);
+    await controller.dispose();
+    expect(head.appendChild).toBe(wrapper);
+    expect(Object.hasOwn(head, 'insertBefore')).toBe(false);
+    expect(Object.hasOwn(head, 'removeChild')).toBe(false);
+  });
+
+  it('still patches a streamed head through the observer when no getter is used', async () => {
+    const { container, controller } = createController();
+    const head = document.createElement('qiankun-head');
+    container.appendChild(head);
+    await vi.waitFor(() => expect(Object.hasOwn(head, 'appendChild')).toBe(true));
+
+    await controller.dispose();
+    for (const method of ['appendChild', 'insertBefore', 'removeChild']) {
+      expect(Object.hasOwn(head, method)).toBe(false);
+    }
+  });
+
+  it('patches replacement heads and releases every patched head', async () => {
+    const { container, controller, sandboxDocument } = createController();
+    const firstHead = document.createElement('qiankun-head');
+    container.appendChild(firstHead);
+    expect(sandboxDocument.head).toBe(firstHead);
+
+    const secondHead = document.createElement('qiankun-head');
+    firstHead.replaceWith(secondHead);
+    expect(sandboxDocument.head).toBe(secondHead);
+    expect(Object.hasOwn(secondHead, 'appendChild')).toBe(true);
+
+    await controller.dispose();
+    for (const head of [firstHead, secondHead]) {
+      for (const method of ['appendChild', 'insertBefore', 'removeChild']) {
+        expect(Object.hasOwn(head, method)).toBe(false);
+      }
+    }
+  });
+
+  it('uses the active installation when a script retains its document across remounts', async () => {
+    const { container, controller, sandboxDocument, nodeTransformer } = createController();
+    const firstHead = document.createElement('qiankun-head');
+    container.appendChild(firstHead);
+    await controller.mount(container);
+    await controller.unmount();
+
+    // Accessing a retired proxy must not restore released methods.
+    expect(sandboxDocument.head).toBe(firstHead);
+    expect(Object.hasOwn(firstHead, 'appendChild')).toBe(false);
+    await controller.mount(container);
+    const secondHead = document.createElement('qiankun-head');
+    firstHead.replaceWith(secondHead);
+    // ESM modules can keep the original document binding after the mount installs a new proxy.
+    expect(sandboxDocument.head).toBe(secondHead);
+    expect(Object.hasOwn(secondHead, 'appendChild')).toBe(true);
+    const style = sandboxDocument.createElement('style');
+    sandboxDocument.head.appendChild(style);
+    expect(nodeTransformer).toHaveBeenCalledTimes(1);
+
+    await controller.dispose();
+    expect(sandboxDocument.head).toBe(secondHead);
+    expect(Object.hasOwn(secondHead, 'appendChild')).toBe(false);
+  });
+
+  it('does not let an old document getter take ownership from a later sandbox', async () => {
+    const first = createController();
+    const secondTransformer = vi.fn<IsolationPluginConfig['nodeTransformer']>((node) => node);
+    const second = createSandbox('head-patching-takeover', {
+      container: first.container,
+      provisionContainerHead: false,
+      nodeTransformer: secondTransformer,
+      fetch: window.fetch,
+    });
+    controllers.push(second);
+
+    const head = document.createElement('qiankun-head');
+    first.container.appendChild(head);
+    expect(second.instance.globalThis.document.head).toBe(head);
+    expect(first.sandboxDocument.head).toBe(head);
+    await first.controller.dispose();
+    const style = document.createElement('style');
+    head.appendChild(style);
+    expect(secondTransformer).toHaveBeenCalledTimes(1);
+    expect(first.nodeTransformer).not.toHaveBeenCalled();
+    expect(first.config.dynamicStyleSheetElements).toHaveLength(0);
+  });
+});

--- a/packages/sandbox/src/patchers/dynamicAppend/forStandardSandbox.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/forStandardSandbox.ts
@@ -84,6 +84,8 @@ const sharedState = (() => {
 })();
 
 const { containerOwners, elementConfigs, sandboxConfigs } = sharedState;
+// Scripts may retain a document proxy across remounts; its getter must use the active installation.
+const activeHeadPatchers = new WeakMap<PluginCompartment, (headElement: HTMLHeadElement) => void>();
 
 const getSandboxConfig = (element: HTMLElement) => elementConfigs.get(element);
 const setSandboxConfig = (element: HTMLElement, config: SandboxConfig) => elementConfigs.set(element, config);
@@ -133,13 +135,19 @@ function patchDocument(
     return () => {};
   }
 
-  const unpatch = patchDocumentHeadAndBodyMethods(container, compartment);
+  const { ensureHeadPatched, unpatch } = patchDocumentHeadAndBodyMethods(container, compartment);
+  activeHeadPatchers.set(compartment, ensureHeadPatched);
 
   const getDocumentHeadElement = () => {
     const currentContainer = getRequiredContainer(getContainer, appName);
     const containerHeadElement = getContainerHeadElement(currentContainer);
     if (!containerHeadElement) {
       throw new QiankunError(`${appName} head element not existed while accessing document.head!`);
+    }
+    // A streamed head and the adjacent inline script can enter live DOM in the same
+    // insertion batch, before MutationObserver delivery. Never expose an unpatched head.
+    if (containerOwners.get(currentContainer) === compartment) {
+      activeHeadPatchers.get(compartment)?.(containerHeadElement);
     }
     return containerHeadElement;
   };
@@ -228,13 +236,19 @@ function patchDocument(
 
   return () => {
     unpatch();
+    if (activeHeadPatchers.get(compartment) === ensureHeadPatched) {
+      activeHeadPatchers.delete(compartment);
+    }
     if (containerOwners.get(container) === compartment) {
       containerOwners.delete(container);
     }
   };
 }
 
-function patchDocumentHeadAndBodyMethods(container: HTMLElement, compartment: PluginCompartment): Unpatch {
+function patchDocumentHeadAndBodyMethods(
+  container: HTMLElement,
+  compartment: PluginCompartment,
+): { ensureHeadPatched: (headElement: HTMLHeadElement) => void; unpatch: Unpatch } {
   // tag the mount points with the owning app config, so fragment-wrapped children (parsed via
   // innerHTML rather than the sandboxed createElement) can inherit it during decomposition
   const tagMountPoint = (mountPoint: HTMLElement) => {
@@ -249,46 +263,39 @@ function patchDocumentHeadAndBodyMethods(container: HTMLElement, compartment: Pl
     }
   };
 
-  let patchedHeadMethods:
-    | {
-        appendChild: typeof document.head.appendChild;
-        insertBefore: typeof document.head.insertBefore;
-        removeChild: typeof document.head.removeChild;
-      }
-    | undefined;
-  const patchHeadElementMethod = (headElement: HTMLHeadElement) => {
-    tagMountPoint(headElement);
-    patchedHeadMethods = {
-      appendChild: getOverwrittenAppendChildOrInsertBefore(
-        nativeAppendChild,
-        getSandboxConfig,
-        'head',
-        setSandboxConfig,
-      ),
-      insertBefore: getOverwrittenAppendChildOrInsertBefore(
-        nativeInsertBefore,
-        getSandboxConfig,
-        'head',
-        setSandboxConfig,
-      ),
-      removeChild: getNewRemoveChild(nativeRemoveChild, getSandboxConfig),
-    };
-    Object.assign(headElement, patchedHeadMethods);
+  const patchedHeadMethods = {
+    appendChild: getOverwrittenAppendChildOrInsertBefore(nativeAppendChild, getSandboxConfig, 'head', setSandboxConfig),
+    insertBefore: getOverwrittenAppendChildOrInsertBefore(
+      nativeInsertBefore,
+      getSandboxConfig,
+      'head',
+      setSandboxConfig,
+    ),
+    removeChild: getNewRemoveChild(nativeRemoveChild, getSandboxConfig),
   };
-  let containerHeadElement = getContainerHeadElement(container);
+  const patchedHeads = new Set<HTMLHeadElement>();
+  let released = false;
+  const ensureHeadPatched = (headElement: HTMLHeadElement) => {
+    // Repeated getters and observer delivery must preserve wrappers installed by the app.
+    if (released || patchedHeads.has(headElement)) return;
+    tagMountPoint(headElement);
+    Object.assign(headElement, patchedHeadMethods);
+    patchedHeads.add(headElement);
+  };
+  const containerHeadElement = getContainerHeadElement(container);
   let observer: MutationObserver | undefined;
   if (!containerHeadElement) {
-    // patch container head element after it is mounted
+    // Keep eager patching for head references obtained without the sandbox document getter.
     observer = new MutationObserver(() => {
-      containerHeadElement = getContainerHeadElement(container);
-      if (containerHeadElement) {
-        patchHeadElementMethod(containerHeadElement);
+      const headElement = getContainerHeadElement(container);
+      if (headElement) {
+        if (containerOwners.get(container) === compartment) ensureHeadPatched(headElement);
         observer?.disconnect();
       }
     });
     observer.observe(container, { subtree: true, childList: true });
   } else {
-    patchHeadElementMethod(containerHeadElement);
+    ensureHeadPatched(containerHeadElement);
   }
 
   const containerBodyElement = container;
@@ -305,20 +312,22 @@ function patchDocumentHeadAndBodyMethods(container: HTMLElement, compartment: Pl
   };
   Object.assign(containerBodyElement, patchedBodyMethods);
 
-  return () => {
+  const unpatch = () => {
+    released = true;
     observer?.disconnect();
-    if (containerHeadElement && patchedHeadMethods) {
-      if (containerHeadElement.appendChild === patchedHeadMethods.appendChild) {
-        Reflect.deleteProperty(containerHeadElement, 'appendChild');
+    patchedHeads.forEach((headElement) => {
+      if (headElement.appendChild === patchedHeadMethods.appendChild) {
+        Reflect.deleteProperty(headElement, 'appendChild');
       }
-      if (containerHeadElement.insertBefore === patchedHeadMethods.insertBefore) {
-        Reflect.deleteProperty(containerHeadElement, 'insertBefore');
+      if (headElement.insertBefore === patchedHeadMethods.insertBefore) {
+        Reflect.deleteProperty(headElement, 'insertBefore');
       }
-      if (containerHeadElement.removeChild === patchedHeadMethods.removeChild) {
-        Reflect.deleteProperty(containerHeadElement, 'removeChild');
+      if (headElement.removeChild === patchedHeadMethods.removeChild) {
+        Reflect.deleteProperty(headElement, 'removeChild');
       }
-      untagMountPoint(containerHeadElement);
-    }
+      untagMountPoint(headElement);
+    });
+    patchedHeads.clear();
 
     if (containerBodyElement.appendChild === patchedBodyMethods.appendChild) {
       Reflect.deleteProperty(containerBodyElement, 'appendChild');
@@ -331,6 +340,8 @@ function patchDocumentHeadAndBodyMethods(container: HTMLElement, compartment: Pl
     }
     untagMountPoint(containerBodyElement);
   };
+
+  return { ensureHeadPatched, unpatch };
 }
 
 function patchDOMPrototypeFns(): Unpatch {


### PR DESCRIPTION
修复 #3151：单个入口 HTML 分块中，紧跟 `</head>` 的内联脚本访问 `document.head` 时，虚拟头元素尚未完成补丁安装，动态样式会绕过隔离、地址解析和卸载后的恢复。

## 做了什么 / 为什么

- 在 `document.head` 和 `document.querySelector('head')` 返回元素前同步确保 `appendChild`、`insertBefore`、`removeChild` 已安装沙箱补丁。保留 MutationObserver，为未经过这两个访问入口的元素引用提供原有兜底；两条路径共用幂等操作，不覆盖微应用自行包装的方法。
- 记录本次安装处理过的虚拟头，卸载时逐一清理；旧 document 引用在重挂载后使用当前补丁安装器，并通过容器归属检查避免抢占其他微应用。ESM 与经典脚本共用 document 代理，因此修复同时适用于两条执行路径。
- 新增 7 条单测及单分块 HTML 回归夹具，覆盖样式隔离、相对样式地址、宿主不受影响、卸载移除和缓存生命周期重挂载恢复。未增加依赖，也未修改 loader 或 writable-dom。

## 如何验证

- `pnpm run eslint && pnpm run prettier:check && pnpm --filter @qiankunjs/sandbox run test && pnpm --filter qiankun run test`：通过，sandbox 79 条、qiankun 33 条。
- `pnpm run build:packages`、`pnpm --filter @qiankunjs/e2e run build:fixtures`：通过。
- Chromium：`early-head`、`sandbox-js`、`style-isolation`、`esm-sandbox`、`nested-sandbox`、`standalone-sandbox`、`container-gate` 共 35 条用例通过。
- 原实现的单测对照失败于返回了尚未安装补丁的虚拟头；真实浏览器对照得到 `patched:false,scoped:false,bootstrap:1,mount:1`，精确复现问题。恢复修复后重新构建并通过同一用例。

Closes #3151

🤖 Generated with [Claude Code](https://claude.com/claude-code)
