### PR TITLE
docs: document CSP requirements for qiankun 3

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -30,6 +30,7 @@ const enSidebar = {
         { text: 'What is qiankun?', link: '/guide/what-is-qiankun' },
         { text: 'Get started in 5 minutes', link: '/guide/getting-started' },
         { text: 'Browser support', link: '/guide/browser-support' },
+        { text: 'Content Security Policy (CSP)', link: '/guide/csp-requirements' },
       ],
     },
     {
@@ -179,6 +180,7 @@ const zhSidebar = {
         { text: '什么是 qiankun', link: '/zh-CN/guide/what-is-qiankun' },
         { text: '快速上手', link: '/zh-CN/guide/getting-started' },
         { text: '浏览器支持', link: '/zh-CN/guide/browser-support' },
+        { text: '内容安全策略（CSP）', link: '/zh-CN/guide/csp-requirements' },
       ],
     },
     {

--- a/docs/cookbook/standalone-sandbox.md
+++ b/docs/cookbook/standalone-sandbox.md
@@ -284,21 +284,7 @@ This model is not suitable for hostile code. It does not harden objects, freeze 
 
 ## Content Security Policy
 
-The classic evaluator and ESM engine avoid `eval` and `new Function`, so they do not require `'unsafe-eval'`. They execute generated code through blob URLs instead.
-
-At minimum, the relevant CSP directives must account for:
-
-- `blob:` in `script-src` for classic and ESM execution;
-- permission for the inline `script[type="importmap"]` injected by the ESM engine;
-- the remote origins in `connect-src`, because external scripts and modules are fetched;
-- `blob:` in `style-src` when style isolation converts external stylesheets;
-- the page's nonce, hash, or inline-style policy for dynamically created `<style>` elements.
-
-```http
-Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline' blob:; connect-src 'self' https://widgets.example
-```
-
-This illustrative policy permits the runtime import map and widget-created inline styles. The exact policy depends on the execution path and widget, and cross-origin fetches must also satisfy CORS. Adding `'unsafe-eval'` does not fix a missing blob, inline-script, or network-source permission and is not required by this package.
+The Classic script evaluator and ESM engine do not rely on `eval` or `new Function`, so the framework itself does not require `'unsafe-eval'`. Blob URLs, inline import maps, styles, and cross-origin fetches have separate CSP requirements. See [Content Security Policy (CSP)](/guide/csp-requirements) for policy examples and the current nonce limitations.
 
 ## Production checklist
 

--- a/docs/guide/csp-requirements.md
+++ b/docs/guide/csp-requirements.md
@@ -1,0 +1,85 @@
+# Content Security Policy (CSP)
+
+qiankun 3's script evaluators do not rely on `eval` or `new Function`, so the framework itself does not require `'unsafe-eval'`. After sandbox transformation, however, scripts and styles may reach the browser through Blob URLs or inline elements. The host application's Content Security Policy (CSP) must allow these resources.
+
+This page covers the default sandbox and standalone use of `@qiankunjs/sandbox`. Micro-apps share the host document, so configure the policy on the **host HTML response**. Changing only the micro-app resource server's CSP does not replace host configuration. For browser compatibility, see [Browser support](/guide/browser-support).
+
+## Minimal policy examples
+
+The following response header assumes that **the host, micro-apps, and their resources share the same origin**, and that the application uses ESM, inline scripts, and style isolation:
+
+```http
+Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'unsafe-inline'; style-src 'self' blob: 'unsafe-inline'; connect-src 'self'
+```
+
+This is a minimal example for those execution paths. `'unsafe-inline'` permits all inline content of the corresponding type; narrow it according to the paths described below. Configure images, fonts, APIs, and other origins according to your application.
+
+For cross-origin deployments, add the actual origins of micro-app entries, scripts, modules, isolated stylesheets, and APIs to `connect-src`, for example:
+
+```http
+Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'unsafe-inline'; style-src 'self' blob: 'unsafe-inline'; connect-src 'self' https://micro-app.example.com https://api.example.com
+```
+
+Replace the example domains with your own. Cross-origin fetches must also satisfy CORS; CSP permission does not replace the server's CORS response headers. Origins of untransformed external scripts or stylesheets loaded directly by the browser must also appear in `script-src` or `style-src`, respectively.
+
+## What each permission allows
+
+| Policy | When it is needed | Reason |
+| --- | --- | --- |
+| `default-src 'self'` | Default origin restriction in these examples | Resource types without a specific directive fall back to the same-origin policy |
+| `script-src 'self'` | Loading the host's own external scripts | The browser loads the host code directly |
+| `script-src blob:` | Sandboxed external Classic scripts, ESM, or `evaluateScript()` | Transformed scripts, modules, and runtime helper modules execute through Blob URLs |
+| `script-src 'unsafe-inline'` | The current ESM engine, or inline Classic scripts without nonce or equivalent authorization | The ESM engine injects inline import maps; inline Classic scripts in HTML remain inline after rewriting |
+| `style-src 'self'` | Loading same-origin external stylesheets | Without style isolation, the browser still loads external stylesheets directly |
+| `style-src blob:` | External stylesheets with `styleIsolation` enabled, or shared stylesheet dependency reuse | Isolated styles load through Blob URLs after fetching and rewriting, including `@scope`; dependency reuse also generates Blob stylesheet placeholders |
+| `style-src 'unsafe-inline'` | Inline styles without nonce or equivalent authorization | Existing or dynamically created style elements remain inline after `@scope` rewriting |
+| `connect-src` | Fetching micro-app HTML, external scripts, modules, isolated stylesheets, and their `@import` resources | These resources are fetched before processing; host and micro-app API requests are also subject to this directive |
+
+Images, fonts, and other resources requested directly by the browser remain subject to directives such as `img-src` and `font-src`. Converting CSS to a Blob URL does not automatically allow them.
+
+If your policy sets `script-src-elem` or `style-src-elem` separately, check that those directives allow the corresponding elements too. Changing only `script-src` or `style-src` may have no effect. See the [CSP specification](https://www.w3.org/TR/CSP3/#directive-script-src-elem) for fallback rules.
+
+### Classic scripts only
+
+External Classic scripts and the standalone sandbox's `evaluateScript()` execute through Blob URLs. If neither the host nor the micro-apps contain scripts, event-handler attributes, or other content requiring inline authorization, and you do not use ESM, you can remove `'unsafe-inline'` from `script-src`:
+
+```http
+Content-Security-Policy: default-src 'self'; script-src 'self' blob:; style-src 'self' blob: 'unsafe-inline'; connect-src 'self'
+```
+
+This example still assumes same-origin resources. It retains permissions for style isolation and inline styles; narrow `style-src` further when those styles are absent. Do not apply it unchanged to an HTML entry containing inline Classic scripts: those scripts are rewritten in place, not automatically converted to Blob URLs.
+
+### ESM
+
+Ordinary JavaScript modules and helper modules execute through Blob URLs, but their module mappings come from dynamically created `<script type="importmap">` elements. These elements have no `src` and contain runtime-generated JSON, so they are subject to inline script checks. See the [HTML script preparation steps](https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element).
+
+Typed module imports such as JSON, CSS, and WASM retain their original URLs and use native browser loading. Cross-origin use also requires those origins to be allowed by the resource directives the browser applies.
+
+With the source allowlist policies used on this page, allowing only `blob:` is therefore insufficient for ESM: `'unsafe-inline'` is also needed. `'unsafe-eval'` cannot replace that permission.
+
+## Can I use a nonce?
+
+Browsers can authorize individual inline script or style elements with a matching nonce. However, qiankun currently has **no unified CSP nonce option**. Internally generated import maps do not inherit the nonce from a host script or micro-app entry, so adding a nonce to the entry alone does not let you remove `'unsafe-inline'` from this page's ESM examples.
+
+Complete nonce propagation is **planned for a later 3.x release**; no configuration is available yet. Projects requiring a nonce policy throughout should account for this limitation when evaluating integration. This page does not provide examples for an unimplemented nonce API.
+
+Runtime import maps also contain instance identifiers and newly created Blob URLs, so a fixed build-time hash cannot cover them. Inline Classic scripts and isolated styles are rewritten too; hashes of their original contents cannot directly authorize the transformed elements.
+
+Adding a nonce or hash to the same source list makes browsers ignore `'unsafe-inline'` in that list; combining them does not provide a fallback. See the [CSP inline matching rules](https://www.w3.org/TR/CSP3/#match-element-to-source-list).
+
+## Verification
+
+1. Use production builds and configure the policy on the host HTML response.
+2. In your target browsers, exercise initial loading, dynamic resources, remounting after unmount, and the ESM and style isolation paths your application uses.
+3. Inspect CSP console reports to distinguish blocked Blob scripts, inline import maps, inline scripts or styles, and fetch destinations.
+
+The repository's [Classic CSP tests](https://github.com/umijs/qiankun/blob/next/e2e/tests/sandbox-js.spec.ts), [ESM CSP tests](https://github.com/umijs/qiankun/blob/next/e2e/tests/esm-sandbox.spec.ts), and [standalone sandbox test](https://github.com/umijs/qiankun/blob/next/e2e/tests/standalone-sandbox.spec.ts) cover policies without `'unsafe-eval'`. These tests still allow Blob URLs and inline content; they do not establish support for nonce policies.
+
+Application code, third-party dependencies, or development tools that call `eval` / `new Function` can still trigger CSP violations. qiankun's independence from those calls does not mean your micro-apps are free of them.
+
+## Further reading
+
+- [Browser support](/guide/browser-support)
+- [Native ESM support](/concepts/esm-sandbox)
+- [Style isolation](/concepts/style-isolation)
+- [Using the sandbox without qiankun](/cookbook/standalone-sandbox)

--- a/docs/zh-CN/cookbook/standalone-sandbox.md
+++ b/docs/zh-CN/cookbook/standalone-sandbox.md
@@ -284,19 +284,7 @@ await sandbox.evaluateScript(`
 
 ## Content Security Policy
 
-Classic 脚本求值器和 ESM 引擎都不会调用 `eval` 或 `new Function`，因此无需在 CSP 中加入 `'unsafe-eval'`。生成后的代码通过 Blob URL 执行，需要为相关指令放行实际使用的资源：
-
-- `script-src` 需要允许 `blob:`；
-- ESM 引擎会动态插入内联的 `script[type="importmap"]`，脚本策略也要允许这类节点；
-- 远程脚本和模块会先通过 fetch 获取，相应源需要出现在 `connect-src` 中；
-- 外链样式经过隔离转换后可能使用 Blob URL，此时 `style-src` 也要允许 `blob:`；
-- 动态创建的 `<style>` 仍受页面现有的 nonce、hash 或内联样式策略约束。
-
-```http
-Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline' blob:; connect-src 'self' https://widgets.example
-```
-
-上面的示例同时放行了运行时 import map 和组件创建的内联样式。实际策略应根据所用执行路径和资源继续收紧，跨源 fetch 还必须满足 CORS。缺少 Blob、内联脚本或网络源权限时，添加 `'unsafe-eval'` 无法解决问题，也不是这个包的运行要求。
+Classic 脚本求值器和 ESM 引擎不依赖 `eval` 或 `new Function`，无需为框架本身放行 `'unsafe-eval'`。Blob URL、内联 import map、样式和跨源 fetch 各有对应的 CSP 要求，策略示例与当前 nonce 限制见[内容安全策略（CSP）](/zh-CN/guide/csp-requirements)。
 
 ## 上线前检查
 

--- a/docs/zh-CN/guide/csp-requirements.md
+++ b/docs/zh-CN/guide/csp-requirements.md
@@ -1,0 +1,85 @@
+# 内容安全策略（CSP）
+
+qiankun 3 的脚本执行器不依赖 `eval` 或 `new Function`，无需为框架本身放行 `'unsafe-eval'`。但脚本和样式经过沙箱转换后，可能通过 Blob URL 或内联节点交给浏览器，主应用的内容安全策略（CSP）需要允许这些资源。
+
+本页适用于默认沙箱及独立使用的 `@qiankunjs/sandbox`。微应用与主应用共用文档，策略应配置在**主应用 HTML 响应**上；只调整微应用资源服务器的 CSP 不能代替主应用配置。浏览器兼容性见[浏览器支持](/zh-CN/guide/browser-support)。
+
+## 最小策略示例
+
+以下响应头适用于**主应用、微应用及其资源均同源**，且使用 ESM、内联脚本和样式隔离的场景：
+
+```http
+Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'unsafe-inline'; style-src 'self' blob: 'unsafe-inline'; connect-src 'self'
+```
+
+这是满足上述运行方式的最小示例。`'unsafe-inline'` 会放行对应类别的所有内联内容，应按下文的执行路径收紧。业务用到的图片、字体、接口和其他来源仍需按实际情况配置。
+
+跨源部署时，在 `connect-src` 中加入微应用入口、脚本、模块、隔离样式及接口的实际来源，例如：
+
+```http
+Content-Security-Policy: default-src 'self'; script-src 'self' blob: 'unsafe-inline'; style-src 'self' blob: 'unsafe-inline'; connect-src 'self' https://micro-app.example.com https://api.example.com
+```
+
+将示例域名替换为实际地址。跨源 fetch 还必须满足 CORS；CSP 放行不会代替服务器的 CORS 响应头。未经过转换、由浏览器直接加载的外链脚本或样式，其来源还需分别加入 `script-src` 或 `style-src`。
+
+## 各项权限的用途
+
+| 策略 | 何时需要 | 原因 |
+| --- | --- | --- |
+| `default-src 'self'` | 示例的默认来源约束 | 未单独配置的资源类型回退到同源策略 |
+| `script-src 'self'` | 加载主应用自身的外链脚本 | 主应用代码由浏览器直接加载 |
+| `script-src blob:` | 沙箱执行外链 Classic 脚本、ESM，或调用 `evaluateScript()` | 转换后的脚本、模块和运行时辅助模块通过 Blob URL 执行 |
+| `script-src 'unsafe-inline'` | 使用当前 ESM 引擎，或存在未通过 nonce 等方式授权的内联 Classic 脚本 | ESM 引擎动态插入内联 import map；HTML 中的内联 Classic 脚本重写后仍是内联脚本 |
+| `style-src 'self'` | 加载同源外链样式 | 未启用样式隔离时，外链样式仍由浏览器直接加载 |
+| `style-src blob:` | 对外链样式启用 `styleIsolation`，或复用共享样式依赖 | 隔离样式在 fetch 和 `@scope` 等重写后通过 Blob URL 加载；依赖复用也会生成 Blob 样式占位资源 |
+| `style-src 'unsafe-inline'` | 使用未通过 nonce 等方式授权的内联样式 | 原有或动态创建的 style 节点经过 `@scope` 重写后仍是内联节点 |
+| `connect-src` | 获取微应用 HTML、外链脚本、模块、隔离样式及其 `@import` 资源 | 这些资源先通过 fetch 获取；主应用和微应用的业务请求也受此指令约束 |
+
+图片、字体等由浏览器直接请求的资源仍受 `img-src`、`font-src` 等指令约束，不会因为 CSS 已经转成 Blob URL 而自动放行。
+
+若现有策略单独设置了 `script-src-elem` 或 `style-src-elem`，还需检查这些指令是否允许对应节点；只修改 `script-src` 或 `style-src` 可能不会生效。具体回退规则见 [CSP 规范](https://www.w3.org/TR/CSP3/#directive-script-src-elem)。
+
+### 只使用 Classic 脚本
+
+外链 Classic 脚本和独立沙箱的 `evaluateScript()` 都通过 Blob URL 执行。若主应用和微应用均没有需要内联授权的脚本、事件处理属性等内容，也不使用 ESM，可以去掉 `script-src` 中的 `'unsafe-inline'`：
+
+```http
+Content-Security-Policy: default-src 'self'; script-src 'self' blob:; style-src 'self' blob: 'unsafe-inline'; connect-src 'self'
+```
+
+此示例仍假设资源同源。它保留了样式隔离和内联样式所需的权限；没有这些样式时，可以继续收紧 `style-src`。不要将它直接用于包含内联 Classic 脚本的 HTML 入口：这类脚本只会被重写，不会自动转成 Blob URL。
+
+### 使用 ESM
+
+普通 JavaScript 模块及辅助模块通过 Blob URL 执行，但模块映射由动态创建的 `<script type="importmap">` 提供。该节点没有 `src`，内容是运行时生成的 JSON，仍受内联脚本检查。规则见 [HTML 规范中的脚本准备步骤](https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element)。
+
+JSON、CSS、WASM 等带类型的模块导入会保留原始 URL，交由浏览器原生加载；跨源使用时，还需按浏览器实际采用的资源指令放行对应来源。
+
+因此，在本页采用的来源白名单策略下，仅放行 `blob:` 不足以运行 ESM，还需要 `'unsafe-inline'`。`'unsafe-eval'` 不能代替这项权限。
+
+## 能否使用 nonce
+
+浏览器支持通过匹配的 nonce 授权单个内联 script 或 style 节点。但当前 qiankun **没有统一的 CSP nonce 配置**，内部生成的 import map 不会自动继承主应用脚本或微应用入口上的 nonce，因此不能仅通过给入口添加 nonce，就把本页 ESM 示例中的 `'unsafe-inline'` 删除。
+
+完整的 nonce 传递能力属于 **3.x 后续计划**，尚未提供可用配置。需要全程使用 nonce 策略的项目，应将这一限制纳入接入评估；本页不提供尚未实现的 nonce API 示例。
+
+另外，运行时 import map 包含实例标识和新建的 Blob URL，无法用一份构建期固定 hash 覆盖。内联 Classic 脚本和隔离样式的内容也会被重写，原始内容的 hash 不能直接用于授权转换后的节点。
+
+同一来源列表中加入 nonce 或 hash 后，浏览器会忽略其中的 `'unsafe-inline'`，不能靠同时添加两者作为兜底。参见 [CSP 的内联匹配规则](https://www.w3.org/TR/CSP3/#match-element-to-source-list)。
+
+## 如何验证
+
+1. 使用生产构建产物，在主应用 HTML 响应上配置策略。
+2. 在目标浏览器中分别验证首次加载、动态资源加载、卸载后重新挂载，以及实际使用的 ESM 和样式隔离路径。
+3. 查看控制台的 CSP 违规信息，区分被阻止的是 Blob 脚本、内联 import map、内联脚本或样式，还是 fetch 的目标来源。
+
+仓库中的 [Classic CSP 用例](https://github.com/umijs/qiankun/blob/next/e2e/tests/sandbox-js.spec.ts)、[ESM CSP 用例](https://github.com/umijs/qiankun/blob/next/e2e/tests/esm-sandbox.spec.ts)和[独立沙箱用例](https://github.com/umijs/qiankun/blob/next/e2e/tests/standalone-sandbox.spec.ts)覆盖了不含 `'unsafe-eval'` 的策略。这些用例仍放行 Blob 和内联内容，不能作为 nonce 策略已经受支持的依据。
+
+如果业务代码、第三方依赖或开发工具自身调用 `eval` / `new Function`，它们仍可能触发 CSP 拦截；qiankun 不依赖这些调用，不代表微应用也没有这类调用。
+
+## 继续阅读
+
+- [浏览器支持](/zh-CN/guide/browser-support)
+- [原生 ESM 支持](/zh-CN/concepts/esm-sandbox)
+- [样式隔离](/zh-CN/concepts/style-isolation)
+- [不依赖 qiankun，独立使用沙箱](/zh-CN/cookbook/standalone-sandbox)


### PR DESCRIPTION
## 做了什么

新增中英文「内容安全策略（CSP）」指南，中文先写、英文对齐，并加入导航；独立沙箱页面改为链接到统一说明。

## 为什么

说明 qiankun 3 的实际 CSP 要求：执行链路不依赖 unsafe-eval，但 Blob 脚本、内联 Classic 脚本、动态 import map、隔离样式与 fetch 来源仍各受对应指令限制。给出同源、跨源与 Classic-only 策略示例，明确当前没有统一的 nonce 配置、完整 nonce 传递属于后续 3.x 计划。页面放在 guide，便于在接入前与浏览器要求一起评估。

已逐条核对运行时源码、现有 CSP 用例与 HTML/CSP 规范；原始内联 Classic 脚本仍为内联节点，不能笼统称所有 Classic 脚本都经 Blob 执行。可作为 #3129 相关说明，本文范围为 v3。

## 如何验证

- `pnpm run docs:build`：通过。
- `pnpm run eslint && pnpm run prettier:check`：通过。首次 eslint 因新 worktree 缺少声明构建报类型解析错误；`pnpm run build:packages` 后通过。
- `pnpm exec prettier --ignore-path /dev/null --check docs/zh-CN/guide/csp-requirements.md docs/guide/csp-requirements.md`：通过；根目录格式检查默认忽略 docs。
- `pnpm --filter @qiankunjs/shared run test`：194 个测试通过。
- `pnpm --filter @qiankunjs/sandbox run test`：72 个测试通过。
- `pnpm --filter @qiankunjs/e2e run build:fixtures`：通过。
- `pnpm --filter @qiankunjs/e2e exec playwright test tests/sandbox-js.spec.ts tests/esm-sandbox.spec.ts tests/standalone-sandbox.spec.ts --project=chromium --grep unsafe-eval`：3 个用例通过。这些用例放行 inline/Blob，不代表 nonce 策略已受支持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
