### PR TITLE
fix(release): support stable releases and omit empty note sections

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -44,6 +44,15 @@ before resetting or migrating the release workflow.
 sub-package to npm, then `scripts/generate-release-notes.mjs` aggregates the published packages'
 `CHANGELOG.md` entries into one set of notes and `gh release create` posts a **single GitHub Release**.
 
+The release job uses `ci:version` and `ci:publish` for both prerelease and stable releases. The GitHub
+Release is marked as a prerelease when the qiankun version contains `-` (for example, `3.0.0-rc.22`);
+otherwise it is explicitly marked as **Latest** with `--latest`. The notes generator removes dependency
+update entries and any change subsection left without a `- ` item, then omits packages with no remaining
+change items.
+
+The workflow stays at `.github/workflows/changeset-prerelease.yml` even for stable releases: npm trusted
+publishing is bound to that filename and the `changeset-release` environment.
+
 In prerelease mode, `scripts/publish-packages.mjs` runs `changeset publish --tag <pre.json tag>` with
 `pre.json` set aside for the duration of the publish, then restores it. Both halves are needed: Changesets
 refuses `--tag` outright while the pre-state says `mode: "pre"`, yet its own tag choice in that mode sends a

--- a/.github/workflows/changeset-prerelease.yml
+++ b/.github/workflows/changeset-prerelease.yml
@@ -69,9 +69,14 @@ jobs:
           # fact via the /release-changelog skill (gh release edit).
           node scripts/generate-release-notes.mjs '${{ steps.changesets.outputs.publishedPackages }}' > /tmp/release-notes.md
 
+          case "${VERSION}" in
+            *-*) RELEASE_FLAG="--prerelease" ;;
+            *) RELEASE_FLAG="--latest" ;;
+          esac
+
           gh release create "${TAG}" \
             --title "${TAG}" \
             --notes-file /tmp/release-notes.md \
-            --prerelease
+            "${RELEASE_FLAG}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "build:examples-site": "pnpm run build:packages && node scripts/build-examples-site.mjs",
     "check:lodash-imports": "node scripts/check-lodash-imports.mjs",
     "ci:version": "changeset version && node scripts/sanitize-pre-state.mjs",
