### PR TITLE
feat(ui-bindings): add MicroAppLink navigation components

### DIFF
--- a/docs/ecosystem/react.md
+++ b/docs/ecosystem/react.md
@@ -4,6 +4,8 @@
 
 Use it when the host is a React SPA and you want to drop a micro-app in as an ordinary component (on a route, inside a panel) rather than registering it globally with [`registerMicroApps`](/api/register-micro-apps).
 
+The package also exports [`MicroAppLink`](#micro-app-link) for host route navigation, documented below.
+
 ## Installation
 
 ```bash
@@ -11,6 +13,46 @@ npm install @qiankunjs/react@rc qiankun@rc
 ```
 
 The peer dependencies are `react` and `react-dom`, both required at `>=16.9.0`.
+
+## Route navigation with MicroAppLink {#micro-app-link}
+
+`MicroAppLink` provides host navigation for apps registered with [`registerMicroApps`](/api/register-micro-apps). After the host registers its micro-apps and calls [`start`](/api/start), clicking a link changes the URL through single-spa's `navigateToUrl`. The registered `activeRule` determines which micro-apps mount or unmount. The link does not load micro-apps itself.
+
+```tsx
+import { MicroAppLink, type MicroAppLinkProps } from '@qiankunjs/react';
+import { useRef } from 'react';
+
+export default function Navigation() {
+  const linkRef = useRef<HTMLAnchorElement>(null);
+  const appLink: MicroAppLinkProps = {
+    to: '/app1',
+    className: 'nav-link',
+    activeClassName: 'is-active',
+  };
+
+  return (
+    <nav>
+      <MicroAppLink {...appLink} ref={linkRef}>App one</MicroAppLink>
+      <MicroAppLink to="/app2/settings" replace>App two settings</MicroAppLink>
+    </nav>
+  );
+}
+```
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `to` | `string` | **Required.** Target URL, rendered as the link's `href`. |
+| `replace` | `boolean` | Whether to replace the current history entry. Defaults to `false`, adding a new entry on navigation. |
+| `className` | `string` | CSS class for the link. |
+| `activeClassName` | `string` | CSS class appended when the current URL matches the target URL prefix. No class is appended by default. |
+| `children` | `ReactNode` | Link content. |
+| `ref` | `Ref<HTMLAnchorElement>` | Points to the rendered `<a>` element. |
+
+`MicroAppLinkProps` is exported from the package entry point. Native anchor props other than those consumed by the component, including `target`, `rel`, `download`, `aria-*`, `data-*`, and event handlers, are forwarded to `<a>`. `to` supplies `href`.
+
+The component calls the provided `onClick` first. It intercepts only a left click on a same-origin HTTP(S) link when the event has not been canceled with `preventDefault()`, no Ctrl / Meta / Shift / Alt modifier is pressed, and the effective `target` is empty or `_self` (an omitted target follows the page's `<base target>` setting). Such clicks navigate within the current page. External links, download links, other browsing targets, and modified clicks retain browser behavior. With `replace`, the component uses `history.replaceState` and dispatches `popstate` to notify routing listeners.
+
+For `activeClassName`, the component resolves the target URL and compares its `pathname + search + hash` with the start of the corresponding current URL string. For example, `to="/app1"` matches both `/app1/settings` and `/app10`, and `to="/"` matches every path. Query parameters and hashes in `to` participate in the same prefix comparison. This is a string comparison without route parameter parsing. For exact matching, the host can set `className` and `aria-current` itself.
 
 ## Basic usage
 

--- a/docs/ecosystem/vue.md
+++ b/docs/ecosystem/vue.md
@@ -4,6 +4,8 @@
 
 The component is built on [`vue-demi`](https://github.com/vueuse/vue-demi), so a single build runs under both Vue 2 and Vue 3.
 
+The package also exports [`MicroAppLink`](#micro-app-link) for host route navigation, documented below.
+
 ## Installation
 
 ```bash
@@ -15,6 +17,42 @@ npm install @qiankunjs/vue@rc qiankun@rc
 ::: tip Prerequisite
 The `MicroApp` component calls `loadMicroApp` directly, so you do not need `registerMicroApps` or `start` for it. You still need [`start`](/api/start) if you also use route-based registration elsewhere in the same app. See [Micro-app lifecycle and props](/concepts/lifecycle-and-props) for how mount and update map to single-spa.
 :::
+
+## Route navigation with MicroAppLink {#micro-app-link}
+
+`MicroAppLink` provides navigation for Vue 3 hosts using [`registerMicroApps`](/api/register-micro-apps). After the host registers its micro-apps and calls [`start`](/api/start), clicking a link changes the URL through single-spa's `navigateToUrl`. The registered `activeRule` determines which micro-apps mount or unmount. The link does not load micro-apps itself.
+
+```vue
+<script setup lang="ts">
+import { MicroAppLink, type MicroAppLinkProps } from '@qiankunjs/vue';
+
+const appLink: MicroAppLinkProps = {
+  to: '/app1',
+  className: 'nav-link',
+  activeClassName: 'is-active',
+};
+</script>
+
+<template>
+  <nav>
+    <MicroAppLink v-bind="appLink">App one</MicroAppLink>
+    <MicroAppLink to="/app2/settings" replace>App two settings</MicroAppLink>
+  </nav>
+</template>
+```
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `to` | `string` | **Required.** Target URL, rendered as the link's `href`. |
+| `replace` | `boolean` | Whether to replace the current history entry. Defaults to `false`, adding a new entry on navigation. |
+| `className` | `string` | CSS class for the link. Use `class-name` in templates if preferred. |
+| `activeClassName` | `string` | CSS class appended when the current URL matches the target URL prefix. Use `active-class-name` in templates if preferred. No class is appended by default. |
+
+The default slot provides the link content. `MicroAppLinkProps` is exported from the package entry point. Native anchor attributes other than those consumed by the component, including `class`, `target`, `rel`, `download`, `aria-*`, `data-*`, and event listeners, are forwarded to `<a>`. `to` supplies `href`.
+
+The component calls the provided `@click` listener first. It intercepts only a left click on a same-origin HTTP(S) link when the event has not been canceled with `preventDefault()`, no Ctrl / Meta / Shift / Alt modifier is pressed, and the effective `target` is empty or `_self` (an omitted target follows the page's `<base target>` setting). Such clicks navigate within the current page. External links, download links, other browsing targets, and modified clicks retain browser behavior. Use `@click.prevent` to cancel component navigation. With `replace`, the component uses `history.replaceState` and dispatches `popstate` to notify routing listeners.
+
+For `activeClassName`, the component resolves the target URL and compares its `pathname + search + hash` with the start of the corresponding current URL string. For example, `to="/app1"` matches both `/app1/settings` and `/app10`, and `to="/"` matches every path. Query parameters and hashes in `to` participate in the same prefix comparison. This is a string comparison without route parameter parsing. For exact matching, the host can set `className` and `aria-current` itself.
 
 ## Basic usage
 

--- a/docs/zh-CN/ecosystem/react.md
+++ b/docs/zh-CN/ecosystem/react.md
@@ -4,6 +4,8 @@
 
 当 React 主应用需要在路由页面或局部面板中以组件形式使用微应用，而不希望通过 [`registerMicroApps`](/zh-CN/api/register-micro-apps) 进行全局注册时，可使用该组件。
 
+包中还提供用于主应用路由导航的 [`MicroAppLink`](#micro-app-link)，其用法见下文。
+
 ## 安装
 
 ```bash
@@ -11,6 +13,46 @@ npm install @qiankunjs/react@rc qiankun@rc
 ```
 
 主应用必须安装 `react` 和 `react-dom`，两者的版本均需满足 `>=16.9.0`。
+
+## 路由导航：MicroAppLink {#micro-app-link}
+
+`MicroAppLink` 用于 [`registerMicroApps`](/zh-CN/api/register-micro-apps) 路由模式下的主应用导航。主应用完成注册并调用 [`start`](/zh-CN/api/start) 后，点击链接即可通过 single-spa 的 `navigateToUrl` 切换 URL，由已注册的 `activeRule` 决定微应用的挂载与卸载。链接本身不加载微应用。
+
+```tsx
+import { MicroAppLink, type MicroAppLinkProps } from '@qiankunjs/react';
+import { useRef } from 'react';
+
+export default function Navigation() {
+  const linkRef = useRef<HTMLAnchorElement>(null);
+  const appLink: MicroAppLinkProps = {
+    to: '/app1',
+    className: 'nav-link',
+    activeClassName: 'is-active',
+  };
+
+  return (
+    <nav>
+      <MicroAppLink {...appLink} ref={linkRef}>应用一</MicroAppLink>
+      <MicroAppLink to="/app2/settings" replace>应用二设置</MicroAppLink>
+    </nav>
+  );
+}
+```
+
+| 属性 | 类型 | 说明 |
+| --- | --- | --- |
+| `to` | `string` | **必填。** 目标 URL，作为链接的 `href`。 |
+| `replace` | `boolean` | 是否替换当前历史记录。默认值为 `false`，导航时新增一条历史记录。 |
+| `className` | `string` | 链接的 CSS 类名。 |
+| `activeClassName` | `string` | 当前地址匹配目标地址前缀时追加的 CSS 类名。默认不追加。 |
+| `children` | `ReactNode` | 链接内容。 |
+| `ref` | `Ref<HTMLAnchorElement>` | 指向渲染出的 `<a>` 元素。 |
+
+`MicroAppLinkProps` 从包入口导出。除组件自身使用的属性外，`target`、`rel`、`download`、`aria-*`、`data-*`、事件处理函数等原生链接属性都会传递给 `<a>`；`href` 由 `to` 指定。
+
+组件先执行传入的 `onClick`，再判断是否接管导航。只有未被 `preventDefault()` 取消、未按下 Ctrl / Meta / Shift / Alt、目标为当前窗口（有效的 `target` 为空或为 `_self`，未设置时遵循页面的 `<base target>`）的同源 HTTP(S) 链接左键点击，才会阻止默认行为并在当前页面内导航。外链、下载链接、其他窗口目标及带修饰键的点击均保留浏览器行为。`replace` 为 `true` 时使用 `history.replaceState` 替换当前记录，并发送 `popstate` 通知路由更新。
+
+`activeClassName` 将目标 URL 解析后，以它的 `pathname + search + hash` 为前缀匹配当前地址的对应部分。例如，`to="/app1"` 会匹配 `/app1/settings`，也会匹配 `/app10`；`to="/"` 会匹配所有路径。查询参数和哈希若包含在 `to` 中，也参与前缀匹配。这是字符串前缀匹配，不解析路由参数；需要精确匹配时，可由主应用自行设置 `className` 和 `aria-current`。
 
 ## 基础用法
 

--- a/docs/zh-CN/ecosystem/vue.md
+++ b/docs/zh-CN/ecosystem/vue.md
@@ -4,6 +4,8 @@
 
 组件基于 [`vue-demi`](https://github.com/vueuse/vue-demi) 构建，同一份构建产物同时支持 Vue 2 和 Vue 3。
 
+包中还提供用于主应用路由导航的 [`MicroAppLink`](#micro-app-link)，其用法见下文。
+
 ## 安装
 
 ```bash
@@ -15,6 +17,42 @@ npm install @qiankunjs/vue@rc qiankun@rc
 ::: tip 使用前提
 `MicroApp` 组件直接调用 `loadMicroApp`，单独使用时无需调用 `registerMicroApps` 或 `start`。如果同一主应用还使用基于路由的注册方式，则仍需调用 [`start`](/zh-CN/api/start)。挂载和更新操作与 single-spa 生命周期的对应关系参见[微应用生命周期与 props](/zh-CN/concepts/lifecycle-and-props)。
 :::
+
+## 路由导航：MicroAppLink {#micro-app-link}
+
+`MicroAppLink` 用于 Vue 3 主应用的 [`registerMicroApps`](/zh-CN/api/register-micro-apps) 路由模式。主应用完成注册并调用 [`start`](/zh-CN/api/start) 后，点击链接即可通过 single-spa 的 `navigateToUrl` 切换 URL，由已注册的 `activeRule` 决定微应用的挂载与卸载。链接本身不加载微应用。
+
+```vue
+<script setup lang="ts">
+import { MicroAppLink, type MicroAppLinkProps } from '@qiankunjs/vue';
+
+const appLink: MicroAppLinkProps = {
+  to: '/app1',
+  className: 'nav-link',
+  activeClassName: 'is-active',
+};
+</script>
+
+<template>
+  <nav>
+    <MicroAppLink v-bind="appLink">应用一</MicroAppLink>
+    <MicroAppLink to="/app2/settings" replace>应用二设置</MicroAppLink>
+  </nav>
+</template>
+```
+
+| 属性 | 类型 | 说明 |
+| --- | --- | --- |
+| `to` | `string` | **必填。** 目标 URL，作为链接的 `href`。 |
+| `replace` | `boolean` | 是否替换当前历史记录。默认值为 `false`，导航时新增一条历史记录。 |
+| `className` | `string` | 链接的 CSS 类名，模板中也可写为 `class-name`。 |
+| `activeClassName` | `string` | 当前地址匹配目标地址前缀时追加的 CSS 类名，模板中也可写为 `active-class-name`。默认不追加。 |
+
+默认插槽提供链接内容。`MicroAppLinkProps` 从包入口导出。除组件自身使用的属性外，`class`、`target`、`rel`、`download`、`aria-*`、`data-*` 和事件监听器等原生链接属性都会传递给 `<a>`；`href` 由 `to` 指定。
+
+组件先执行传入的 `@click` 监听器，再判断是否接管导航。只有未被 `preventDefault()` 取消、未按下 Ctrl / Meta / Shift / Alt、目标为当前窗口（有效的 `target` 为空或为 `_self`，未设置时遵循页面的 `<base target>`）的同源 HTTP(S) 链接左键点击，才会阻止默认行为并在当前页面内导航。外链、下载链接、其他窗口目标及带修饰键的点击均保留浏览器行为。可通过 `@click.prevent` 取消组件导航。`replace` 为 `true` 时使用 `history.replaceState` 替换当前记录，并发送 `popstate` 通知路由更新。
+
+`activeClassName` 将目标 URL 解析后，以它的 `pathname + search + hash` 为前缀匹配当前地址的对应部分。例如，`to="/app1"` 会匹配 `/app1/settings`，也会匹配 `/app10`；`to="/"` 会匹配所有路径。查询参数和哈希若包含在 `to` 中，也参与前缀匹配。这是字符串前缀匹配，不解析路由参数；需要精确匹配时，可由主应用自行设置 `className` 和 `aria-current`。
 
 ## 基本用法
 

--- a/examples/main/src/components/Dashboard.tsx
+++ b/examples/main/src/components/Dashboard.tsx
@@ -1,7 +1,7 @@
+import { MicroAppLink } from '@qiankunjs/react';
 import { useCallback, useEffect, useState } from 'react';
 import { microApps } from '../apps';
 import { useLocale, useMessages } from '../i18n';
-import { navigate } from '../router';
 
 export default function Dashboard() {
   const locale = useLocale();
@@ -37,9 +37,8 @@ export default function Dashboard() {
         <ul>
           {microApps.map((app) => (
             <li key={app.name} className="border-b border-hairline last:border-b-0">
-              <button
-                type="button"
-                onClick={() => navigate(app.path)}
+              <MicroAppLink
+                to={app.path}
                 className="group flex w-full items-center gap-4 px-5 py-4 text-left transition-colors duration-150 hover:bg-paper"
               >
                 <span className="size-2.5 shrink-0 rounded-full" style={{ backgroundColor: app.accent }} />
@@ -59,7 +58,7 @@ export default function Dashboard() {
                   {app.loadingPath}
                 </span>
                 <span className="text-ink-soft transition-transform duration-150 group-hover:translate-x-0.5">→</span>
-              </button>
+              </MicroAppLink>
             </li>
           ))}
         </ul>

--- a/examples/main/src/components/Sidebar.tsx
+++ b/examples/main/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
+import { MicroAppLink } from '@qiankunjs/react';
 import { microApps, siblingShell } from '../apps';
 import { useLocale, useMessages } from '../i18n';
-import { navigate } from '../router';
 import Seal from './Seal';
 
 /** the short form of each loading path, for the tag on the right of a nav item */
@@ -16,9 +16,8 @@ export default function Sidebar({ activePath }: SidebarProps) {
 
   return (
     <aside className="flex w-64 shrink-0 flex-col border-r border-hairline bg-surface">
-      <button
-        type="button"
-        onClick={() => navigate('/')}
+      <MicroAppLink
+        to="/"
         className="flex items-center gap-3 border-b border-hairline px-5 py-5 text-left"
       >
         <Seal size={36} />
@@ -26,14 +25,14 @@ export default function Sidebar({ activePath }: SidebarProps) {
           <span className="block font-display text-lg font-semibold tracking-[-0.01em] text-ink">qiankun</span>
           <span className="block font-mono text-[11px] text-ink-soft">{m.shellSubtitle}</span>
         </span>
-      </button>
+      </MicroAppLink>
 
       <nav className="flex-1 px-3 py-4">
         <NavItem
           label={m.dashboard}
           sub={m.dashboardSub}
           active={activePath === '/'}
-          onClick={() => navigate('/')}
+          to="/"
         />
 
         <p className="mt-6 mb-2 px-2 font-mono text-[10px] tracking-[0.18em] text-ink-soft uppercase">{m.microApps}</p>
@@ -45,7 +44,7 @@ export default function Sidebar({ activePath }: SidebarProps) {
             dot={app.accent}
             mono={loadingTag[app.loadingPath]}
             active={activePath.startsWith(app.path)}
-            onClick={() => navigate(app.path)}
+            to={app.path}
           />
         ))}
       </nav>
@@ -74,16 +73,15 @@ interface NavItemProps {
   label: string;
   sub: string;
   active: boolean;
-  onClick: () => void;
+  to: string;
   dot?: string;
   mono?: string;
 }
 
-function NavItem({ label, sub, active, onClick, dot, mono }: NavItemProps) {
+function NavItem({ label, sub, active, to, dot, mono }: NavItemProps) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
+    <MicroAppLink
+      to={to}
       aria-current={active ? 'page' : undefined}
       className={`relative flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors duration-150 ${
         active ? 'bg-primary/8 text-primary' : 'text-ink hover:bg-paper'
@@ -96,6 +94,6 @@ function NavItem({ label, sub, active, onClick, dot, mono }: NavItemProps) {
         <span className={`block text-xs ${active ? 'text-primary/70' : 'text-ink-soft'}`}>{sub}</span>
       </span>
       {mono && <span className="font-mono text-[10px] text-ink-soft">{mono}</span>}
-    </button>
+    </MicroAppLink>
   );
 }

--- a/examples/main/src/main.tsx
+++ b/examples/main/src/main.tsx
@@ -1,7 +1,11 @@
+import { start } from 'qiankun';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
+
+// Install routing notifications before the first MicroAppLink click, even on the dashboard.
+start();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/examples/main/src/router.ts
+++ b/examples/main/src/router.ts
@@ -1,32 +1,15 @@
 import { useSyncExternalStore } from 'react';
 
-/**
- * The shell owns its routing now: micro apps are mounted by `<MicroApp />` off React state, so
- * navigation must not lean on single-spa patching history — qiankun starts single-spa lazily
- * with the first micro app, and until then a pushState emits no popstate at all. We therefore
- * announce our own navigations, and still listen for single-spa reroutes so a micro app
- * navigating the host stays in sync.
- */
-const NAVIGATION_EVENT = 'shell:navigation';
-
+/** Keep the shell in sync with MicroAppLink, browser history, and micro-app navigation. */
 function subscribe(callback: () => void) {
   window.addEventListener('popstate', callback);
-  window.addEventListener(NAVIGATION_EVENT, callback);
   window.addEventListener('single-spa:routing-event', callback);
   return () => {
     window.removeEventListener('popstate', callback);
-    window.removeEventListener(NAVIGATION_EVENT, callback);
     window.removeEventListener('single-spa:routing-event', callback);
   };
 }
 
 export function usePathname(): string {
   return useSyncExternalStore(subscribe, () => window.location.pathname);
-}
-
-export function navigate(path: string): void {
-  if (window.location.pathname === path) return;
-
-  window.history.pushState(null, '', path);
-  window.dispatchEvent(new Event(NAVIGATION_EVENT));
 }

--- a/examples/vue-host/README.md
+++ b/examples/vue-host/README.md
@@ -10,8 +10,10 @@ Vue 3.5 + Vite 8 host for the qiankun examples: the second shell, and the one th
 - Slots: `#loader="{ loading }"` draws the stage veil and `#error-boundary="{ error }"` draws the
   mount-failed panel. The binding's wrapper is not positioned, so the shell positions it through
   `wrapper-class-name`.
-- Routing: `src/router.ts` is a reactive pathname that broadcasts its own navigations — qiankun only
-  starts single-spa with the first micro app, so before that a `pushState` emits no `popstate`.
+- Routing: the brand, sidebar, and dashboard use `<MicroAppLink>` from `@qiankunjs/vue`.
+  `src/main.ts` calls `start()` before mounting the shell so navigation works from the dashboard
+  before any micro app has loaded. `src/router.ts` keeps a reactive pathname in sync with browser
+  history and single-spa routing events; the active route still drives `<MicroApp>` mounting.
 - Deliberately slim: no dashboard, seal or trigram (see `examples/DESIGN.md`), plain scoped CSS over
   the shared tokens, and no `@qiankunjs/bundler-plugin` — this is a host, not a micro app.
 

--- a/examples/vue-host/src/App.vue
+++ b/examples/vue-host/src/App.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import { MicroAppLink } from '@qiankunjs/vue';
 import { computed } from 'vue';
 import { appByPath, microApps, siblingShell } from './apps';
 import { locale, t, toggleLocale } from './i18n';
-import { currentPath, navigate } from './router';
+import { currentPath } from './router';
 import Dashboard from './Dashboard.vue';
 import Stage from './Stage.vue';
 
@@ -17,36 +18,34 @@ const loadingTag = { 'esm sandbox': 'esm', classic: 'classic', streamed: 'stream
 <template>
   <div class="shell">
     <aside>
-      <button type="button" class="brand" @click="navigate(home)">
+      <MicroAppLink :to="home" class-name="brand">
         <span class="seal" aria-hidden>乾坤</span>
         <span>
           <strong>qiankun</strong>
           <small class="mono">{{ t.shellSubtitle }}</small>
         </span>
-      </button>
+      </MicroAppLink>
 
       <nav>
-        <button
-          type="button"
+        <MicroAppLink
+          :to="home"
           :aria-current="currentPath === home ? 'page' : undefined"
           :class="{ active: currentPath === home }"
-          @click="navigate(home)"
         >
           <span>
             <span class="label">{{ t.dashboard }}</span>
             <span class="sub">{{ t.dashboardSub }}</span>
           </span>
-        </button>
+        </MicroAppLink>
 
         <p class="nav-group mono">{{ t.microApps }}</p>
 
-        <button
+        <MicroAppLink
           v-for="app in microApps"
           :key="app.name"
-          type="button"
+          :to="app.path"
           :aria-current="currentPath.startsWith(app.path) ? 'page' : undefined"
-          :class="{ active: currentPath.startsWith(app.path) }"
-          @click="navigate(app.path)"
+          active-class-name="active"
         >
           <span class="dot" :style="{ backgroundColor: app.accent }" />
           <span>
@@ -54,7 +53,7 @@ const loadingTag = { 'esm sandbox': 'esm', classic: 'classic', streamed: 'stream
             <span class="sub">{{ app.stack[locale] }}</span>
           </span>
           <span class="tag mono">{{ loadingTag[app.loadingPath] }}</span>
-        </button>
+        </MicroAppLink>
       </nav>
 
       <footer class="mono">
@@ -94,6 +93,8 @@ aside {
 }
 
 .brand {
+  color: inherit;
+  text-decoration: none;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -145,7 +146,8 @@ nav {
   padding: 16px 12px;
 }
 
-nav button {
+nav a {
+  text-decoration: none;
   position: relative;
   display: flex;
   align-items: center;
@@ -162,17 +164,17 @@ nav button {
   transition: background-color 150ms ease-out;
 }
 
-nav button:hover {
+nav a:hover {
   background: var(--paper);
 }
 
-nav button.active {
+nav a.active {
   background: color-mix(in srgb, var(--primary) 8%, transparent);
   color: var(--primary);
 }
 
 /* the amber rail marks the active route — one of the few places amber carries meaning */
-nav button.active::before {
+nav a.active::before {
   content: '';
   position: absolute;
   top: 8px;
@@ -204,7 +206,7 @@ nav button.active::before {
   border-radius: 50%;
 }
 
-nav button > span:not(.dot):not(.tag) {
+nav a > span:not(.dot):not(.tag) {
   flex: 1;
   line-height: 1.25;
 }
@@ -221,7 +223,7 @@ nav button > span:not(.dot):not(.tag) {
   color: var(--ink-soft);
 }
 
-nav button.active .sub {
+nav a.active .sub {
   color: color-mix(in srgb, var(--primary) 70%, transparent);
 }
 

--- a/examples/vue-host/src/Dashboard.vue
+++ b/examples/vue-host/src/Dashboard.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
+import { MicroAppLink } from '@qiankunjs/vue';
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { microApps } from './apps';
 import { locale, t } from './i18n';
-import { navigate } from './router';
 
 /**
  * The host-side half of the sub apps' window probe: sub apps write
@@ -40,7 +40,7 @@ const realmBody = computed(() => t.value.hostRealmBody.split('{code}'));
       </div>
       <ul>
         <li v-for="app in microApps" :key="app.name">
-          <button type="button" @click="navigate(app.path)">
+          <MicroAppLink :to="app.path">
             <span class="dot" :style="{ backgroundColor: app.accent }" />
             <span class="identity">
               <span class="label">{{ app.label }}</span>
@@ -50,7 +50,7 @@ const realmBody = computed(() => t.value.hostRealmBody.split('{code}'));
             <span class="entry mono">{{ app.entry }}</span>
             <span class="pill mono" :class="{ esm: app.loadingPath === 'esm sandbox' }">{{ app.loadingPath }}</span>
             <span class="arrow">→</span>
-          </button>
+          </MicroAppLink>
         </li>
       </ul>
     </section>
@@ -161,7 +161,9 @@ const realmBody = computed(() => t.value.hostRealmBody.split('{code}'));
   border-bottom: 0;
 }
 
-.registry button {
+.registry a {
+  color: inherit;
+  text-decoration: none;
   display: flex;
   align-items: center;
   gap: 16px;
@@ -175,7 +177,7 @@ const realmBody = computed(() => t.value.hostRealmBody.split('{code}'));
   transition: background-color 150ms ease-out;
 }
 
-.registry button:hover {
+.registry a:hover {
   background: var(--paper);
 }
 
@@ -242,7 +244,7 @@ const realmBody = computed(() => t.value.hostRealmBody.split('{code}'));
   transition: transform 150ms ease-out;
 }
 
-.registry button:hover .arrow {
+.registry a:hover .arrow {
   transform: translateX(2px);
 }
 
@@ -304,7 +306,7 @@ const realmBody = computed(() => t.value.hostRealmBody.split('{code}'));
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .registry button,
+  .registry a,
   .arrow {
     transition: none;
   }

--- a/examples/vue-host/src/main.ts
+++ b/examples/vue-host/src/main.ts
@@ -1,5 +1,9 @@
+import { start } from 'qiankun';
 import { createApp } from 'vue';
 import App from './App.vue';
 import './styles.css';
+
+// Install routing notifications before the first MicroAppLink click, even on the dashboard.
+start();
 
 createApp(App).mount('#app');

--- a/examples/vue-host/src/router.ts
+++ b/examples/vue-host/src/router.ts
@@ -1,14 +1,6 @@
 import { readonly, ref } from 'vue';
 
-/**
- * The shell owns its routing: micro apps are mounted by `<MicroApp />` off reactive state, so
- * navigation must not lean on single-spa patching history — qiankun starts single-spa lazily with
- * the first micro app, and until then a pushState emits no popstate at all. We therefore announce
- * our own navigations, and still listen for single-spa reroutes so a micro app navigating the host
- * stays in sync.
- */
-const NAVIGATION_EVENT = 'shell:navigation';
-
+/** Keep the shell in sync with MicroAppLink, browser history, and micro-app navigation. */
 const pathname = ref(window.location.pathname);
 
 const sync = () => {
@@ -17,14 +9,6 @@ const sync = () => {
 
 // the shell lives for the lifetime of the page, so these listeners are never torn down
 window.addEventListener('popstate', sync);
-window.addEventListener(NAVIGATION_EVENT, sync);
 window.addEventListener('single-spa:routing-event', sync);
 
 export const currentPath = readonly(pathname);
-
-export function navigate(path: string): void {
-  if (window.location.pathname === path) return;
-
-  window.history.pushState(null, '', path);
-  window.dispatchEvent(new Event(NAVIGATION_EVENT));
-}

--- a/packages/qiankun/src/index.ts
+++ b/packages/qiankun/src/index.ts
@@ -6,3 +6,4 @@ export * from './apis/effects';
 export * from './apis/errorHandler';
 export type * from './types';
 export { moduleSourceInstanceKeyPlaceholder, precompileModuleSource } from '@qiankunjs/sandbox';
+export { navigateToUrl } from '@qiankunjs/single-spa';

--- a/packages/ui-bindings/react/src/MicroAppLink.tsx
+++ b/packages/ui-bindings/react/src/MicroAppLink.tsx
@@ -1,0 +1,46 @@
+import { isMicroAppLinkActive, navigateMicroAppLink, subscribeToMicroAppLinkLocation } from '@qiankunjs/ui-shared';
+import React, { forwardRef, useEffect, useState } from 'react';
+
+export type MicroAppLinkProps = Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> & {
+  to: string;
+  replace?: boolean;
+  activeClassName?: string;
+};
+
+/** A host navigation link for micro apps registered with `registerMicroApps`. */
+export const MicroAppLink = forwardRef<HTMLAnchorElement, MicroAppLinkProps>(
+  ({ to, replace = false, className, activeClassName, onClick, ...anchorProps }, ref) => {
+    const [locationHref, setLocationHref] = useState(() =>
+      typeof window === 'undefined' ? undefined : window.location.href,
+    );
+
+    useEffect(() => {
+      // The post-subscription read closes the render-to-effect navigation gap.
+      // eslint-disable-next-line @eslint-react/set-state-in-effect
+      const updateLocation = () => setLocationHref(window.location.href);
+      const unsubscribe = subscribeToMicroAppLinkLocation(updateLocation);
+      // A navigation can finish between rendering and installing the listener.
+      updateLocation();
+      return unsubscribe;
+    }, []);
+
+    const linkClassName = [className, activeClassName && isMicroAppLinkActive(to, locationHref) && activeClassName]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <a
+        {...anchorProps}
+        ref={ref}
+        href={to}
+        className={linkClassName || undefined}
+        onClick={(event) => {
+          onClick?.(event);
+          navigateMicroAppLink(event, event.currentTarget, replace);
+        }}
+      />
+    );
+  },
+);
+
+MicroAppLink.displayName = 'MicroAppLink';

--- a/packages/ui-bindings/react/src/__tests__/MicroAppLink.test.tsx
+++ b/packages/ui-bindings/react/src/__tests__/MicroAppLink.test.tsx
@@ -1,0 +1,298 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Window } from 'happy-dom';
+
+vi.mock('qiankun', () => ({ loadMicroApp: vi.fn(), navigateToUrl: vi.fn() }));
+
+import React, { act, createRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { navigateToUrl } from 'qiankun';
+import { MicroAppLink, type MicroAppLinkProps } from '../index';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const navigateToUrlMock = vi.mocked(navigateToUrl);
+
+describe('MicroAppLink', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  let originalHref: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const happyWindow = window as unknown as Window;
+    happyWindow.happyDOM.settings.navigation.disableMainFrameNavigation = true;
+    happyWindow.happyDOM.settings.navigation.disableChildFrameNavigation = true;
+    happyWindow.happyDOM.settings.navigation.disableChildPageNavigation = true;
+    originalHref = window.location.href;
+    window.history.replaceState(null, '', '/');
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+    navigateToUrlMock.mockImplementation((url) => {
+      window.history.pushState(null, '', url as string);
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    // Native external links change happy-dom's origin even with network navigation disabled.
+    (window as unknown as Window).happyDOM.setURL(originalHref);
+    vi.restoreAllMocks();
+  });
+
+  async function render(props: MicroAppLinkProps) {
+    await act(async () => {
+      root.render(<MicroAppLink {...props} />);
+    });
+    return host.querySelector('a')!;
+  }
+
+  function click(anchor: HTMLAnchorElement, options: MouseEventInit = {}) {
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0, ...options });
+    act(() => {
+      anchor.dispatchEvent(event);
+    });
+    return event;
+  }
+
+  it('renders an anchor, forwards its attributes and children, and exposes its ref', async () => {
+    const ref = createRef<HTMLAnchorElement>();
+    await act(async () => {
+      root.render(
+        <MicroAppLink
+          ref={ref}
+          to="/app1/foo"
+          replace
+          activeClassName="active"
+          className="navigation-link"
+          title="Open app one"
+          aria-label="App one"
+          target="_self"
+          rel="help"
+        >
+          <span>App one</span>
+        </MicroAppLink>,
+      );
+    });
+
+    const anchor = host.querySelector('a')!;
+    expect(ref.current).toBe(anchor);
+    expect(anchor.getAttribute('href')).toBe('/app1/foo');
+    expect(anchor.className).toBe('navigation-link');
+    expect(anchor.title).toBe('Open app one');
+    expect(anchor.getAttribute('aria-label')).toBe('App one');
+    expect(anchor.target).toBe('_self');
+    expect(anchor.rel).toBe('help');
+    expect(anchor.querySelector('span')?.textContent).toBe('App one');
+    expect(anchor.hasAttribute('to')).toBe(false);
+    expect(anchor.hasAttribute('replace')).toBe(false);
+    expect(anchor.hasAttribute('activeClassName')).toBe(false);
+
+    await act(async () => root.render(null));
+    expect(ref.current).toBeNull();
+  });
+
+  it.each([undefined, '', '_self'])('intercepts plain left clicks with target %s', async (target) => {
+    const onClick = vi.fn<NonNullable<MicroAppLinkProps['onClick']>>((event) => {
+      expect(event.defaultPrevented).toBe(false);
+      expect(navigateToUrlMock).not.toHaveBeenCalled();
+    });
+    const anchor = await render({ to: '/app1/foo', target, onClick, children: <span>App one</span> });
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+
+    act(() => anchor.querySelector('span')!.dispatchEvent(event));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+    expect(navigateToUrlMock).toHaveBeenCalledExactlyOnceWith(new URL('/app1/foo', originalHref).href);
+  });
+
+  it.each<MouseEventInit>([
+    { metaKey: true },
+    { ctrlKey: true },
+    { shiftKey: true },
+    { altKey: true },
+    { button: 1 },
+    { button: 2 },
+  ])('preserves native behavior for click options %j', async (options) => {
+    const anchor = await render({ to: '/app1/foo' });
+    const event = click(anchor, options);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(navigateToUrlMock).not.toHaveBeenCalled();
+  });
+
+  it('lets the caller prevent navigation in onClick', async () => {
+    const anchor = await render({ to: '/app1/foo', onClick: (event) => event.preventDefault() });
+
+    expect(click(anchor).defaultPrevented).toBe(true);
+    expect(navigateToUrlMock).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate an event already prevented before the React handler', async () => {
+    const anchor = await render({ to: '/app1/foo' });
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    event.preventDefault();
+
+    act(() => anchor.dispatchEvent(event));
+
+    expect(navigateToUrlMock).not.toHaveBeenCalled();
+  });
+
+  it.each<MicroAppLinkProps>([
+    { to: '/app1/foo', target: '_blank' },
+    { to: '/app1/foo', target: '_parent' },
+    { to: '/app1/foo', target: 'another-frame' },
+    { to: '/app1/foo', download: true },
+    { to: '/app1/foo', download: '' },
+    { to: '/app1/foo', download: 'app.html' },
+    { to: 'https://external.example/app1' },
+    { to: '//external.example/app1' },
+    { to: 'mailto:help@example.com' },
+    { to: 'tel:+1234567' },
+  ])('preserves native behavior for anchor props %j', async (props) => {
+    const anchor = await render(props);
+    const event = click(anchor);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(navigateToUrlMock).not.toHaveBeenCalled();
+  });
+
+  it('handles same-origin absolute destinations', async () => {
+    const to = new URL('/app1/foo', originalHref).href;
+    const anchor = await render({ to });
+
+    expect(click(anchor).defaultPrevented).toBe(true);
+    expect(navigateToUrlMock).toHaveBeenCalledExactlyOnceWith(to);
+  });
+
+  it('replaces the history entry and emits popstate without adding an entry', async () => {
+    window.history.replaceState({ host: 'state' }, '', '/app1');
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+    const pushState = vi.spyOn(window.history, 'pushState');
+    const onPopState = vi.fn();
+    window.addEventListener('popstate', onPopState);
+    const anchor = await render({ to: '/app2/foo', replace: true, activeClassName: 'active' });
+
+    expect(click(anchor).defaultPrevented).toBe(true);
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { host: 'state' },
+      '',
+      new URL('/app2/foo', originalHref).href,
+    );
+    expect(pushState).not.toHaveBeenCalled();
+    expect(onPopState).toHaveBeenCalledTimes(1);
+    expect(window.location.pathname).toBe('/app2/foo');
+    expect(anchor.className).toBe('active');
+    expect(navigateToUrlMock).not.toHaveBeenCalled();
+    window.removeEventListener('popstate', onPopState);
+  });
+
+  it('matches the current location prefix and retains the base class', async () => {
+    window.history.replaceState(null, '', '/app1/foo?view=details#content');
+    let anchor = await render({ to: '/app1', className: 'navigation-link', activeClassName: 'active' });
+    expect(anchor.className).toBe('navigation-link active');
+
+    anchor = await render({ to: '/app2', className: 'navigation-link', activeClassName: 'active' });
+    expect(anchor.className).toBe('navigation-link');
+
+    anchor = await render({ to: '/app1' });
+    expect(anchor.hasAttribute('class')).toBe(false);
+  });
+
+  it('keeps the current link active until a routing event confirms navigation', async () => {
+    window.history.replaceState(null, '', '/app1');
+    await act(async () => {
+      root.render(
+        <>
+          <MicroAppLink to="/app1" activeClassName="active">
+            App one
+          </MicroAppLink>
+          <MicroAppLink to="/app2" activeClassName="active">
+            App two
+          </MicroAppLink>
+        </>,
+      );
+    });
+    const [first, second] = Array.from(host.querySelectorAll('a'));
+
+    click(second);
+    expect(window.location.pathname).toBe('/app2');
+    expect(first.className).toBe('active');
+    expect(second.className).toBe('');
+
+    act(() => window.dispatchEvent(new Event('single-spa:routing-event')));
+    expect(first.className).toBe('');
+    expect(second.className).toBe('active');
+  });
+
+  it('retains the original active link when navigation is canceled with a silent rollback', async () => {
+    window.history.replaceState(null, '', '/app1');
+    await act(async () => {
+      root.render(
+        <>
+          <MicroAppLink to="/app1" activeClassName="active">
+            App one
+          </MicroAppLink>
+          <MicroAppLink to="/app2" activeClassName="active">
+            App two
+          </MicroAppLink>
+        </>,
+      );
+    });
+    const [first, second] = Array.from(host.querySelectorAll('a'));
+
+    click(second);
+    expect(window.location.pathname).toBe('/app2');
+    expect(first.className).toBe('active');
+    expect(second.className).toBe('');
+
+    // single-spa restores the URL without a routing event when cancelNavigation resolves true.
+    act(() => window.history.replaceState(null, '', '/app1'));
+    expect(window.location.pathname).toBe('/app1');
+    expect(first.className).toBe('active');
+    expect(second.className).toBe('');
+  });
+
+  it.each(['popstate', 'hashchange', 'single-spa:routing-event'])(
+    'updates active styling when %s is dispatched',
+    async (eventType) => {
+      const anchor = await render({ to: '/app1#details', activeClassName: 'active' });
+      expect(anchor.className).toBe('');
+
+      act(() => {
+        window.history.replaceState(null, '', '/app1#details');
+        window.dispatchEvent(new Event(eventType));
+      });
+      expect(anchor.className).toBe('active');
+
+      act(() => {
+        window.history.replaceState(null, '', '/app2');
+        window.dispatchEvent(new Event(eventType));
+      });
+      expect(anchor.className).toBe('');
+    },
+  );
+
+  it('removes location listeners when unmounted', async () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+    const removeEventListener = vi.spyOn(window, 'removeEventListener');
+    await render({ to: '/app1', activeClassName: 'active' });
+    const routingListeners = addEventListener.mock.calls.filter(([name]) =>
+      ['popstate', 'hashchange', 'single-spa:routing-event'].includes(name),
+    );
+    expect(routingListeners).toHaveLength(3);
+
+    await act(async () => root.render(null));
+
+    for (const [name, listener] of routingListeners) {
+      expect(removeEventListener).toHaveBeenCalledWith(name, listener);
+    }
+  });
+});

--- a/packages/ui-bindings/react/src/index.ts
+++ b/packages/ui-bindings/react/src/index.ts
@@ -1,3 +1,4 @@
 export * from './MicroApp';
+export * from './MicroAppLink';
 // the payload a `<MicroApp ref>` hands back, so callers can type the ref they pass in
 export type { MicroAppType } from '@qiankunjs/ui-shared';

--- a/packages/ui-bindings/shared/src/__tests__/link.test.ts
+++ b/packages/ui-bindings/shared/src/__tests__/link.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { navigateToUrl } from 'qiankun';
+import { isMicroAppLinkActive, navigateMicroAppLink, subscribeToMicroAppLinkLocation } from '../link';
+
+vi.mock('qiankun', () => ({ navigateToUrl: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.history.replaceState(null, '', '/app1/page?sort=name#details');
+});
+
+afterEach(() => {
+  document.head.querySelector('base')?.remove();
+  vi.restoreAllMocks();
+});
+
+describe('isMicroAppLinkActive', () => {
+  it.each([
+    ['/app1', true],
+    ['/app1/page?sort=name', true],
+    ['/app1/page?sort=name#details', true],
+    ['/app1/page?sort=date', false],
+    ['/app1/page?sort=name#other', false],
+    ['/app2', false],
+    ['https://other.example/app1', false],
+    ['mailto:hello@example.com', false],
+    ['http://[invalid', false],
+  ])('matches the location prefix for %s: %s', (to, active) => {
+    expect(isMicroAppLinkActive(to)).toBe(active);
+  });
+
+  it('resolves relative links against the document base, like an anchor', () => {
+    const base = document.createElement('base');
+    base.href = '/app1/';
+    document.head.appendChild(base);
+    expect(isMicroAppLinkActive('page')).toBe(true);
+  });
+});
+
+describe('navigateMicroAppLink', () => {
+  it('does not duplicate popstate when history.replaceState already dispatches it', () => {
+    const replaceState = window.history.replaceState.bind(window.history);
+    vi.spyOn(window.history, 'replaceState').mockImplementation((state: unknown, unused, url) => {
+      replaceState(state, unused, url);
+      window.dispatchEvent(new PopStateEvent('popstate', { state }));
+    });
+    const listener = vi.fn();
+    window.addEventListener('popstate', listener);
+    const anchor = document.createElement('a');
+    anchor.href = '/app2';
+    navigateMicroAppLink(new MouseEvent('click', { cancelable: true }), anchor, true);
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener('popstate', listener);
+  });
+
+  it('does not intercept a link whose inherited base target opens another window', () => {
+    const base = document.createElement('base');
+    base.target = '_blank';
+    document.head.appendChild(base);
+    const anchor = document.createElement('a');
+    anchor.href = '/app2';
+    const event = new MouseEvent('click', { cancelable: true });
+    navigateMicroAppLink(event, anchor);
+    expect(event.defaultPrevented).toBe(false);
+    expect(navigateToUrl).not.toHaveBeenCalled();
+  });
+
+  it('leaves malformed URLs to the browser', () => {
+    const anchor = document.createElement('a');
+    anchor.href = 'http://[invalid';
+    const event = new MouseEvent('click', { cancelable: true });
+    navigateMicroAppLink(event, anchor);
+    expect(event.defaultPrevented).toBe(false);
+    expect(navigateToUrl).not.toHaveBeenCalled();
+  });
+
+  it('waits for routing notifications before updating subscribers, and cleans up', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToMicroAppLinkLocation(listener);
+    const anchor = document.createElement('a');
+    anchor.href = '/app2';
+    const event = new MouseEvent('click', { cancelable: true });
+    navigateMicroAppLink(event, anchor);
+    expect(listener).not.toHaveBeenCalled();
+    for (const name of ['popstate', 'hashchange', 'single-spa:routing-event']) {
+      window.dispatchEvent(new Event(name));
+    }
+    expect(listener).toHaveBeenCalledTimes(3);
+    unsubscribe();
+    navigateMicroAppLink(new MouseEvent('click', { cancelable: true }), anchor);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/ui-bindings/shared/src/index.ts
+++ b/packages/ui-bindings/shared/src/index.ts
@@ -3,6 +3,8 @@ import type { AppConfiguration, MicroApp as MicroAppTypeDefinition, LifeCycles }
 import { loadMicroApp } from 'qiankun';
 import { omit } from 'lodash';
 
+export { isMicroAppLinkActive, navigateMicroAppLink, subscribeToMicroAppLinkLocation } from './link';
+
 export type MicroAppType = {
   _unmounting?: boolean;
   _updatingPromise?: Promise<null>;

--- a/packages/ui-bindings/shared/src/link.ts
+++ b/packages/ui-bindings/shared/src/link.ts
@@ -1,0 +1,93 @@
+import { navigateToUrl } from 'qiankun';
+
+type LinkClickEvent = Pick<
+  MouseEvent,
+  'button' | 'metaKey' | 'altKey' | 'ctrlKey' | 'shiftKey' | 'defaultPrevented' | 'preventDefault'
+>;
+
+const locationEvents = ['popstate', 'hashchange', 'single-spa:routing-event'] as const;
+
+function resolveLinkUrl(to: string, base?: string): URL | undefined {
+  try {
+    return new URL(to, base);
+  } catch {
+    return undefined;
+  }
+}
+
+function replaceUrl(url: string): void {
+  const state: unknown = window.history.state;
+  const notification = { received: false };
+  // single-spa delays function listeners until mounting finishes. An event-listener object
+  // observes its synchronous history notification, so we do not send a second popstate.
+  const listener = {
+    handleEvent() {
+      notification.received = true;
+    },
+  };
+  window.addEventListener('popstate', listener);
+  try {
+    window.history.replaceState(state, '', url);
+  } finally {
+    window.removeEventListener('popstate', listener);
+  }
+  if (!notification.received) {
+    window.dispatchEvent(new PopStateEvent('popstate', { state }));
+  }
+}
+
+/** Keep active classes current for browser navigation and single-spa reroutes. */
+export function subscribeToMicroAppLinkLocation(listener: () => void): () => void {
+  locationEvents.forEach((event) => window.addEventListener(event, listener));
+  return () => {
+    locationEvents.forEach((event) => window.removeEventListener(event, listener));
+  };
+}
+
+export function isMicroAppLinkActive(
+  to: string,
+  locationHref = typeof window === 'undefined' ? undefined : window.location.href,
+): boolean {
+  if (!locationHref) return false;
+
+  const current = resolveLinkUrl(locationHref);
+  const destination = resolveLinkUrl(to, typeof document === 'undefined' ? locationHref : document.baseURI);
+  const route = (url: URL) => `${url.pathname}${url.search}${url.hash}`;
+  return (
+    !!current && !!destination && destination.origin === current.origin && route(current).startsWith(route(destination))
+  );
+}
+
+/** Preserve native anchor behavior unless this is a same-window, same-origin navigation. */
+export function navigateMicroAppLink(event: LinkClickEvent, anchor: HTMLAnchorElement, replace = false): void {
+  const target =
+    anchor.getAttribute('target') ?? anchor.ownerDocument.querySelector('base[target]')?.getAttribute('target');
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    (target && target.toLowerCase() !== '_self') ||
+    anchor.hasAttribute('download')
+  ) {
+    return;
+  }
+
+  const destination = resolveLinkUrl(anchor.href);
+  if (
+    !destination ||
+    !['http:', 'https:'].includes(destination.protocol) ||
+    destination.origin !== window.location.origin
+  ) {
+    return;
+  }
+
+  event.preventDefault();
+  if (replace) {
+    replaceUrl(anchor.href);
+  } else {
+    navigateToUrl(anchor.href);
+  }
+}

--- a/packages/ui-bindings/vue/src/MicroAppLink.ts
+++ b/packages/ui-bindings/vue/src/MicroAppLink.ts
@@ -1,0 +1,56 @@
+import { computed, defineComponent, h, onBeforeUnmount, onMounted, ref, type AnchorHTMLAttributes } from 'vue-demi';
+import { isMicroAppLinkActive, navigateMicroAppLink, subscribeToMicroAppLinkLocation } from '@qiankunjs/ui-shared';
+
+export interface MicroAppLinkProps extends Omit<AnchorHTMLAttributes, 'href'> {
+  to: string;
+  replace?: boolean;
+  className?: string;
+  activeClassName?: string;
+}
+
+export const MicroAppLink = defineComponent<MicroAppLinkProps>({
+  name: 'MicroAppLink',
+  inheritAttrs: false,
+  props: {
+    to: { type: String, required: true },
+    replace: { type: Boolean, default: false },
+    className: { type: String, default: undefined },
+    activeClassName: { type: String, default: undefined },
+  },
+  emits: {
+    click: (_event: MouseEvent) => true,
+  },
+  setup(props, { attrs, emit, slots }) {
+    const locationHref = ref(typeof window === 'undefined' ? undefined : window.location.href);
+    const active = computed(() => isMicroAppLinkActive(props.to, locationHref.value));
+    let unsubscribe: (() => void) | undefined;
+
+    onMounted(() => {
+      const updateLocation = () => {
+        locationHref.value = window.location.href;
+      };
+      updateLocation();
+      unsubscribe = subscribeToMicroAppLinkLocation(updateLocation);
+    });
+    onBeforeUnmount(() => unsubscribe?.());
+
+    const onClick = (event: MouseEvent) => {
+      emit('click', event);
+      if (event.currentTarget instanceof HTMLAnchorElement) {
+        navigateMicroAppLink(event, event.currentTarget, props.replace);
+      }
+    };
+
+    return () =>
+      h(
+        'a',
+        {
+          ...attrs,
+          href: props.to,
+          class: [attrs.class, props.className, active.value && props.activeClassName],
+          onClick,
+        },
+        slots.default?.(),
+      );
+  },
+});

--- a/packages/ui-bindings/vue/src/__tests__/MicroAppLink.test.ts
+++ b/packages/ui-bindings/vue/src/__tests__/MicroAppLink.test.ts
@@ -1,0 +1,268 @@
+/**
+ * @vitest-environment happy-dom
+ * @vitest-environment-options {"settings":{"navigation":{"disableMainFrameNavigation":true,"disableChildFrameNavigation":true,"disableChildPageNavigation":true}}}
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp, h, nextTick, ref, type App } from 'vue';
+import { navigateToUrl } from 'qiankun';
+import { MicroAppLink, type MicroAppLinkProps } from '../index';
+
+vi.mock('qiankun', () => ({ loadMicroApp: vi.fn(), navigateToUrl: vi.fn() }));
+
+describe('MicroAppLink', () => {
+  let host: HTMLDivElement;
+  let app: App | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Native anchor behavior changes happy-dom's URL even with network navigation disabled.
+    (window as unknown as { happyDOM: { setURL(url: string): void } }).happyDOM.setURL('http://localhost:3000/');
+    window.history.replaceState(null, '', '/');
+    host = document.createElement('div');
+    document.body.appendChild(host);
+  });
+
+  afterEach(() => {
+    app?.unmount();
+    app = undefined;
+    host.remove();
+    vi.restoreAllMocks();
+  });
+
+  const mount = (props: Partial<MicroAppLinkProps> = {}) => {
+    app = createApp({
+      render: () => h(MicroAppLink, { to: '/app1/foo', ...props }, { default: () => h('span', 'Open micro app') }),
+    });
+    app.mount(host);
+    return host.querySelector('a')!;
+  };
+
+  const click = (anchor: HTMLAnchorElement, init: MouseEventInit = {}) => {
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, ...init });
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+    anchor.dispatchEvent(event);
+    return { event, preventDefault };
+  };
+
+  it('renders an anchor with its default slot and anchor attributes', () => {
+    const props: InstanceType<typeof MicroAppLink>['$props'] = {
+      to: '/app1/foo',
+      className: 'link',
+      class: 'custom',
+      title: 'Application',
+      target: '_self',
+      rel: 'bookmark',
+      onClick: vi.fn(),
+      'aria-label': 'Open app',
+    };
+    const anchor = mount(props);
+
+    expect(anchor.getAttribute('href')).toBe('/app1/foo');
+    expect(anchor.querySelector('span')?.textContent).toBe('Open micro app');
+    expect(anchor.className).toBe('custom link');
+    expect(anchor.title).toBe('Application');
+    expect(anchor.getAttribute('aria-label')).toBe('Open app');
+    expect(anchor.target).toBe('_self');
+    expect(anchor.rel).toBe('bookmark');
+    expect(anchor.hasAttribute('to')).toBe(false);
+    expect(anchor.hasAttribute('replace')).toBe(false);
+    expect(anchor.hasAttribute('activeclassname')).toBe(false);
+  });
+
+  it('prevents default and navigates an ordinary left click after calling the user handler once', () => {
+    const onClick = vi.fn((event: MouseEvent) => {
+      expect(event.defaultPrevented).toBe(false);
+      expect(navigateToUrl).not.toHaveBeenCalled();
+    });
+    const anchor = mount({ onClick });
+    const { event, preventDefault } = click(anchor);
+
+    expect(onClick).toHaveBeenCalledExactlyOnceWith(event);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(event.defaultPrevented).toBe(true);
+    expect(navigateToUrl).toHaveBeenCalledExactlyOnceWith(anchor.href);
+  });
+
+  it('lets the user handler cancel navigation', () => {
+    const onClick = vi.fn((event: MouseEvent) => event.preventDefault());
+    const anchor = mount({ onClick });
+    const { event, preventDefault } = click(anchor);
+
+    expect(onClick).toHaveBeenCalledExactlyOnceWith(event);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(navigateToUrl).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate an event that was already prevented', () => {
+    const anchor = mount();
+    const event = new MouseEvent('click', { cancelable: true });
+    event.preventDefault();
+    anchor.dispatchEvent(event);
+
+    expect(navigateToUrl).not.toHaveBeenCalled();
+  });
+
+  it.each<MouseEventInit>([
+    { button: 1 },
+    { button: 2 },
+    { metaKey: true },
+    { ctrlKey: true },
+    { altKey: true },
+    { shiftKey: true },
+  ])('preserves native behavior for mouse options %j', (options) => {
+    const { preventDefault } = click(mount(), options);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(navigateToUrl).not.toHaveBeenCalled();
+  });
+
+  it.each(['https://external.example/app', '//external.example/app', 'mailto:hello@example.com'])(
+    'preserves native behavior for external destination %s',
+    (to) => {
+      const { preventDefault } = click(mount({ to }));
+
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(navigateToUrl).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['_blank', '_parent', 'named-frame'])('preserves native behavior for target %s', (target) => {
+    const { preventDefault } = click(mount({ target }));
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(navigateToUrl).not.toHaveBeenCalled();
+  });
+
+  it('navigates links targeting the current browsing context', () => {
+    const anchor = mount({ target: '_self' });
+    const { preventDefault } = click(anchor);
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(navigateToUrl).toHaveBeenCalledExactlyOnceWith(anchor.href);
+  });
+
+  it('preserves native download behavior', () => {
+    const { preventDefault } = click(mount({ download: 'export.html' }));
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(navigateToUrl).not.toHaveBeenCalled();
+  });
+
+  it('replaces the current history entry and emits popstate', () => {
+    window.history.replaceState({ retained: true }, '', '/before');
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+    const onPopState = vi.fn();
+    window.addEventListener('popstate', onPopState);
+    try {
+      const anchor = mount({ replace: true });
+      const { preventDefault } = click(anchor);
+
+      expect(preventDefault).toHaveBeenCalledOnce();
+      expect(replaceState).toHaveBeenCalledExactlyOnceWith({ retained: true }, '', anchor.href);
+      expect(window.location.pathname).toBe('/app1/foo');
+      expect(onPopState).toHaveBeenCalledOnce();
+      expect(navigateToUrl).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('popstate', onPopState);
+    }
+  });
+
+  it.each(['popstate', 'hashchange', 'single-spa:routing-event'])(
+    'updates its active class after %s',
+    async (eventName) => {
+      const anchor = mount({ to: '/app1', className: 'link', activeClassName: 'active' });
+      expect(anchor.className).toBe('link');
+
+      window.history.replaceState(null, '', '/app1/foo');
+      window.dispatchEvent(new Event(eventName));
+      await nextTick();
+      expect(anchor.className).toBe('link active');
+
+      window.history.replaceState(null, '', '/app2');
+      window.dispatchEvent(new Event(eventName));
+      await nextTick();
+      expect(anchor.className).toBe('link');
+    },
+  );
+
+  it('updates the active class when the destination prop changes', async () => {
+    window.history.replaceState(null, '', '/app1/foo');
+    const to = ref('/app1');
+    app = createApp({ render: () => h(MicroAppLink, { to: to.value, activeClassName: 'active' }) });
+    app.mount(host);
+    const anchor = host.querySelector('a')!;
+    expect(anchor.className).toBe('active');
+
+    to.value = '/app2';
+    await nextTick();
+    expect(anchor.className).toBe('');
+    expect(anchor.getAttribute('href')).toBe('/app2');
+  });
+
+  it('updates active links when the navigation routing event arrives', async () => {
+    vi.mocked(navigateToUrl).mockImplementationOnce((url) => {
+      if (typeof url === 'string') {
+        window.history.pushState(null, '', url);
+      }
+    });
+    const anchor = mount({ activeClassName: 'active' });
+    click(anchor);
+    await nextTick();
+
+    expect(window.location.pathname).toBe('/app1/foo');
+    expect(anchor.className).toBe('');
+
+    window.dispatchEvent(new Event('single-spa:routing-event'));
+    await nextTick();
+    expect(anchor.className).toBe('active');
+  });
+
+  it('preserves the original active link when navigation is silently canceled', async () => {
+    window.history.replaceState(null, '', '/before');
+    vi.mocked(navigateToUrl).mockImplementationOnce((url) => {
+      if (typeof url === 'string') {
+        window.history.pushState(null, '', url);
+      }
+    });
+    app = createApp({
+      render: () =>
+        h('nav', [
+          h(MicroAppLink, { to: '/before', activeClassName: 'active' }),
+          h(MicroAppLink, { to: '/app1/foo', activeClassName: 'active' }),
+        ]),
+    });
+    app.mount(host);
+    const [original, destination] = host.querySelectorAll('a');
+    expect(original.className).toBe('active');
+    expect(destination.className).toBe('');
+
+    click(destination);
+    await nextTick();
+    expect(window.location.pathname).toBe('/app1/foo');
+    expect(original.className).toBe('active');
+    expect(destination.className).toBe('');
+
+    // single-spa restores canceled navigation without dispatching a routing event.
+    window.history.replaceState(null, '', '/before');
+    await nextTick();
+    expect(original.className).toBe('active');
+    expect(destination.className).toBe('');
+  });
+
+  it('removes location listeners when unmounted', () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+    const removeEventListener = vi.spyOn(window, 'removeEventListener');
+    mount({ activeClassName: 'active' });
+    const locationSubscriptions = addEventListener.mock.calls.filter(([name]) =>
+      ['popstate', 'hashchange', 'single-spa:routing-event'].includes(name),
+    );
+    expect(locationSubscriptions).toHaveLength(3);
+
+    app?.unmount();
+    app = undefined;
+
+    for (const [name, listener] of locationSubscriptions) {
+      expect(removeEventListener).toHaveBeenCalledWith(name, listener);
+    }
+  });
+});

--- a/packages/ui-bindings/vue/src/index.ts
+++ b/packages/ui-bindings/vue/src/index.ts
@@ -1,1 +1,2 @@
 export * from './MicroApp';
+export { MicroAppLink, type MicroAppLinkProps } from './MicroAppLink';


### PR DESCRIPTION
## 做了什么

为 `@qiankunjs/react` 和 `@qiankunjs/vue` 新增 `MicroAppLink` 及 `MicroAppLinkProps`。组件渲染原生链接，通过 qiankun 新导出的 `navigateToUrl` 切换主应用路由，支持替换历史记录、地址前缀高亮，以及 React ref / Vue 默认插槽。

两个示例 shell 的首页、侧栏和应用卡片均使用新组件，并在渲染前调用 `start()`，确保首页首次点击即可触发路由更新。补充中英文组件文档。

## 为什么

`registerMicroApps` 路由模式需要可复用的框架导航组件，避免各主应用重复编写点击拦截和历史记录处理。组件保留修饰键、新窗口、下载、外链和调用方取消点击的原生行为。替换历史记录只通知一次 `popstate`；活动类名等待路由通知更新，避免取消导航后残留错误高亮。

## 如何验证

- `pnpm run eslint`、`pnpm run prettier:check` 通过。
- React / Vue / ui-shared 单测分别为 39 / 34 / 24 项，全部通过，包含 71 项新增测试。
- `pnpm run build`（包含示例）和 `pnpm run docs:build` 通过。
- 构建 e2e fixtures 后运行 Chromium `router-mode.spec.ts`，4 项通过。
- 启动 `pnpm run start:example` 后使用 Playwright 验证两个 shell：React、Vue、Webpack、Pure HTML 切换，前进、后退和首页卸载；每个 shell 全程只有一次页面文档请求，无页面脚本错误。
- 在两个运行中的 shell 内分别挂载真实 React / Vue 链接并注册 classic / ESM 微应用，验证路由挂载与卸载、replace 历史长度不变且只触发一次 popstate，以及取消导航后的 URL 和高亮回退。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
