### PR TITLE
docs: drop rc-stage markers [HOLD until 3.0.0]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Build/release:
 - **Mainland reachability is a hard constraint.** Google Fonts only via the `.cn` mirrors (`fonts.googleapis.cn`/`fonts.gstatic.cn`); never reference resources on domains unreachable from mainland China.
 - **Domains**: canonical docs domain is `https://www.qiankunjs.com` (zh under `/zh-CN/`); `qiankun.umijs.org` stays alive and 307s to it; v2 docs live at `v2.qiankun.umijs.org`; live examples at `examples.qiankunjs.com`. Old-site URLs are kept working via `docs/public/_redirects` — extend it when moving pages, never break inbound links.
 - **Consistency rules**: terminology never drifts (主应用/微应用/沙箱/隔离膜; qiankun always lowercase); link text in reference lists ("相关内容"/"继续阅读"/"延伸阅读") equals the target page's H1; API pages use 「函数签名」/「默认值为 X」; `guide/browser-support` is the single source of truth for browser requirements — link it, don't restate version numbers elsewhere.
-- Until 3.0 reaches npm `latest`, install commands must say `qiankun@rc`, and the site shows a version banner (layout-top slot in `docs/.vitepress/theme/index.js`; remove it together with `--vp-layout-top-height` once stable ships).
+- Install stable releases from the default npm `latest` dist-tag; omit the tag in install commands (for example, `npm i qiankun`).
 - **README GitHub alerts**: put the `[!WARNING]`/`[!NOTE]` marker on its own line followed by a blank `>` line. Prettier's `proseWrap: never` re-joins plain soft breaks, which silently breaks alert rendering.
 - VitePress compiles every `.md` as a Vue SFC: bare `<Tag>` in prose/link text or `{{` in inline code breaks the build (fenced code blocks are safe).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/qiankun"><img src="https://img.shields.io/npm/v/qiankun/rc.svg?style=flat-square" alt="npm version" /></a>
+  <a href="https://www.npmjs.com/package/qiankun"><img src="https://img.shields.io/npm/v/qiankun/latest.svg?style=flat-square" alt="npm version" /></a>
   <a href="https://codecov.io/gh/umijs/qiankun"><img src="https://img.shields.io/codecov/c/github/umijs/qiankun.svg?style=flat-square" alt="coverage" /></a>
   <a href="https://www.npmjs.com/package/qiankun"><img src="https://img.shields.io/npm/dm/qiankun.svg?style=flat-square" alt="npm downloads" /></a>
   <a href="https://github.com/umijs/qiankun/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/umijs/qiankun/ci.yml?branch=next&style=flat-square" alt="build status" /></a>