-    "prerelease:alpha": "changeset pre enter alpha && changeset && pnpm ci:version",
-    "release:alpha": "pnpm run build && changeset publish && changeset pre exit",
     "eslint": "eslint packages/",
     "prettier": "prettier --write .",
     "prettier:check": "prettier -c .",

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -66,10 +66,10 @@ function discoverPackageDirs() {
 
 /**
  * Extract the latest version entry from a CHANGELOG.md content string.
- * Returns filtered lines with "Updated dependencies" noise removed,
+ * Returns filtered lines with "Updated dependencies" noise and empty subsections removed,
  * or null if no entry is found.
  */
-function extractLatestEntry(changelogContent) {
+export function extractLatestEntry(changelogContent) {
   const lines = changelogContent.split('\n');
 
   // Find the range of the first ## version section
@@ -119,79 +119,102 @@ function extractLatestEntry(changelogContent) {
     filtered.push(line);
   }
 
-  return filtered;
+  // Keep a changeset subsection only when a real change item remains in it.
+  const result = [];
+  let section = [];
+
+  function appendSection() {
+    if (!section[0]?.startsWith('### ') || section.some((line) => line.startsWith('- '))) {
+      result.push(...section);
+    }
+  }
+
+  for (const line of filtered) {
+    if (line.startsWith('### ')) {
+      appendSection();
+      section = [];
+    }
+    section.push(line);
+  }
+  appendSection();
+
+  return result;
 }
 
 // --- Main ---
 
-const publishedPackagesJSON = process.argv[2];
-if (!publishedPackagesJSON) {
-  console.error("Usage: node scripts/generate-release-notes.mjs '<publishedPackagesJSON>'");
-  process.exit(1);
-}
-
-let publishedPackages;
-try {
-  publishedPackages = JSON.parse(publishedPackagesJSON);
-} catch (e) {
-  console.error('Failed to parse publishedPackages JSON:', e.message);
-  process.exit(1);
-}
-
-if (!Array.isArray(publishedPackages) || publishedPackages.length === 0) {
-  console.error('No published packages provided.');
-  process.exit(1);
-}
-
-const packageDirs = discoverPackageDirs();
-const sections = [];
-
-// Sort: qiankun first (facade package), then alphabetical
-const sorted = [...publishedPackages].sort((a, b) => {
-  if (a.name === 'qiankun') return -1;
-  if (b.name === 'qiankun') return 1;
-  return a.name.localeCompare(b.name);
-});
-
-for (const { name, version } of sorted) {
-  const dir = packageDirs.get(name);
-  if (!dir) {
-    console.error(`Warning: could not find directory for package "${name}"`);
-    continue;
+function main() {
+  const publishedPackagesJSON = process.argv[2];
+  if (!publishedPackagesJSON) {
+    console.error("Usage: node scripts/generate-release-notes.mjs '<publishedPackagesJSON>'");
+    process.exit(1);
   }
 
-  const changelogPath = join(dir, 'CHANGELOG.md');
-  if (!existsSync(changelogPath)) {
-    console.error(`Warning: no CHANGELOG.md found for "${name}" at ${changelogPath}`);
-    continue;
+  let publishedPackages;
+  try {
+    publishedPackages = JSON.parse(publishedPackagesJSON);
+  } catch (e) {
+    console.error('Failed to parse publishedPackages JSON:', e.message);
+    process.exit(1);
   }
 
-  const content = readFileSync(changelogPath, 'utf-8');
-  const entryLines = extractLatestEntry(content);
-
-  if (!entryLines || entryLines.length === 0) {
-    continue;
+  if (!Array.isArray(publishedPackages) || publishedPackages.length === 0) {
+    console.error('No published packages provided.');
+    process.exit(1);
   }
 
-  // Skip the "## version" line (first entry) — we'll use our own formatted header
-  const restLines = entryLines.slice(1);
+  const packageDirs = discoverPackageDirs();
+  const sections = [];
 
-  // Trim leading/trailing blank lines
-  while (restLines.length > 0 && restLines[0].trim() === '') restLines.shift();
-  while (restLines.length > 0 && restLines[restLines.length - 1].trim() === '') restLines.pop();
+  // Sort: qiankun first (facade package), then alphabetical
+  const sorted = [...publishedPackages].sort((a, b) => {
+    if (a.name === 'qiankun') return -1;
+    if (b.name === 'qiankun') return 1;
+    return a.name.localeCompare(b.name);
+  });
 
-  // If only headings remain with no actual change items, skip this package
-  const hasActualChanges = restLines.some((l) => l.startsWith('- '));
-  if (!hasActualChanges) {
-    continue;
+  for (const { name, version } of sorted) {
+    const dir = packageDirs.get(name);
+    if (!dir) {
+      console.error(`Warning: could not find directory for package "${name}"`);
+      continue;
+    }
+
+    const changelogPath = join(dir, 'CHANGELOG.md');
+    if (!existsSync(changelogPath)) {
+      console.error(`Warning: no CHANGELOG.md found for "${name}" at ${changelogPath}`);
+      continue;
+    }
+
+    const content = readFileSync(changelogPath, 'utf-8');
+    const entryLines = extractLatestEntry(content);
+
+    if (!entryLines || entryLines.length === 0) {
+      continue;
+    }
+
+    // Skip the "## version" line (first entry) — we'll use our own formatted header
+    const restLines = entryLines.slice(1);
+
+    // Trim leading/trailing blank lines
+    while (restLines.length > 0 && restLines[0].trim() === '') restLines.shift();
+    while (restLines.length > 0 && restLines[restLines.length - 1].trim() === '') restLines.pop();
+
+    // If only headings remain with no actual change items, skip this package
+    const hasActualChanges = restLines.some((l) => l.startsWith('- '));
+    if (!hasActualChanges) {
+      continue;
+    }
+
+    sections.push(`## ${name} \`${version}\`\n\n${restLines.join('\n')}`);
   }
 
-  sections.push(`## ${name} \`${version}\`\n\n${restLines.join('\n')}`);
+  if (sections.length === 0) {
+    console.error('No changelog entries found for any published package.');
+    process.exit(1);
+  }
+
+  console.log(sections.join('\n\n'));
 }
 
-if (sections.length === 0) {
-  console.error('No changelog entries found for any published package.');
-  process.exit(1);
-}
-
-console.log(sections.join('\n\n'));
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/generate-release-notes.test.mjs
+++ b/scripts/generate-release-notes.test.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { extractLatestEntry } from './generate-release-notes.mjs';
+
+test('removes empty subsections before, between, and after actual changes', () => {
+  const entry = extractLatestEntry(`# qiankun
+
+## 3.0.0
+
+### Empty before
+
+### Major Changes
+
+- Introduce the new runtime.
+
+### Empty middle
+
+- Updated dependencies [abc123]
+  - @qiankunjs/shared@1.0.0
+
+### Minor Changes
+
+- Support a new integration.
+
+### Empty after
+
+`);
+
+  assert.equal(
+    entry.join('\n').trim(),
+    `## 3.0.0
+
+### Major Changes
+
+- Introduce the new runtime.
+
+### Minor Changes
+
+- Support a new integration.`,
+  );
+});
+
+test('removes dependency-only subsections and their version references', () => {
+  const entry = extractLatestEntry(`## 3.0.0-rc.22
+
+### Patch Changes
+
+- Updated dependencies [abc123]
+- Updated dependencies [def456]
+  - @qiankunjs/shared@1.0.0-rc.22
+  - @qiankunjs/sandbox@1.0.0-rc.22
+
+### Minor Changes
+
+- Updated dependencies [789abc]
+  - @qiankunjs/loader@1.0.0-rc.22
+`);
+
+  assert.equal(entry.join('\n').trim(), '## 3.0.0-rc.22');
+});
+
+test('preserves actual change items and multiline descriptions around dependency updates', () => {
+  const entry = extractLatestEntry(`## 3.0.0
+
+### Patch Changes
+
+- Fix remounting.
+  Keep the container occupied until cleanup finishes.
+
+  - Preserve the mount order.
+  - Release the container on failure.
+
+  Further details belong to the same change.
+
+- Updated dependencies [abc123]
+  - @qiankunjs/shared@1.0.0
+- Fix cleanup.
+  Preserve this continuation too.
+`);
+
+  assert.equal(
+    entry.join('\n').trim(),
+    `## 3.0.0
+
+### Patch Changes
+
+- Fix remounting.
+  Keep the container occupied until cleanup finishes.
+
+  - Preserve the mount order.
+  - Release the container on failure.
+
+  Further details belong to the same change.
+
+- Fix cleanup.
+  Preserve this continuation too.`,
+  );
+});
+
+test('extracts only the latest version while retaining populated subsections', () => {
+  const entry = extractLatestEntry(`# qiankun
+
+## 3.0.0
+
+### Major Changes
+
+- Ship the stable release.
+
+## 3.0.0-rc.22
+
+### Patch Changes
+
+- Fix the previous prerelease.
+`);
+
+  assert.equal(
+    entry.join('\n').trim(),
+    `## 3.0.0
+
+### Major Changes
+
+- Ship the stable release.`,
+  );
+});
+
+test('does not fall back to older changes when the latest version only updates dependencies', () => {
+  const entry = extractLatestEntry(`## 3.0.0
+
+### Patch Changes
+
+- Updated dependencies [abc123]
+  - @qiankunjs/shared@1.0.0
+
+## 3.0.0-rc.22
+
+### Patch Changes
+
+- Fix the previous prerelease.
+`);
+
+  assert.equal(entry.join('\n').trim(), '## 3.0.0');
+});
+
+test('preserves changes without a subsection heading', () => {
+  const entry = extractLatestEntry(`## 3.0.0
+
+- Fix cleanup.
+  Retain the description.
+
+- Updated dependencies [abc123]
+  - @qiankunjs/shared@1.0.0
+`);
+
+  assert.equal(
+    entry.join('\n').trim(),
+    `## 3.0.0
+
+- Fix cleanup.
+  Retain the description.`,
+  );
+});
+
+test('returns null when no version entry exists', () => {
+  assert.equal(extractLatestEntry('# qiankun\n\nNo releases yet.\n'), null);
+});


### PR DESCRIPTION
## 做了什么

- 创建 GitHub Release 时按 qiankun 版本号选择标记：包含 `-` 使用 `--prerelease`，正式版显式使用 `--latest`。
- 聚合 release notes 时，先过滤依赖更新，再删除没有变更条目的小节；补充 7 个回归测试，覆盖空小节、依赖更新、多行说明及最新版本边界。
- 删除陈旧的 `prerelease:alpha` / `release:alpha` 脚本，并更新三阶段发布说明。

## 为什么

原 workflow 固定使用 `--prerelease`，会把正式版标记成预发布，无法接替旧版 Latest；依赖更新被过滤后，release notes 仍可能留下空标题。workflow 文件名和 `changeset-release` environment 保持不变，继续使用现有 OIDC trusted publishing，不新增 npm token 步骤。

## 如何验证

- `pnpm run test:release-scripts`：15/15 通过。
- `pnpm run build:packages`：通过；新 worktree 生成依赖声明后，`pnpm run eslint && pnpm run prettier:check` 通过。
- actionlint 1.7.12 检查 `.github/workflows/changeset-prerelease.yml`：退出码 0，无诊断。
- 提取 workflow 的 shell 发布片段，用 mock `gh` 检查 `3.0.0`、`3.0.1`、`3.0.0-rc.22`、`3.0.0-alpha.1`：标记及 tag/title/notes 参数全部符合预期。
- 实际运行 release notes CLI 读取 rc.22 changelog：保留 5 条 Minor Changes，移除空 Patch Changes。未触发真实发布。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
