### PR TITLE
feat: add typed exports for published packages

### DIFF
--- a/packages/bundler-plugin/package.json
+++ b/packages/bundler-plugin/package.json
@@ -40,7 +40,8 @@
         "types": "./dist/cjs/vite/index.d.ts",
         "default": "./dist/cjs/vite/index.js"
       }
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build:webpack4": "cd ./tests/webpack4 && npm install && pnpm run build",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -25,7 +25,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../shared/vite.config.exports.ts",
+    "build": "rimraf dist && vite build --config ../../vite.library.exports.config.ts",
     "bench": "pnpm run build && tachometer ./benchmarks/parser/tern/import-html-entry.html ./benchmarks/parser/tern/parser.html --timeout=1",
     "test": "vitest --run"
   },

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -10,9 +10,22 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../../vite.library.config.ts && tsc -p tsconfig.build.json && node ../../scripts/copy-declarations.mjs src dist/esm && node ../../scripts/copy-declarations.mjs dist/esm dist/cjs",
+    "build": "rimraf dist && vite build --config ../shared/vite.config.exports.ts",
     "bench": "pnpm run build && tachometer ./benchmarks/parser/tern/import-html-entry.html ./benchmarks/parser/tern/parser.html --timeout=1",
     "test": "vitest --run"
   },

--- a/packages/qiankun/package.json
+++ b/packages/qiankun/package.json
@@ -28,7 +28,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../shared/vite.config.exports.ts",
+    "build": "rimraf dist && vite build --config ../../vite.library.exports.config.ts",
     "test": "vitest run"
   },
   "repository": {

--- a/packages/qiankun/package.json
+++ b/packages/qiankun/package.json
@@ -13,9 +13,22 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../../vite.library.config.ts && tsc -p tsconfig.build.json && node ../../scripts/copy-declarations.mjs src dist/esm && node ../../scripts/copy-declarations.mjs dist/esm dist/cjs",
+    "build": "rimraf dist && vite build --config ../shared/vite.config.exports.ts",
     "test": "vitest run"
   },
   "repository": {

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -25,7 +25,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../shared/vite.config.exports.ts",
+    "build": "rimraf dist && vite build --config ../../vite.library.exports.config.ts",
     "test": "vitest --run"
   },
   "files": [

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -10,9 +10,22 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../../vite.library.config.ts && tsc -p tsconfig.build.json && node ../../scripts/copy-declarations.mjs src dist/esm && node ../../scripts/copy-declarations.mjs dist/esm dist/cjs",
+    "build": "rimraf dist && vite build --config ../shared/vite.config.exports.ts",
     "test": "vitest --run"
   },
   "files": [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,9 +10,22 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../../vite.library.config.ts && tsc -p tsconfig.build.json && node ../../scripts/copy-declarations.mjs src dist/esm && node ../../scripts/copy-declarations.mjs dist/esm dist/cjs",
+    "build": "rimraf dist && vite build --config vite.config.exports.ts",
     "test": "vitest --run"
   },
   "author": "Kuitos",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -25,7 +25,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config vite.config.exports.ts",
+    "build": "rimraf dist && vite build --config ../../vite.library.exports.config.ts",
     "test": "vitest --run"
   },
   "author": "Kuitos",

