### PR TITLE
chore: complete published package metadata

### DIFF
--- a/packages/bundler-plugin/package.json
+++ b/packages/bundler-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "Bundler plugins for qiankun micro-frontend framework",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/umijs/qiankun.git"
+    "url": "git+https://github.com/umijs/qiankun.git",
+    "directory": "packages/bundler-plugin"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -70,5 +71,14 @@
   "devDependencies": {
     "vite": "^8.1.5",
     "webpack": "^5.108.4"
-  }
+  },
+  "homepage": "https://www.qiankunjs.com",
+  "bugs": {
+    "url": "https://github.com/umijs/qiankun/issues"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "sideEffects": false
 }

--- a/packages/loader/README.md
+++ b/packages/loader/README.md
@@ -1,0 +1,11 @@
+# @qiankunjs/loader
+
+qiankun 的流式 HTML 入口加载器，负责将微应用的 HTML 逐步写入容器，并通过沙箱提供的接口完成资源转换和脚本执行。它是 qiankun 加载流程的底层组件；业务应用建议使用 `qiankun` 的公开 API，无需单独安装本包。
+
+文档：[HTML 入口](https://www.qiankunjs.com/zh-CN/concepts/html-entry-loading)。
+
+## English
+
+The streaming HTML-entry loader for qiankun. It incrementally writes a micro-app's HTML into its container and uses sandbox-provided interfaces for asset transformation and script execution. This package is a low-level part of qiankun's loading pipeline; application code should use the public `qiankun` APIs without installing it separately.
+
+Documentation: [HTML entry](https://www.qiankunjs.com/concepts/html-entry-loading).

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@qiankunjs/loader",
   "version": "0.1.0-rc.22",
-  "description": "",
+  "description": "Streaming HTML-entry loader for qiankun",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/umijs/qiankun.git"
+    "url": "git+https://github.com/umijs/qiankun.git",
+    "directory": "packages/loader"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -26,9 +27,14 @@
     "tachometer": "^0.7.2"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "files": [
     "dist"
-  ]
+  ],
+  "homepage": "https://www.qiankunjs.com",
+  "bugs": {
+    "url": "https://github.com/umijs/qiankun/issues"
+  }
 }

--- a/packages/qiankun/package.json
+++ b/packages/qiankun/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/umijs/qiankun.git"
+    "url": "git+https://github.com/umijs/qiankun.git",
+    "directory": "packages/qiankun"
   },
   "files": [
     "dist"
@@ -30,7 +31,7 @@
   "bugs": {
     "url": "https://github.com/umijs/qiankun/issues"
   },
-  "homepage": "https://github.com/umijs/qiankun#readme",
+  "homepage": "https://www.qiankunjs.com",
   "dependencies": {
     "@qiankunjs/loader": "workspace:^",
     "@qiankunjs/sandbox": "workspace:^",
@@ -39,6 +40,7 @@
     "@qiankunjs/single-spa": "workspace:^"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   }
 }

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -4,7 +4,8 @@
   "description": "qiankun sandbox",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/umijs/qiankun.git"
+    "url": "git+https://github.com/umijs/qiankun.git",
+    "directory": "packages/sandbox"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -24,6 +25,11 @@
     "lodash": "^4.18.1"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "homepage": "https://www.qiankunjs.com",
+  "bugs": {
+    "url": "https://github.com/umijs/qiankun/issues"
   }
 }

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,11 @@
+# @qiankunjs/shared
+
+qiankun 内部共用的基础模块，为加载器、沙箱和运行时提供资源转换、请求处理、模块解析及 ESM 沙箱引擎等能力。它位于 qiankun 内部依赖关系的底层，不建议业务应用直接依赖；接入微应用请使用 `qiankun` 的公开 API。
+
+文档：[加载一个微应用实例](https://www.qiankunjs.com/zh-CN/concepts/architecture)。
+
+## English
+
+Internal foundation modules shared by qiankun's loader, sandbox, and runtime, including asset transformation, fetch utilities, module resolution, and the ESM sandbox engine. This package sits at the bottom of qiankun's internal dependency graph and is not recommended as a direct application dependency; use the public `qiankun` APIs to integrate micro-apps.
+
+Documentation: [Loading a micro-app instance](https://www.qiankunjs.com/concepts/architecture).

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,8 @@
   "description": "internal shared package for qiankun",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/umijs/qiankun.git"
+    "url": "git+https://github.com/umijs/qiankun.git",
+    "directory": "packages/shared"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -25,6 +26,11 @@
     "dist"
   ],
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "homepage": "https://www.qiankunjs.com",
+  "bugs": {
+    "url": "https://github.com/umijs/qiankun/issues"
   }
 }

