### PR TITLE
docs: mark implemented RFCs as accepted

### DIFF
--- a/docs/rfcs/container-occupancy-gate.md
+++ b/docs/rfcs/container-occupancy-gate.md
@@ -1,10 +1,10 @@
 # RFC: Container Occupancy Gate — Serialize DOM Writes for Micro Apps Sharing One Container
 
-- **Status**: Draft(已实现,见本分支:两段临界区 + FIFO 闸门 + 失败兜底,附闸门单测与 loadApp 集成单测)
+- **Status**: Accepted
 - **Author**: qiankun maintainers
 - **Created**: 2026-07-25
 - **Target Release**: qiankun v3.x
-- **Tracking Issue**: #3139
+- **Tracking Issue**: [#3139](https://github.com/umijs/qiankun/issues/3139) · [PR #3169](https://github.com/umijs/qiankun/pull/3169)
 - **Last Revision**: 2026-07-28(review 修订:①段释放信号覆盖 post-stream 求值、①→② 采纳、initializedContainers 归属令牌、兜底先 teardown、update/指示器纳入守护、预热按需触发,并新增 §已知限制)
 
 ## 背景

--- a/docs/rfcs/esm-sandbox.md
+++ b/docs/rfcs/esm-sandbox.md
@@ -1,10 +1,10 @@
 # RFC: ESM Sandbox for qiankun
 
-- **Status**: Draft（v1 已实现，见 `rfc/esm-sandbox` 分支）
+- **Status**: Accepted
 - **Author**: qiankun maintainers
 - **Created**: 2026-04-18
 - **Target Release**: qiankun v3.x
-- **Tracking Issue**: TBD
+- **Tracking Issue**: [PR #3133](https://github.com/umijs/qiankun/pull/3133)
 - **Last Revision**: 2026-07-18（随 Compartment Alignment RFC 更新当前接口：ESM 机制收进 `Compartment` 的 module hooks / descriptor 门面；`extraGlobals` 接入应用配置；内部 realm registry 更名为 instance registry；lexer 切至 CSP-safe 的 `es-module-lexer/js` 入口；document credentials 通过上下文专属 runtime bridge 贯穿普通动态 import 图；synthetic key 加入跨 qiankun 副本随机 nonce；dispose 的全部异步边界改为 fail-closed；预编译 `ModuleSource` 只按结构化 import span 重定位。下文保留 v1 设计过程中的 realm 术语，用于解释当时的安全模型。）
 - **Previous Implementation Revision**: 2026-07-04（第三轮修订，随 v1 实现 + code review 落地：realm 访问器改为**每副本随机 key + 不可猜 token** 索引（堵死裸标识符/proxy/`with` 三条越权路径，并顺带解决多 qiankun 副本抢占单例崩溃）；`dispose` 覆盖全部 blob（含 inline/rebuilt）并接入 single-spa `unload`；入口选取改为"显式 entry 优先 → 生命周期 namespace → 最后执行"且非入口模块失败不炸整个 app、支持 `export default` 生命周期；typed import（JSON/CSS）走 §14 passthrough 而非硬崩；probe 去掉 120 字窗口改为"解构集非空 ∧ 含声明关键字"不漏检；动态 import 用 lexer `imp.d` 定位括号并整体覆盖 `[ss,se)` 修正注释击穿/尾逗号；fetch 透传 `crossorigin` credentials；import-bindings/importmap 解析加注释剥离与幂等；membrane 复用 `esmInternalPrefix` 且不拷贝 `__qk_*` 到 target）
 - **Second Revision**: 2026-07-04（注入引导改为 runtime 模块 import（消除 CSP `unsafe-eval` 依赖与 TDZ）、解构白名单按需过滤（标识符扫描 ∩ 基集）、顶层重名 SyntaxError 防护、共享依赖收缩为 source 级、既有 sourceMappingURL 偏移合并）

--- a/docs/rfcs/insertion-point-ownership.md
+++ b/docs/rfcs/insertion-point-ownership.md
@@ -1,10 +1,10 @@
 # RFC: Insertion-Point Ownership for Dynamic DOM Attribution
 
-- **Status**: Draft(已实现,见本分支:标记拆分 → 归属收敛 + 创建者机制退役 + CSSOM 位置解析,附归属契约单测)
+- **Status**: Accepted
 - **Author**: qiankun maintainers
 - **Created**: 2026-07-25
 - **Target Release**: qiankun v3.x
-- **Tracking Issue**: TBD
+- **Tracking Issue**: [PR #3165](https://github.com/umijs/qiankun/pull/3165)
 - **Last Revision**: 2026-07-25(实现与验证完成:全仓单测、Chromium e2e、eslint/prettier、本地性能基准全部通过;嵌套沙箱补齐真实 e2e harness(`fixtures/sub-nested`,qiankun 套 qiankun),核心判别用例经变异测试确认可区分新旧归属语义。review 收尾:Q1 定案为无条件 warn、unpatch 清除挂载点 stamp、S2/D5 补缓存边界、D2 补 cloneNode 已知限制;二轮 review:效果位更名 `nativePassthroughNode` 以名实相符,盖章点从 writable-dom fork 移入 `loadEntry` 闭包,fork 不再感知 qiankun 语义)
 
 ## Summary

--- a/docs/rfcs/standalone-sandbox.md
+++ b/docs/rfcs/standalone-sandbox.md
@@ -5,7 +5,7 @@
 - **Created**: 2026-07-18
 - **Last Revision**: 2026-07-18（实现与验收完成）
 - **Target Release**: `@qiankunjs/sandbox` v3.x
-- **Tracking Issue**: TBD
+- **Tracking Issue**: [PR #3161](https://github.com/umijs/qiankun/pull/3161)
 - **Depends on**: [Compartment Alignment RFC](./compartment-alignment.md)（Accepted，本 RFC 是其延伸阶段⑤）
 
 ## Summary


### PR DESCRIPTION
## 做了什么

将 ESM Sandbox、Container Occupancy Gate、Insertion-Point Ownership 三份已落地 RFC 的状态改为 Accepted，补充对应 PR #3133、#3169、#3165 链接；保留容器占用 RFC 的 issue #3139，并补齐独立沙箱 RFC 的 PR #3161 追踪信息。

## 为什么

这些设计的实现已经合入，Draft、TBD 和「见本分支」不再反映现状。仅更新状态与追踪字段，保留设计正文和历史修订记录。

## 如何验证

- `git show --no-patch --format='%h %s' d7b0a05c 11b84425 945fa02d 8bec431c` 与各提交的 `git merge-base --is-ancestor <commit> HEAD`：确认实现提交及其 PR 编号，四个提交均在当前历史中。
- `pnpm run docs:build`：通过。
- `pnpm run eslint && pnpm run prettier:check`：通过。
- `git diff --check`：通过。未修改运行时代码，无需新增包测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