--- a/packages/shared/vite.config.exports.ts
+++ b/packages/shared/vite.config.exports.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig, type Plugin } from 'vite';
+import libraryConfig from '../../vite.library.config';
+
+const copyDeclarationsScript = fileURLToPath(new URL('../../scripts/copy-declarations.mjs', import.meta.url));
+
+function finalizePackage(packageRoot: string): void {
+  const commandOptions = { cwd: packageRoot, stdio: 'inherit' } as const;
+  execFileSync('tsc', ['-p', 'tsconfig.build.json'], commandOptions);
+  execFileSync(process.execPath, [copyDeclarationsScript, 'src', 'dist/esm'], commandOptions);
+  execFileSync(process.execPath, [copyDeclarationsScript, 'dist/esm', 'dist/cjs'], commandOptions);
+
+  const esmDirectory = join(packageRoot, 'dist/esm');
+  const cjsDirectory = join(packageRoot, 'dist/cjs');
+  writeFileSync(join(esmDirectory, 'package.json'), `${JSON.stringify({ type: 'module' }, null, 2)}\n`);
+  writeFileSync(join(cjsDirectory, 'package.json'), `${JSON.stringify({ type: 'commonjs' }, null, 2)}\n`);
+
+  // Node16/NodeNext require explicit extensions in the ESM declaration scope. Keep the CJS
+  // declarations as emitted, and normalize ESM references only after copying ambient declarations.
+  const declarationFiles = readdirSync(esmDirectory, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.d.ts'))
+    .map((entry) => join(entry.parentPath, entry.name));
+
+  for (const file of declarationFiles) {
+    const source = readFileSync(file, 'utf8');
+    const rewritten = source.replace(
+      /(from\s+|import\s*\(\s*|import\s+)(['"])(\.\.?\/[^'"]+)\2/g,
+      (match: string, prefix: string, quote: string, specifier: string) => {
+        if (/\.[cm]?js$/.test(specifier)) return match;
+        const base = resolve(dirname(file), specifier);
+        if (existsSync(`${base}.d.ts`)) return `${prefix}${quote}${specifier}.js${quote}`;
+        if (existsSync(join(base, 'index.d.ts'))) return `${prefix}${quote}${specifier}/index.js${quote}`;
+        return match;
+      },
+    );
+    if (rewritten !== source) writeFileSync(file, rewritten);
+  }
+}
+
+export default defineConfig((environment) => {
+  const config = libraryConfig(environment);
+  const packageRoot = process.cwd();
+  let finalized = false;
+  let buildFailed = false;
+  const declarationPlugin: Plugin = {
+    name: 'qiankun-package-declarations',
+    apply: 'build',
+    buildStart() {
+      finalized = false;
+      buildFailed = false;
+    },
+    buildEnd(error) {
+      if (error) buildFailed = true;
+    },
+    renderError() {
+      buildFailed = true;
+    },
+    closeBundle() {
+      // closeBundle runs after both output formats are written. Guard repeated cleanup calls so
+      // declarations are generated and normalized once for the completed library build.
+      if (buildFailed || finalized) return;
+      finalized = true;
+      finalizePackage(packageRoot);
+    },
+  };
+
+  return {
+    ...config,
+    plugins: [...(config.plugins ?? []), declarationPlugin],
+  };
+});

--- a/packages/single-spa/package.json
+++ b/packages/single-spa/package.json
@@ -25,7 +25,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../shared/vite.config.exports.ts",
+    "build": "rimraf dist && vite build --config ../../vite.library.exports.config.ts",
     "test": "vitest --run"
   },
   "author": "Kuitos",

--- a/packages/single-spa/package.json
+++ b/packages/single-spa/package.json
@@ -10,9 +10,22 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../../vite.library.config.ts && tsc -p tsconfig.build.json && node ../../scripts/copy-declarations.mjs src dist/esm && node ../../scripts/copy-declarations.mjs dist/esm dist/cjs",
+    "build": "rimraf dist && vite build --config ../shared/vite.config.exports.ts",
     "test": "vitest --run"
   },
   "author": "Kuitos",

--- a/packages/ui-bindings/react/package.json
+++ b/packages/ui-bindings/react/package.json
@@ -5,9 +5,22 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../../../vite.library.config.ts && tsc -p tsconfig.build.json && node ../../../scripts/copy-declarations.mjs src dist/esm && node ../../../scripts/copy-declarations.mjs dist/esm dist/cjs",
+    "build": "rimraf dist && vite build --config ../../shared/vite.config.exports.ts",
     "dev": "vite build --watch --config ../../../vite.library.config.ts",
     "test": "vitest --run"
   },

--- a/packages/ui-bindings/react/package.json
+++ b/packages/ui-bindings/react/package.json
@@ -20,7 +20,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../../shared/vite.config.exports.ts",
+    "build": "rimraf dist && vite build --config ../../../vite.library.exports.config.ts",
     "dev": "vite build --watch --config ../../../vite.library.config.ts",
     "test": "vitest --run"
   },