@@ -70,7 +70,7 @@ Qiankun inherits the fundamentals of [single-spa](https://github.com/single-spa/
 
 > [!NOTE]
 >
-> v3 ships under the `rc` tag while `latest` still points at 2.x. Install with an explicit `@rc` to get it.
+> For qiankun 2.x, see the [v2 documentation](https://v2.qiankun.umijs.org).
 
 The fastest path is the agent skill — install it, then ask your coding agent (Claude Code, Cursor, …) to scaffold a host or a micro app wired up correctly:
 
@@ -81,7 +81,7 @@ npx skills add umijs/qiankun
 Or add qiankun to an existing host application:
 
 ```shell
-npm i qiankun@rc
+npm i qiankun
 ```
 
 Load a micro app into any container element, and keep the returned handle to unmount it:
@@ -140,15 +140,15 @@ This builds the workspace packages and starts every app in parallel — open htt
 
 | Package | Version (click for changelogs) | Description |
 | --- | :-- | --- |
-| [qiankun](packages/qiankun) | [![qiankun version](https://img.shields.io/npm/v/qiankun/rc.svg?style=flat-square)](packages/qiankun/CHANGELOG.md) | The framework: `registerMicroApps`, `loadMicroApp`, `start`, `prefetch` |
-| [@qiankunjs/loader](packages/loader) | [![loader version](https://img.shields.io/npm/v/@qiankunjs/loader/rc.svg?style=flat-square)](packages/loader/CHANGELOG.md) | Streaming HTML-entry loader |
-| [@qiankunjs/sandbox](packages/sandbox) | [![sandbox version](https://img.shields.io/npm/v/@qiankunjs/sandbox/rc.svg?style=flat-square)](packages/sandbox/CHANGELOG.md) | JS sandbox — usable standalone |
-| [@qiankunjs/shared](packages/shared) | [![shared version](https://img.shields.io/npm/v/@qiankunjs/shared/rc.svg?style=flat-square)](packages/shared/CHANGELOG.md) | Asset transpilers, fetch utilities, ESM-sandbox engine |
+| [qiankun](packages/qiankun) | [![qiankun version](https://img.shields.io/npm/v/qiankun/latest.svg?style=flat-square)](packages/qiankun/CHANGELOG.md) | The framework: `registerMicroApps`, `loadMicroApp`, `start`, `prefetch` |
+| [@qiankunjs/loader](packages/loader) | [![loader version](https://img.shields.io/npm/v/@qiankunjs/loader/latest.svg?style=flat-square)](packages/loader/CHANGELOG.md) | Streaming HTML-entry loader |
+| [@qiankunjs/sandbox](packages/sandbox) | [![sandbox version](https://img.shields.io/npm/v/@qiankunjs/sandbox/latest.svg?style=flat-square)](packages/sandbox/CHANGELOG.md) | JS sandbox — usable standalone |
+| [@qiankunjs/shared](packages/shared) | [![shared version](https://img.shields.io/npm/v/@qiankunjs/shared/latest.svg?style=flat-square)](packages/shared/CHANGELOG.md) | Asset transpilers, fetch utilities, ESM-sandbox engine |
 | [@qiankunjs/single-spa](packages/single-spa) | [![single-spa version](https://img.shields.io/npm/v/@qiankunjs/single-spa/latest.svg?style=flat-square)](packages/single-spa/CHANGELOG.md) | Vendored [single-spa](https://github.com/single-spa/single-spa) fork the framework builds on |
 | [@qiankunjs/react](packages/ui-bindings/react) | [![react version](https://img.shields.io/npm/v/@qiankunjs/react/latest.svg?style=flat-square)](packages/ui-bindings/react/CHANGELOG.md) | `<MicroApp />` for React |
 | [@qiankunjs/vue](packages/ui-bindings/vue) | [![vue version](https://img.shields.io/npm/v/@qiankunjs/vue/latest.svg?style=flat-square)](packages/ui-bindings/vue/CHANGELOG.md) | `<MicroApp />` for Vue |
 | [@qiankunjs/ui-shared](packages/ui-bindings/shared) | [![ui-shared version](https://img.shields.io/npm/v/@qiankunjs/ui-shared/latest.svg?style=flat-square)](packages/ui-bindings/shared/CHANGELOG.md) | Shared internals of the UI bindings |
-| [@qiankunjs/bundler-plugin](packages/bundler-plugin) | [![bundler-plugin version](https://img.shields.io/npm/v/@qiankunjs/bundler-plugin/rc.svg?style=flat-square)](packages/bundler-plugin/CHANGELOG.md) | webpack 4/5 and Vite plugins for micro apps |
+| [@qiankunjs/bundler-plugin](packages/bundler-plugin) | [![bundler-plugin version](https://img.shields.io/npm/v/@qiankunjs/bundler-plugin/latest.svg?style=flat-square)](packages/bundler-plugin/CHANGELOG.md) | webpack 4/5 and Vite plugins for micro apps |
 
 ## 📖 Documentation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/qiankun"><img src="https://img.shields.io/npm/v/qiankun/rc.svg?style=flat-square" alt="npm version" /></a>
+  <a href="https://www.npmjs.com/package/qiankun"><img src="https://img.shields.io/npm/v/qiankun/latest.svg?style=flat-square" alt="npm version" /></a>
   <a href="https://codecov.io/gh/umijs/qiankun"><img src="https://img.shields.io/codecov/c/github/umijs/qiankun.svg?style=flat-square" alt="coverage" /></a>
   <a href="https://www.npmjs.com/package/qiankun"><img src="https://img.shields.io/npm/dm/qiankun.svg?style=flat-square" alt="npm downloads" /></a>
   <a href="https://github.com/umijs/qiankun/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/umijs/qiankun/ci.yml?branch=next&style=flat-square" alt="build status" /></a>
@@ -70,7 +70,7 @@ qiankun 继承了 [single-spa](https://github.com/single-spa/single-spa) 的基�
 
 > [!NOTE]
 >
-> v3 目前发布在 `rc` 标签上，npm 的 `latest` 仍指向 2.x。安装时需显式指定 `@rc`。
+> qiankun 2.x 用户请参阅 [v2 文档](https://v2.qiankun.umijs.org)。
 
 最快的方式是使用 agent skill——安装后，让你的 coding agent（Claude Code、Cursor 等）生成配置完整的主应用或微应用：
 
@@ -81,7 +81,7 @@ npx skills add umijs/qiankun
 也可以在现有主应用中直接安装：
 
 ```shell
-npm i qiankun@rc
+npm i qiankun
 ```
 
 把微应用加载到任意容器元素中，并保存返回的实例句柄用于卸载：
@@ -140,15 +140,15 @@ pnpm start:example
 
 | 包名 | 版本（点击查看更新日志） | 说明 |
 | --- | :-- | --- |
-| [qiankun](packages/qiankun) | [![qiankun version](https://img.shields.io/npm/v/qiankun/rc.svg?style=flat-square)](packages/qiankun/CHANGELOG.md) | 框架本体：`registerMicroApps`、`loadMicroApp`、`start`、`prefetch` |
-| [@qiankunjs/loader](packages/loader) | [![loader version](https://img.shields.io/npm/v/@qiankunjs/loader/rc.svg?style=flat-square)](packages/loader/CHANGELOG.md) | 流式 HTML 入口加载器 |
-| [@qiankunjs/sandbox](packages/sandbox) | [![sandbox version](https://img.shields.io/npm/v/@qiankunjs/sandbox/rc.svg?style=flat-square)](packages/sandbox/CHANGELOG.md) | JS 沙箱，可独立使用 |
-| [@qiankunjs/shared](packages/shared) | [![shared version](https://img.shields.io/npm/v/@qiankunjs/shared/rc.svg?style=flat-square)](packages/shared/CHANGELOG.md) | 资源转译器、fetch 工具、ESM 沙箱引擎 |
+| [qiankun](packages/qiankun) | [![qiankun version](https://img.shields.io/npm/v/qiankun/latest.svg?style=flat-square)](packages/qiankun/CHANGELOG.md) | 框架本体：`registerMicroApps`、`loadMicroApp`、`start`、`prefetch` |
+| [@qiankunjs/loader](packages/loader) | [![loader version](https://img.shields.io/npm/v/@qiankunjs/loader/latest.svg?style=flat-square)](packages/loader/CHANGELOG.md) | 流式 HTML 入口加载器 |
+| [@qiankunjs/sandbox](packages/sandbox) | [![sandbox version](https://img.shields.io/npm/v/@qiankunjs/sandbox/latest.svg?style=flat-square)](packages/sandbox/CHANGELOG.md) | JS 沙箱，可独立使用 |
+| [@qiankunjs/shared](packages/shared) | [![shared version](https://img.shields.io/npm/v/@qiankunjs/shared/latest.svg?style=flat-square)](packages/shared/CHANGELOG.md) | 资源转译器、fetch 工具、ESM 沙箱引擎 |
 | [@qiankunjs/single-spa](packages/single-spa) | [![single-spa version](https://img.shields.io/npm/v/@qiankunjs/single-spa/latest.svg?style=flat-square)](packages/single-spa/CHANGELOG.md) | 框架底座：内置维护的 [single-spa](https://github.com/single-spa/single-spa) 分支 |
 | [@qiankunjs/react](packages/ui-bindings/react) | [![react version](https://img.shields.io/npm/v/@qiankunjs/react/latest.svg?style=flat-square)](packages/ui-bindings/react/CHANGELOG.md) | React 版 `<MicroApp />` |
 | [@qiankunjs/vue](packages/ui-bindings/vue) | [![vue version](https://img.shields.io/npm/v/@qiankunjs/vue/latest.svg?style=flat-square)](packages/ui-bindings/vue/CHANGELOG.md) | Vue 版 `<MicroApp />` |
 | [@qiankunjs/ui-shared](packages/ui-bindings/shared) | [![ui-shared version](https://img.shields.io/npm/v/@qiankunjs/ui-shared/latest.svg?style=flat-square)](packages/ui-bindings/shared/CHANGELOG.md) | UI 绑定的共享内部实现 |
-| [@qiankunjs/bundler-plugin](packages/bundler-plugin) | [![bundler-plugin version](https://img.shields.io/npm/v/@qiankunjs/bundler-plugin/rc.svg?style=flat-square)](packages/bundler-plugin/CHANGELOG.md) | 微应用侧的 webpack 4/5 与 Vite 插件 |
+| [@qiankunjs/bundler-plugin](packages/bundler-plugin) | [![bundler-plugin version](https://img.shields.io/npm/v/@qiankunjs/bundler-plugin/latest.svg?style=flat-square)](packages/bundler-plugin/CHANGELOG.md) | 微应用侧的 webpack 4/5 与 Vite 插件 |
 
 ## 📖 文档
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -6,15 +6,12 @@
    ============================================================================= */
 
 :root {
-  /* Reserved by the version banner rendered in the layout-top slot; remove
-     together with the banner in theme/index.js once 3.0 is `latest`. */
-  --vp-layout-top-height: 32px;
-
   /* ---- brand fonts ---- */
   --qk-font-display: 'Space Grotesk', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
   --qk-font-ornament: 'Songti SC', 'STSong', 'Songti TC', serif;
 
-  --vp-font-family-base: 'IBM Plex Sans', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', -apple-system, sans-serif;
+  --vp-font-family-base:
+    'IBM Plex Sans', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', -apple-system, sans-serif;
   --vp-font-family-mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 
   /* ---- brand color ---- */
@@ -222,7 +219,7 @@
 
 @media (min-width: 960px) {
   .VPHero {
-    padding-top: calc(var(--vp-nav-height) + var(--vp-layout-top-height, 0px) + 88px);
+    padding-top: calc(var(--vp-nav-height) + 88px);
     padding-bottom: 72px;
   }
   .VPHero .container {
@@ -418,41 +415,4 @@
 }
 ::selection {
   background: var(--vp-c-brand-soft);
-}
-
-/* ---- version banner (layout-top slot) ---- */
-.qk-version-banner {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 60;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: var(--vp-layout-top-height, 32px);
-  padding: 0 12px;
-  background: var(--vp-c-brand-1);
-  color: #fff;
-  font-size: 12.5px;
-  line-height: 1;
-  text-align: center;
-  white-space: nowrap;
-  overflow: hidden;
-}
-
-.qk-version-banner code {
-  margin: 0 2px;
-  padding: 2px 5px;
-  border-radius: 3px;
-  background: rgba(255, 255, 255, 0.16);
-  color: #fff;
-  font-family: var(--vp-font-family-mono);
-  font-size: 11.5px;
-}
-
-.qk-version-banner a {
-  color: #fff;
-  text-decoration: underline;
-  text-underline-offset: 2px;
 }

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -3,44 +3,9 @@
 //
 // Mermaid diagrams are rendered by vitepress-plugin-mermaid (wired in
 // config.mjs via withMermaid). No manual mermaid bootstrapping is needed.
-import DefaultTheme from 'vitepress/theme'
-import { h } from 'vue'
-import { useData } from 'vitepress'
-import './custom.css'
-
-// Version banner: the site documents qiankun 3 while npm's `latest` tag still
-// resolves to 2.x, so every page states which major it covers and how to
-// install it. Drop this (and --vp-layout-top-height in custom.css) once 3.0
-// ships as `latest`.
-const VersionBanner = {
-  setup() {
-    const { lang } = useData()
-    return () =>
-      h('div', { class: 'qk-version-banner' }, [
-        lang.value.startsWith('zh')
-          ? h('span', [
-              '当前文档对应 qiankun 3.0（RC），安装请使用 ',
-              h('code', 'npm i qiankun@rc'),
-              '；2.x 文档见 ',
-              h('a', { href: 'https://v2.qiankun.umijs.org' }, 'v2 站点'),
-              '。',
-            ])
-          : h('span', [
-              'These docs cover qiankun 3.0 (RC) — install it with ',
-              h('code', 'npm i qiankun@rc'),
-              '. For 2.x, see the ',
-              h('a', { href: 'https://v2.qiankun.umijs.org' }, 'v2 docs'),
-              '.',
-            ]),
-      ])
-  },
-}
+import DefaultTheme from 'vitepress/theme';
+import './custom.css';
 
 export default {
   extends: DefaultTheme,
-  Layout() {
-    return h(DefaultTheme.Layout, null, {
-      'layout-top': () => h(VersionBanner),
-    })
-  },
-}
+};

--- a/docs/cookbook/prepare-a-vite-app.md
+++ b/docs/cookbook/prepare-a-vite-app.md
@@ -11,7 +11,7 @@ The [Agent skill](/ecosystem/agent-skill) lets a coding agent generate this setu
 Install the bundler plugin in the Vite application:
 
 ```bash
-npm install --save-dev @qiankunjs/bundler-plugin@rc
+npm install --save-dev @qiankunjs/bundler-plugin
 ```
 
 Add `qiankun()` alongside the framework plugin and use a fixed development port:

--- a/docs/cookbook/prepare-a-webpack-app.md
+++ b/docs/cookbook/prepare-a-webpack-app.md
@@ -9,7 +9,7 @@ For Vite, see [Make a Vite app qiankun-ready](/cookbook/prepare-a-vite-app).
 Install the qiankun bundler plugin together with `html-webpack-plugin`:
 
 ```bash
-npm install --save-dev @qiankunjs/bundler-plugin@rc html-webpack-plugin
+npm install --save-dev @qiankunjs/bundler-plugin html-webpack-plugin
 ```
 
 `html-webpack-plugin` produces the HTML entry and lets the qiankun plugin identify its entry script.

--- a/docs/cookbook/standalone-sandbox.md
+++ b/docs/cookbook/standalone-sandbox.md
@@ -10,7 +10,7 @@ The lower-level `Compartment` class is also public for hosts that need a Compart
 ## Install
 
 ```bash
-pnpm add @qiankunjs/sandbox@rc
+pnpm add @qiankunjs/sandbox
 ```
 
 The package is browser-only. It depends on DOM APIs, blob URLs, and dynamically injected import maps, so it must not be initialized during Node.js or SSR rendering.

--- a/docs/ecosystem/bundler-plugin.md
+++ b/docs/ecosystem/bundler-plugin.md
@@ -7,7 +7,7 @@ The package provides separate Vite and Webpack plugins. Use the matching import 
 ## Install
 
 ```bash
-npm install --save-dev @qiankunjs/bundler-plugin@rc
+npm install --save-dev @qiankunjs/bundler-plugin
 ```
 
 It supports Vite 5 and later and Webpack 4 / 5. Both peer dependencies are optional, so install only the bundler your project uses.

--- a/docs/ecosystem/react.md
+++ b/docs/ecosystem/react.md
@@ -9,7 +9,7 @@ The package also exports [`MicroAppLink`](#micro-app-link) for host route naviga
 ## Installation
 
 ```bash
-npm install @qiankunjs/react@rc qiankun@rc
+npm install @qiankunjs/react qiankun
 ```
 
 The peer dependencies are `react` and `react-dom`, both required at `>=16.9.0`.

--- a/docs/ecosystem/vue.md
+++ b/docs/ecosystem/vue.md
@@ -9,7 +9,7 @@ The package also exports [`MicroAppLink`](#micro-app-link) for host route naviga
 ## Installation
 
 ```bash
-npm install @qiankunjs/vue@rc qiankun@rc
+npm install @qiankunjs/vue qiankun
 ```
 
 `vue` is a peer dependency with the range `^2.0.0 || >=3.0.0`. Under Vue 2 you also need `@vue/composition-api` installed (the component uses the Composition API through `vue-demi`).

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,12 +51,8 @@ features:
 Install qiankun in the main app:
 
 ```bash
-npm install qiankun@rc
+npm i qiankun
 ```
-
-::: tip v3 installs from the `rc` tag
-qiankun 3.0 is a release candidate, so npm's `latest` tag still resolves to 2.x. Ask for `@rc` explicitly to get v3.
-:::
 
 Mount after the container exists, then keep the returned handle for status and teardown:
 

--- a/docs/tutorial/build-the-main-app.md
+++ b/docs/tutorial/build-the-main-app.md
@@ -12,7 +12,7 @@ Return to the `qiankun-tutorial` directory, next to `sub-app`:
 npm create vite@latest main-app -- --template react-ts
 cd main-app
 npm install
-npm install qiankun@rc
+npm i qiankun
 ```
 
 ## Fix the main-app port

--- a/docs/tutorial/build-the-micro-app.md
+++ b/docs/tutorial/build-the-micro-app.md
@@ -12,7 +12,7 @@ From your `qiankun-tutorial` directory:
 npm create vite@latest sub-app -- --template react-ts
 cd sub-app
 npm install
-npm install --save-dev @qiankunjs/bundler-plugin@rc
+npm install --save-dev @qiankunjs/bundler-plugin
 ```
 
 ## Configure Vite

--- a/docs/zh-CN/cookbook/prepare-a-vite-app.md
+++ b/docs/zh-CN/cookbook/prepare-a-vite-app.md
@@ -11,7 +11,7 @@ qiankun v3 以原生 ESM 方式加载 Vite 应用。接入时需要安装 Vite �
 在 Vite 应用中安装构建插件：
 
 ```bash
-npm install --save-dev @qiankunjs/bundler-plugin@rc
+npm install --save-dev @qiankunjs/bundler-plugin
 ```
 
 将 `qiankun()` 与框架插件一同加入配置，并指定固定的开发服务器端口：

--- a/docs/zh-CN/cookbook/prepare-a-webpack-app.md
+++ b/docs/zh-CN/cookbook/prepare-a-webpack-app.md
@@ -9,7 +9,7 @@
 安装 qiankun 构建插件和 `html-webpack-plugin`：
 
 ```bash
-npm install --save-dev @qiankunjs/bundler-plugin@rc html-webpack-plugin
+npm install --save-dev @qiankunjs/bundler-plugin html-webpack-plugin
 ```
 
 `html-webpack-plugin` 用于生成 HTML 入口，使 qiankun 插件能够识别对应的入口脚本。

--- a/docs/zh-CN/cookbook/standalone-sandbox.md
+++ b/docs/zh-CN/cookbook/standalone-sandbox.md
@@ -10,7 +10,7 @@
 ## 安装
 
 ```bash
-pnpm add @qiankunjs/sandbox@rc
+pnpm add @qiankunjs/sandbox
 ```
 
 该包仅面向浏览器，运行时依赖 DOM、Blob URL 和动态 import map。不要在 Node.js 或 SSR 渲染阶段初始化沙箱。

--- a/docs/zh-CN/ecosystem/bundler-plugin.md
+++ b/docs/zh-CN/ecosystem/bundler-plugin.md
@@ -7,7 +7,7 @@
 ## 安装
 
 ```bash
-npm install --save-dev @qiankunjs/bundler-plugin@rc
+npm install --save-dev @qiankunjs/bundler-plugin
 ```
 
 插件支持 Vite 5 及以上版本，以及 Webpack 4 和 Webpack 5。该包将 Vite 和 Webpack 声明为可选对等依赖（`peerDependencies`），项目只需安装实际使用的构建工具。

--- a/docs/zh-CN/ecosystem/react.md
+++ b/docs/zh-CN/ecosystem/react.md
@@ -9,7 +9,7 @@
 ## 安装
 
 ```bash
-npm install @qiankunjs/react@rc qiankun@rc
+npm install @qiankunjs/react qiankun
 ```
 
 主应用必须安装 `react` 和 `react-dom`，两者的版本均需满足 `>=16.9.0`。

--- a/docs/zh-CN/ecosystem/vue.md
+++ b/docs/zh-CN/ecosystem/vue.md
@@ -9,7 +9,7 @@
 ## 安装
 
 ```bash
-npm install @qiankunjs/vue@rc qiankun@rc
+npm install @qiankunjs/vue qiankun
 ```
 
 主应用必须安装 `vue`，版本范围为 `^2.0.0 || >=3.0.0`。Vue 2 项目还需要安装 `@vue/composition-api`，因为组件通过 `vue-demi` 使用组合式 API。

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -51,12 +51,8 @@ features:
 在主应用中安装 qiankun：
 
 ```bash
-npm install qiankun@rc
+npm i qiankun
 ```
-
-::: tip v3 目前发布在 `rc` 标签上
-qiankun 3.0 仍处于 RC 阶段，npm 的 `latest` 标签指向的仍是 2.x。安装时需显式指定 `@rc` 才能获得 v3。
-:::
 
 容器创建后即可加载微应用。记得保存返回的实例句柄，后续查询状态、卸载实例都要靠它：
 

--- a/docs/zh-CN/tutorial/build-the-main-app.md
+++ b/docs/zh-CN/tutorial/build-the-main-app.md
@@ -12,7 +12,7 @@
 npm create vite@latest main-app -- --template react-ts
 cd main-app
 npm install
-npm install qiankun@rc
+npm i qiankun
 ```
 
 ## 固定主应用端口

--- a/docs/zh-CN/tutorial/build-the-micro-app.md
+++ b/docs/zh-CN/tutorial/build-the-micro-app.md
@@ -12,7 +12,7 @@ qiankun 微应用仍是标准的前端应用，但入口模块需要额外导出
 npm create vite@latest sub-app -- --template react-ts
 cd sub-app
 npm install
-npm install --save-dev @qiankunjs/bundler-plugin@rc
+npm install --save-dev @qiankunjs/bundler-plugin
 ```
 
 ## 配置 Vite

--- a/skills/qiankun/SKILL.md
+++ b/skills/qiankun/SKILL.md
@@ -27,13 +27,13 @@ Determine these, asking the user only when not inferable from context:
 3. **Framework** — React or Vue; TypeScript or JavaScript. Templates in the references are TS; strip types for JS.
 4. **Dev port** — must be fixed and unique per app, because the host hard-references it in `entry`. Convention: main app `7099`, sub apps `7101`, `7102`, …
 
-Package versions — until qiankun 3.0 stable ships, `rc` is the dist-tag for the core packages:
+Package versions — install stable releases from the default `latest` dist-tag; omit the tag in installation commands:
 
 | Package                               | Dist-tag | Goes in                                       |
 | ------------------------------------- | -------- | --------------------------------------------- |
-| `qiankun`                             | `rc`     | main app `dependencies`                       |
-| `@qiankunjs/react` / `@qiankunjs/vue` | `rc`     | main app `dependencies` (optional UI binding) |
-| `@qiankunjs/bundler-plugin`           | `rc`     | sub app `devDependencies`                     |
+| `qiankun`                             | `latest` | main app `dependencies`                       |
+| `@qiankunjs/react` / `@qiankunjs/vue` | `latest` | main app `dependencies` (optional UI binding) |
+| `@qiankunjs/bundler-plugin`           | `latest` | sub app `devDependencies`                     |
 
 ## Key facts
 

--- a/skills/qiankun/references/create-main-app.md
+++ b/skills/qiankun/references/create-main-app.md
@@ -6,7 +6,7 @@ Prerequisites: the shared facts in [SKILL.md](../SKILL.md) — app name, framewo
 
    ```bash
    pnpm create vite <main-app-name> --template react-ts
-   pnpm add qiankun@rc @qiankunjs/react@rc   # vue shell: @qiankunjs/vue@rc
+   pnpm add qiankun @qiankunjs/react   # vue shell: @qiankunjs/vue
    ```
 
    Pin the port in `vite.config.ts` (`server: { port: 7099, strictPort: true }`).

--- a/skills/qiankun/references/create-micro-app.md
+++ b/skills/qiankun/references/create-micro-app.md
@@ -13,7 +13,7 @@ For a **new** app, start at step 1. To **convert an existing Vite app**, skip to
 2. Add the bundler plugin:
 
    ```bash
-   pnpm add -D @qiankunjs/bundler-plugin@rc
+   pnpm add -D @qiankunjs/bundler-plugin
    ```
 
 3. Edit `vite.config.ts` — register the plugin and pin the port:


### PR DESCRIPTION
**HOLD until 3.0.0：仅在 qiankun 3.0.0 正式发布、相关包的 npm latest 指向稳定版后，由 Captain 合并。请保持草稿状态。**

## 做了什么

删除文档站完整版本 banner、layout-top slot、CSS 高度变量与首页相关偏移；中英文首页、教程、生态页面和 cookbook 的安装命令移除 rc 标签。README 的主 badge 与包表统一读取 latest，NOTE 改为指向 v2 文档站的一句话说明，并保留 GitHub alert 所需空引用行。同步 agent skill 安装示例、dist-tag 表和 AGENTS.md 中指定的安装规则。

## 为什么

正式版发布后，默认安装命令应直接获得稳定版，站点也不再需要 RC 提示。本层提前准备，发布前不得合并；下层 CSP 文档与 RFC 状态更新可以先行审阅。

## 如何验证

- `pnpm run docs:build`：通过。
- `pnpm run eslint && pnpm run prettier:check`：通过。
- `pnpm exec prettier --ignore-path /dev/null --check docs/.vitepress/theme/index.js docs/.vitepress/theme/custom.css`：通过。
- `grep -rn "@rc" docs README.md README.zh-CN.md skills AGENTS.md`：0 匹配，退出码 1（包含最终构建产物的全目录扫描）。
- README alert 结构、v2 链接、latest badges 的脚本断言：通过。
- 对构建后的首页与 CSP 页，以中英文、1440px/390px 两种宽度进行 Chromium 检查：8/8 通过；无版本 banner、无 rc 安装提示，导航顶边为 0，banner 高度变量已删除，桌面导航可达 CSP 页。
- `git diff --check`：通过。仅文档、主题和 skill 内容变更，无运行时代码改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