--- a/packages/single-spa/package.json
+++ b/packages/single-spa/package.json
@@ -4,7 +4,8 @@
   "description": "qiankun's vendored fork of single-spa (7.0 branch @ ce0f925a, v7.0.0-beta.13)",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/umijs/qiankun.git"
+    "url": "git+https://github.com/umijs/qiankun.git",
+    "directory": "packages/single-spa"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -17,9 +18,14 @@
   "author": "Kuitos",
   "license": "MIT",
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "files": [
     "dist"
-  ]
+  ],
+  "homepage": "https://www.qiankunjs.com",
+  "bugs": {
+    "url": "https://github.com/umijs/qiankun/issues"
+  }
 }

--- a/packages/ui-bindings/react/package.json
+++ b/packages/ui-bindings/react/package.json
@@ -30,10 +30,19 @@
     "react-dom": ">=16.9.0"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "files": [
     "dist"
   ],
-  "repository": "git@github.com:umijs/qiankun.git"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/umijs/qiankun.git",
+    "directory": "packages/ui-bindings/react"
+  },
+  "homepage": "https://www.qiankunjs.com",
+  "bugs": {
+    "url": "https://github.com/umijs/qiankun/issues"
+  }
 }

--- a/packages/ui-bindings/shared/README.md
+++ b/packages/ui-bindings/shared/README.md
@@ -1,0 +1,11 @@
+# @qiankunjs/ui-shared
+
+qiankun 的 React 和 Vue 组件共用的内部模块，封装微应用的挂载、更新、加载状态和错误处理，并提供共用类型。它连接组件层与 qiankun 运行时，不建议单独使用；React 和 Vue 主应用请分别使用 `@qiankunjs/react` 和 `@qiankunjs/vue`。
+
+文档：[生态概览](https://www.qiankunjs.com/zh-CN/ecosystem/)。
+
+## English
+
+Internal modules shared by qiankun's React and Vue components, covering micro-app mounting, updates, loading state, error handling, and shared types. This package connects the component layer to the qiankun runtime and is not recommended for standalone use; React and Vue host applications should use `@qiankunjs/react` and `@qiankunjs/vue`, respectively.
+
+Documentation: [Ecosystem overview](https://www.qiankunjs.com/ecosystem/).

--- a/packages/ui-bindings/shared/package.json
+++ b/packages/ui-bindings/shared/package.json
@@ -24,10 +24,19 @@
     "qiankun": "^3.0.0-rc.15"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "files": [
     "dist"
   ],
-  "repository": "git@github.com:umijs/qiankun.git"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/umijs/qiankun.git",
+    "directory": "packages/ui-bindings/shared"
+  },
+  "homepage": "https://www.qiankunjs.com",
+  "bugs": {
+    "url": "https://github.com/umijs/qiankun/issues"
+  }
 }

--- a/packages/ui-bindings/vue/package.json
+++ b/packages/ui-bindings/vue/package.json
@@ -32,10 +32,19 @@
     }
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "files": [
     "dist"
   ],
-  "repository": "git@github.com:umijs/qiankun.git"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/umijs/qiankun.git",
+    "directory": "packages/ui-bindings/vue"
+  },
+  "homepage": "https://www.qiankunjs.com",
+  "bugs": {
+    "url": "https://github.com/umijs/qiankun/issues"
+  }
 }


### PR DESCRIPTION
补齐 9 个发布包的仓库目录、官网、问题反馈地址和公开发布配置；为 loader、shared、ui-shared 新增简短的中英文 README，并补上 loader 描述及 bundler-plugin 的 sideEffects 声明。版本号、依赖和 peerDependencies 均保持不变。

这些信息让 npm 包页面能够说明各包用途，并准确链接到单仓库中的源码目录，避免缺失 README 和发布配置。

验证：`pnpm run build:packages`、`pnpm --filter './packages/**' run test`（614 项通过、3 项原有跳过）、`pnpm run eslint`、`pnpm run prettier:check` 均通过；9 个包的 `pnpm pack --dry-run` 均包含 README、dist 和 LICENSE。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