--- a/packages/ui-bindings/shared/package.json
+++ b/packages/ui-bindings/shared/package.json
@@ -5,9 +5,22 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../../../vite.library.config.ts && tsc -p tsconfig.build.json && node ../../../scripts/copy-declarations.mjs src dist/esm && node ../../../scripts/copy-declarations.mjs dist/esm dist/cjs",
+    "build": "rimraf dist && vite build --config ../../shared/vite.config.exports.ts",
     "dev": "vite build --watch --config ../../../vite.library.config.ts",
     "test": "vitest --run"
   },

--- a/packages/ui-bindings/shared/package.json
+++ b/packages/ui-bindings/shared/package.json
@@ -20,7 +20,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../../shared/vite.config.exports.ts",
+    "build": "rimraf dist && vite build --config ../../../vite.library.exports.config.ts",
     "dev": "vite build --watch --config ../../../vite.library.config.ts",
     "test": "vitest --run"
   },

--- a/packages/ui-bindings/vue/package.json
+++ b/packages/ui-bindings/vue/package.json
@@ -5,9 +5,22 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../../../vite.library.config.ts && tsc -p tsconfig.build.json && node ../../../scripts/copy-declarations.mjs src dist/esm && node ../../../scripts/copy-declarations.mjs dist/esm dist/cjs",
+    "build": "rimraf dist && vite build --config ../../shared/vite.config.exports.ts",
     "dev": "vite build --watch --config ../../../vite.library.config.ts",
     "test": "vitest --run"
   },

--- a/packages/ui-bindings/vue/package.json
+++ b/packages/ui-bindings/vue/package.json
@@ -20,7 +20,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && vite build --config ../../shared/vite.config.exports.ts",
+    "build": "rimraf dist && vite build --config ../../../vite.library.exports.config.ts",
     "dev": "vite build --watch --config ../../../vite.library.config.ts",
     "test": "vitest --run"
   },

--- a/vite.library.exports.config.ts
+++ b/vite.library.exports.config.ts
@@ -3,9 +3,9 @@ import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig, type Plugin } from 'vite';
-import libraryConfig from '../../vite.library.config';
+import libraryConfig from './vite.library.config';
 
-const copyDeclarationsScript = fileURLToPath(new URL('../../scripts/copy-declarations.mjs', import.meta.url));
+const copyDeclarationsScript = fileURLToPath(new URL('./scripts/copy-declarations.mjs', import.meta.url));
 
 function finalizePackage(packageRoot: string): void {
   const commandOptions = { cwd: packageRoot, stdio: 'inherit' } as const;


### PR DESCRIPTION
为 8 个发布包新增根入口 exports，按 import/require 分别声明 types 和 JavaScript 路径；为全部 9 个包开放 package.json 子路径，保留 bundler-plugin 的 webpack/vite 子路径和各包原有 main/module/types。

新增根目录构建配置 `vite.library.exports.config.ts`，在声明生成后标记 dist/esm 与 dist/cjs 的模块类型，并补齐 ESM 声明中的相对引用扩展名，使 exports 的类型与实际产物一致。它与 `vite.library.config.ts` 并列并复用基础配置，各包直接引用根目录路径；配置使用显式文件名，避免被 Vitest 自动拾取。没有修改 src 运行时逻辑、版本号或 peerDependencies。

验证：完整 `pnpm run build`、全部包测试（614 项通过、3 项原有跳过）、ESLint、Prettier 均通过；9 个包的 `pnpm pack --dry-run` 均包含 README、dist、LICENSE；构建 e2e 夹具后，Chromium `lifecycle.spec.ts` 5/5 通过。逐包执行 `npx --yes @arethetypeswrong/cli --pack <pkg dir>`，全部没有 FalseCJS/FalseESM，8 个新增 exports 的包无诊断。

配置移到根目录后，重新运行 `pnpm run build:packages && pnpm run eslint && pnpm run prettier:check`，全部通过。

已知限制：bundler-plugin 原有 webpack/vite 子路径在旧 node10 解析模式下仍报 NoResolution（变更前基线相同）；node16 import/require 与 bundler 模式均通过。此 PR 依赖下层发布元数据 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
