### PR TITLE
perf(esm-sandbox): isolate module source fetch cache

### DIFF
--- a/docs/internals/esm-sandbox.md
+++ b/docs/internals/esm-sandbox.md
@@ -44,7 +44,7 @@ flowchart TD
   E --> F["native import(blobUrl) in document order"]
 ```
 
-1. **Fetch** the module through the decorated `fetch` (cacheable → retryable → throwable).
+1. **Fetch** the module through a separate response cache configured by `loadApp` (cacheable → retryable → throwable). Module sources do not consume the cache capacity reserved for HTML entries, Classic scripts, and styles.
 2. **Scan** it with [`es-module-lexer`](https://github.com/guybedford/es-module-lexer), a WASM lexer warmed once at `start()` time via `prepareEsmLexer()`.
 3. **Rewrite** the source so that:
    - references to sandboxed globals are destructured from the membrane view at the top of the module (`const { window, document, … } = __qk_view`);
@@ -120,6 +120,12 @@ Vite serves CSS as JS modules that inject styles at the module top level. Becaus
 :::
 
 ## Lifecycle and caching
+
+`loadApp` uses separate LRU response caches: 512 entries for module sources and the existing 50 entries for HTML entries, Classic scripts, and styles. Both key requests by canonical URL and effective `credentials`, cache in-flight Promises, clone responses for each reader, and discard failed responses.
+
+Application instances within one qiankun runtime copy share the module response cache. It lasts for the runtime's lifetime and is not cleared by an individual instance's `dispose()`, allowing new instances to reuse source responses without a typical 270-module Vite development graph evicting HTML entries and styles. The 512-entry limit bounds the number of responses, not their total bytes; least recently used entries are evicted at capacity. When using `createSandbox` or `Compartment` directly, response caching depends on the caller-provided `fetch`; `createSandbox` also accepts `moduleFetch` to configure module-source requests separately.
+
+The engine still owns each instance's descriptors, rewritten modules, and namespaces separately; membrane views are never shared across instances. The instance module graph is not limited to 512 entries. `dispose()` releases the instance caches and blob URLs.
 
 The ESM sandbox retains its module graph across mount/unmount, which changes one important assumption compared with the classic sandbox:
 

--- a/docs/rfcs/esm-sandbox.md
+++ b/docs/rfcs/esm-sandbox.md
@@ -73,7 +73,7 @@ qiankun 当前的 JS 沙箱实现基于 classic script 执行模型：
     │     的双取问题（见 §10.1）。
     │
     ├─ ESM transpiler (packages/shared/src/assets-transpilers/module.ts, 新增) 流水线（per module）
-    │   ├─ fetch 源码（走全局 LRU cache，引用计数 +1）
+    │   ├─ fetch 源码（走独立的模块响应 LRU，容量 512）
     │   ├─ es-module-lexer 扫描 imports / exports / import.meta / dynamic import()
     │   ├─ 标识符扫描过滤：单遍 token 扫描 ∩ globalsInBrowser，再剔除模块自声明/导入重名（见 §1）
     │   ├─ 顶部注入 globals 与 import.meta（经 per-instance runtime 模块 import 引导，零 eval、无 TDZ，见 §1）：
@@ -481,7 +481,7 @@ return {
 | remount | **复用同一个 blob URL** | 命中复用 | 重新激活 |
 | unload | 引用计数 -1，归零则 `revokeObjectURL` | 不动（全局 LRU 自管理） | GC |
 
-blob URL 缓存 key 必须包含 instanceId；fetch LRU 可以继续按原始 URL 复用响应体。这样同一子应用的同一实例 remount 可复用 module namespace，而 unload 后重新加载会获得新的实例前缀与 blob URL，避免命中已退休的全局 import map 条目。
+blob URL 缓存 key 必须包含 instanceId；模块响应 LRU 按原始 URL 与 credentials 复用响应体，容量为 512，与入口和样式的 50 条 LRU 分离。这样同一子应用的同一实例 remount 可复用 module namespace，而 unload 后重新加载会获得新的实例前缀与 blob URL，避免命中已退休的全局 import map 条目。
 
 > **不变量（需显式声明）**：remount = **同 instanceId、复用同一 blob、不注入新 import map 条目**；unload→reload = **分配新 instanceId、新 blob、新条目**。Acceptance 的「100 次循环」必须明确是 remount（不含 unload），否则会被误读为 reload 级膨胀（见 Acceptance / §11）。
 
@@ -598,6 +598,10 @@ qiankun 用全局单变量 `nativeGlobal.__currentLockingSandbox__` 把 `documen
 ```
 
 > 注意两实例的 vue 条目指向**各自的** blob——v1 是 source 级共享：fetch 响应经 LRU 只取一次，但改写产物与 module namespace 不共享（见上方第 4 点）。`__qk_shared__/...` 形式的稳定 key 条目仅在 v2 引入 namespace 级共享后才会出现。
+
+**模块源码响应缓存（Q4 已解决）**
+
+`loadApp` 从同一份 retryable → throwable fetch 分别装配两条缓存路径：模块源码使用独立的 512 条 LRU，入口、Classic 脚本和样式继续使用 50 条 LRU。两者不相互占用容量；源码响应按 URL 与 credentials 在同一运行时副本内共享，`dispose()` 不清空共享缓存。保留全局共享而非增加实例内响应缓存，是因为引擎已有 descriptor/module Promise 缓存，实例内不会因 LRU 淘汰而再次下载已加载模块；需要解决的是跨实例复用与入口、样式被大模块图挤出的开销。实例销毁仍释放自身改写产物、模块图和 Realm。直接使用 sandbox/Compartment 的调用方仍决定其 fetch 是否缓存。
 
 **浏览器兼容性**
 
@@ -979,7 +983,7 @@ loadMicroApp(
 1. **`__qk_import_meta.resolve` 是否需要支持 fallback 到浏览器原生 `import.meta.resolve`？** —— 后者要求 baseURL 必须是当前模块 URL，但 qiankun 内部已用 blob URL 加载，原生 resolve 可能给出 blob URL。倾向：完全自实现，不 fallback。
 2. **是否提供 `disableEsmSandbox` 全局开关用于排查？** —— 倾向：是，作为 escape hatch。
 3. **Vite HMR 是否支持？** —— v1 范围外。Vite HMR 走 WebSocket + 模块热替换，与本方案的"复用 blob URL"语义直接冲突。需要单独 RFC。v1 提供 `import.meta.hot` noop stub 保证不报错（见 §13）。
-4. **全局 fetch LRU 缓存容量是否足够？** —— `makeFetchCacheable` 当前全局 LRU 容量为 50。**单个**中等规模 Vite dev 子应用即有 ~270 模块，**已远超 50**——不必等「多应用并发」就会频繁淘汰（原表述把风险归因于多应用并发，定位偏了）。§17 的依赖图级 prefetch 会进一步加压。选项：(a) 为 ESM 模块 fetch 使用独立的更大缓存（按子应用模块量级，如 ≥512）；(b) 提高全局 LRU 容量；(c) v1 先观察命中率。倾向 **(a)**（独立大缓存），而非沿用 50。
+4. **全局 fetch LRU 缓存容量是否足够？** —— **已解决，采用 (a) 独立模块缓存**：`loadApp` 将模块源码请求与入口、Classic 脚本和样式请求分流，前者使用容量 512 的 LRU，后者保留容量 50。两个缓存都按规范化 URL 与实际生效的 credentials 分区。模块响应缓存由同一运行时副本共享，不随某个引擎销毁而清空，以保留跨实例源码复用；只缓存响应，不共享改写产物或隔离膜。引擎自身的模块图仍按实例保存并在 `dispose()` 时释放，不受 LRU 容量限制。约 270 个模块的应用跨实例加载可复用全部源码，也不会挤出入口和样式。512 是条目数上限而非字节上限，更大或多个应用的工作集仍可能发生淘汰。§17 的依赖图级 prefetch 不包含在本次改动中。
 5. **§12 集成架构方案选择（v1 阻塞决策，不可挂起）** —— 方案 C（移除 + 异步插入）需 POC 验证在 writable-dom 流式管线中的可行性。**修正**：多个动态插入的 module script **设 `async=false` 即由 HTML 规范保证按插入序执行**（与 classic 同机制，option B/C 均适用），并非 C 独有优势；option B 因此不应被「需验证是否在所有浏览器触发执行」低估。真正待验证的是占位/重插与 entry-script onload 钩子、defer 队列的交互。**此项必须在实现前定稿**。
 6. **`loadMicroApp` 多实例是否在 v1 scope 内？** —— 同一子应用加载两次时，不同实例通过 **实例唯一 specifier 前缀** 实现在全局 import map 中的隔离。
 7. **realm 访问器的安全性（v1 已实现，结论较第二轮修正）** —— 第二轮曾定为「membrane get-trap 黑名单屏蔽 `__qk_*`」+ 固定单例 `__qk_realm`。**code review 推翻了「屏蔽足够」**：改写模块跑在真实全局作用域，裸 `__qk_realm(...)` 直达真实全局、**不经 proxy**，屏蔽只挡 `globalThis.__qk_realm`；且 `createMembraneTarget` 拷贝 non-configurable 全局属性会让屏蔽从第二个应用起失效。**v1 最终方案**：访问器改为**每副本随机 key** `globalThis['__qk_r_<random>']` + 按**不可猜 token** 索引（token 仅内联在该实例 runtime blob 源码里，改写器拒绝业务代码 import `__qk_*` specifier）——即便拿到真全局也无从命名访问器、无从提供他人 token。membrane 屏蔽保留为纵深（且 `createMembraneTarget` 不再拷贝 `__qk_*`，复用 `esmInternalPrefix` 单一常量）。详见 §1「安全（v1 实现）」。随机 key 每副本私有，顺带解决多 qiankun 副本抢占单例崩溃。

--- a/docs/zh-CN/internals/esm-sandbox.md
+++ b/docs/zh-CN/internals/esm-sandbox.md
@@ -44,7 +44,7 @@ flowchart TD
 
 处理步骤如下：
 
-1. **获取源码**：通过增强后的 fetch 获取模块。装饰器顺序为 cacheable → retryable → throwable。
+1. **获取源码**：`loadApp` 为模块配置独立的响应缓存，装饰器顺序为 cacheable → retryable → throwable。模块源码不占用入口、Classic 脚本和样式的缓存容量。
 2. **扫描模块**：使用 [`es-module-lexer`](https://github.com/guybedford/es-module-lexer) 分析源码。该 WASM 词法分析器会在 `start()` 期间通过 `prepareEsmLexer()` 预初始化。
 3. **改写源码**：
    - 将受沙箱管理的全局属性在模块顶部从隔离膜视图中解构，例如 `const { window, document, … } = __qk_view`；
@@ -126,6 +126,12 @@ Vite 将 CSS 作为 JavaScript 模块加载，并在模块顶层注入样式。�
 :::
 
 ## 生命周期与缓存
+
+`loadApp` 分别为模块源码与其他资源配置 LRU 响应缓存：模块缓存容量为 512 条，入口、Classic 脚本和样式共用的缓存容量仍为 50 条。两者均按规范化 URL 与实际生效的 `credentials` 区分请求，缓存请求中的 Promise，读取时克隆响应，失败响应不保留。
+
+模块响应缓存由同一份 qiankun 运行时的应用实例共享，生命周期随运行时，不在某个实例的 `dispose()` 中清空。这可以让新实例复用原始源码，同时避免约 270 个模块的 Vite 开发应用挤出入口和样式。512 是条目数量上限，不是字节上限；超过容量时按最近最少使用顺序淘汰。独立使用 `createSandbox` 或 `Compartment` 时，响应缓存由调用方提供的 `fetch` 决定；`createSandbox` 还可通过 `moduleFetch` 单独配置模块源码请求。
+
+引擎仍为每个实例单独保存模块描述符、改写产物和命名空间，不跨实例共享隔离膜视图。实例内模块图不受响应缓存的 512 条容量限制，`dispose()` 会释放实例缓存与 blob URL。
 
 ESM 沙箱会在挂载和卸载之间保留模块图：
 

--- a/packages/qiankun/src/core/__tests__/loadApp.test.ts
+++ b/packages/qiankun/src/core/__tests__/loadApp.test.ts
@@ -192,6 +192,42 @@ describe('loadApp sandbox cleanup', () => {
     );
   });
 
+  it('reuses a 270-module graph across disposed instances without evicting entry or stylesheet responses', async () => {
+    const baseUrl = 'https://module-cache.test/';
+    const entry = `${baseUrl}index.html`;
+    const stylesheet = `${baseUrl}style.css`;
+    const moduleUrls = Array.from({ length: 270 }, (_, i) => `${baseUrl}${i}.js`);
+    const graph = moduleUrls
+      .slice(1)
+      .map((url) => `import '${url}';`)
+      .join('\n');
+    const fetch = vi.fn(
+      async (input: RequestInfo | URL) =>
+        new Response(String(input) === moduleUrls[0] ? graph : 'export {};', { status: 200 }),
+    );
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:module-cache-test');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    mocks.createSandbox.mockImplementation(createRealSandbox);
+    mocks.loadEntry.mockImplementation(async (_entry: string, _container: HTMLElement, opts: LoaderOpts) => {
+      if (!opts.fetch || !opts.compartment) throw new Error('missing loader inputs');
+      await Promise.all([opts.fetch(entry), opts.fetch(stylesheet)]);
+      await opts.compartment.load(moduleUrls[0]);
+      return validLifecycles;
+    });
+
+    for (let instance = 0; instance < 2; instance++) {
+      const container = document.createElement('div');
+      const getParcelConfig = await loadApp({ ...createApp(container), entry }, { fetch });
+      await getParcelConfig(container).unload[0]();
+    }
+
+    // The second instance still links its own graph, but performs no new downloads.
+    expect(fetch).toHaveBeenCalledTimes(272);
+    for (const url of [entry, stylesheet, ...moduleUrls]) {
+      expect(fetch.mock.calls.filter(([input]) => String(input) === url)).toHaveLength(1);
+    }
+  });
+
   it('marks sandbox-less streamed nodes for native passthrough', async () => {
     let streamedNodeTransformer: LoaderOpts['nodeTransformer'];
     mocks.loadEntry.mockImplementationOnce((_entry: unknown, _container: HTMLElement, opts: LoaderOpts) => {

--- a/packages/qiankun/src/core/loadApp.ts
+++ b/packages/qiankun/src/core/loadApp.ts
@@ -70,7 +70,8 @@ export default async function loadApp<T extends ObjectType>(
     ...compartmentHooks
   } = sandboxConfiguration;
 
-  const enhancedFetch = makeFetchCacheable(makeFetchRetryable(makeFetchThrowable(fetch)));
+  const resourceFetch = makeFetchRetryable(makeFetchThrowable(fetch));
+  const enhancedFetch = makeFetchCacheable(resourceFetch);
 
   const markName = `[qiankun] App ${appName} Loading`;
   if (process.env.NODE_ENV === 'development') {
@@ -141,6 +142,7 @@ export default async function loadApp<T extends ObjectType>(
         globals,
         incubatorContext,
         fetch: enhancedFetch,
+        moduleFetch: makeFetchCacheable(resourceFetch, 'modules'),
         nodeTransformer,
         plugins,
         styleIsolation: styleIsolationEnabled,

--- a/packages/sandbox/src/core/sandbox/__tests__/index.test.ts
+++ b/packages/sandbox/src/core/sandbox/__tests__/index.test.ts
@@ -84,6 +84,33 @@ describe('isolation plugin lifecycle', () => {
     await controller.unmount();
   });
 
+  it.each([false, true])('selects the module fetch separately when explicitly configured: %s', async (separate) => {
+    const assetFetch = vi.fn(async () => new Response('export {};'));
+    const moduleFetch = vi.fn(async () => new Response('export {};'));
+    const controller = createSandbox(`module-fetch-${String(appSequence++)}`, {
+      fetch: assetFetch,
+      moduleFetch: separate ? moduleFetch : undefined,
+      compartmentOptions: {
+        moduleHost: {
+          entryUrl: 'https://module-fetch.test/',
+          createModuleUrl: () => 'blob:module-fetch-test',
+          revokeModuleUrl: () => {},
+        },
+      },
+      nodeTransformer: (node, options) => {
+        expect(options.fetch).toBe(assetFetch);
+        return node;
+      },
+    });
+    createdCompartments.push(controller.instance);
+    controller.nodeTransformer(document.createElement('script'), { fetch: assetFetch });
+    await controller.instance.load('./module.js');
+
+    expect(separate ? moduleFetch : assetFetch).toHaveBeenCalledOnce();
+    expect(separate ? assetFetch : moduleFetch).not.toHaveBeenCalled();
+    await controller.dispose();
+  });
+
   it('awaits async mount hooks sequentially', async () => {
     const events: string[] = [];
     let resolveFirstMount: (free: Free) => void = () => {

--- a/packages/sandbox/src/core/sandbox/index.ts
+++ b/packages/sandbox/src/core/sandbox/index.ts
@@ -51,6 +51,8 @@ export interface CreateSandboxOptions {
    */
   styleIsolation?: boolean;
   fetch?: typeof window.fetch;
+  /** Optional module-source transport; defaults to the shared asset fetch above. */
+  moduleFetch?: typeof window.fetch;
   nodeTransformer?: NodeTransformer;
   /**
    * Lower-level Compartment host configuration. Promoted top-level options take
@@ -121,6 +123,7 @@ export function createSandbox(appName: string, opts: CreateSandboxOptions = {}):
     compartmentOptions = {},
     container: containerOption,
     fetch: configuredFetch,
+    moduleFetch,
     globals = {},
     importHook: topLevelImportHook,
     incubatorContext = nativeGlobal,
@@ -191,7 +194,7 @@ export function createSandbox(appName: string, opts: CreateSandboxOptions = {}):
     resolveHook,
     moduleHost: {
       ...compartmentOptions.moduleHost,
-      fetch,
+      fetch: moduleFetch ?? fetch,
     },
   };
 

--- a/packages/shared/src/fetch-utils/__tests__/makeFetchCacheable.test.ts
+++ b/packages/shared/src/fetch-utils/__tests__/makeFetchCacheable.test.ts
@@ -1,102 +1,180 @@
 // @vitest-environment edge-runtime
 
-import { expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { makeFetchCacheable } from '../makeFetchCacheable';
 
 const slogan = 'Hello Qiankun 3.0';
 
-it('should just call fetch once while multiple request invoked parallel', () => {
-  const fetch = vi.fn(() => {
-    return Promise.resolve(new Response(slogan, { status: 200, statusText: 'OK' }));
+describe.each(['assets', 'modules'] as const)('%s cache', (cacheScope) => {
+  it('should just call fetch once while multiple request invoked parallel', () => {
+    const fetch = vi.fn(() => {
+      return Promise.resolve(new Response(slogan, { status: 200, statusText: 'OK' }));
+    });
+    const wrappedFetch = makeFetchCacheable(fetch, cacheScope);
+    const url = 'https://success.qiankun.org';
+    wrappedFetch(url);
+    wrappedFetch(url);
+    wrappedFetch(url);
+
+    expect(fetch).toHaveBeenCalledOnce();
   });
-  const wrappedFetch = makeFetchCacheable(fetch);
-  const url = 'https://success.qiankun.org';
-  wrappedFetch(url);
-  wrappedFetch(url);
-  wrappedFetch(url);
+
+  it('should cache by the canonical URL and effective credentials', () => {
+    const fetch = vi.fn(() => {
+      return Promise.resolve(new Response(slogan, { status: 200, statusText: 'OK' }));
+    });
+    const wrappedFetch = makeFetchCacheable(fetch, cacheScope);
+    const url = 'https://canonical-credentials.qiankun.org';
+
+    wrappedFetch(url);
+    wrappedFetch(new URL(`${url}/`), { credentials: 'same-origin' });
+    wrappedFetch(new Request(`${url}/`));
+    wrappedFetch(url, { credentials: 'include' });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('should let init credentials override Request credentials', () => {
+    const fetch = vi.fn(() => {
+      return Promise.resolve(new Response(slogan, { status: 200, statusText: 'OK' }));
+    });
+    const wrappedFetch = makeFetchCacheable(fetch, cacheScope);
+    const url = 'https://request-credentials.qiankun.org/';
+
+    wrappedFetch(new Request(url, { credentials: 'include' }), {
+      credentials: 'omit',
+    });
+    wrappedFetch(new Request(url, { credentials: 'omit' }));
+    wrappedFetch(new Request(url, { credentials: 'include' }));
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('should support read response body as a stream multi times', async () => {
+    const fetch = vi.fn(() => {
+      return Promise.resolve(new Response(slogan, { status: 200, statusText: 'OK' }));
+    });
+    const wrappedFetch = makeFetchCacheable(fetch, cacheScope);
+
+    const url = 'https://stream.qiankun.org';
+    const response1 = await wrappedFetch(url);
+    const bodyStream1 = response1.body!;
+    expect(bodyStream1.locked).toBe(false);
+    const reader = bodyStream1.getReader();
+    const { done, value } = await reader.read();
+    expect(done).toBe(false);
+    expect(value).toStrictEqual(new TextEncoder().encode('Hello Qiankun 3.0'));
+    expect(bodyStream1.locked).toBe(true);
+
+    const response2 = await wrappedFetch(url);
+    const bodyStream2 = response2.body!;
+    expect(bodyStream2.locked).toBe(false);
+  });
+
+  it('should clear cache while respond error with invalid status code', async () => {
+    const fetch = vi.fn(() => {
+      return Promise.resolve(new Response(slogan, { status: 400 }));
+    });
+    const wrappedFetch = makeFetchCacheable(fetch, cacheScope);
+    const url = 'https://errorStatusCode.qiankun.org';
+
+    const response1 = await wrappedFetch(url);
+    const result1 = await response1.text();
+    expect(result1).toBe(slogan);
+
+    const response2 = await wrappedFetch(url);
+    const result2 = await response2.text();
+    expect(result2).toBe(slogan);
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('should clear cache while respond error', async () => {
+    const fetch = vi.fn(() => {
+      return Promise.reject(new Error('error'));
+    });
+    const wrappedFetch = makeFetchCacheable(fetch, cacheScope);
+
+    const url = 'https://error.qiankun.org';
+    await expect(wrappedFetch(url)).rejects.toThrow('error');
+    await expect(wrappedFetch(url)).rejects.toThrow('error');
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+it('uses the shared asset cache by default', async () => {
+  const fetch = vi.fn(() => Promise.resolve(new Response(slogan)));
+  const defaultFetch = makeFetchCacheable(fetch);
+  const assetFetch = makeFetchCacheable(fetch, 'assets');
+  const url = 'https://default-assets.qiankun.org/entry.html';
+
+  await defaultFetch(url);
+  await assetFetch(url);
 
   expect(fetch).toHaveBeenCalledOnce();
 });
 
-it('should cache by the canonical URL and effective credentials', () => {
-  const fetch = vi.fn(() => {
-    return Promise.resolve(new Response(slogan, { status: 200, statusText: 'OK' }));
-  });
-  const wrappedFetch = makeFetchCacheable(fetch);
-  const url = 'https://canonical-credentials.qiankun.org';
+it('reuses a 270-module graph across wrappers without evicting entry HTML or styles', async () => {
+  const fetch = vi.fn(() => Promise.resolve(new Response(slogan)));
+  const assetFetch = makeFetchCacheable(fetch);
+  const firstModuleFetch = makeFetchCacheable(fetch, 'modules');
+  const nextModuleFetch = makeFetchCacheable(fetch, 'modules');
+  const entryUrl = 'https://large-graph.qiankun.org/entry.html';
+  const styleUrl = 'https://large-graph.qiankun.org/style.css';
+  const moduleUrls = Array.from({ length: 270 }, (_, index) => `https://large-graph.qiankun.org/${String(index)}.js`);
 
-  wrappedFetch(url);
-  wrappedFetch(new URL(`${url}/`), { credentials: 'same-origin' });
-  wrappedFetch(new Request(`${url}/`));
-  wrappedFetch(url, { credentials: 'include' });
+  await assetFetch(entryUrl);
+  await assetFetch(styleUrl);
+  for (const moduleFetch of [firstModuleFetch, nextModuleFetch]) {
+    await Promise.all(
+      moduleUrls.map(async (url) => {
+        const response = await moduleFetch(url);
+        expect(await response.text()).toBe(slogan);
+      }),
+    );
+  }
+  await assetFetch(entryUrl);
+  await assetFetch(styleUrl);
 
-  expect(fetch).toHaveBeenCalledTimes(2);
+  expect(fetch).toHaveBeenCalledTimes(272);
 });
 
-it('should let init credentials override Request credentials', () => {
-  const fetch = vi.fn(() => {
-    return Promise.resolve(new Response(slogan, { status: 200, statusText: 'OK' }));
-  });
-  const wrappedFetch = makeFetchCacheable(fetch);
-  const url = 'https://request-credentials.qiankun.org/';
+it('does not let asset requests evict module responses or share a cache entry with them', async () => {
+  const fetch = vi.fn(() => Promise.resolve(new Response(slogan)));
+  const assetFetch = makeFetchCacheable(fetch);
+  const moduleFetch = makeFetchCacheable(fetch, 'modules');
+  const moduleUrl = 'https://asset-pressure.qiankun.org/module.js';
 
-  wrappedFetch(new Request(url, { credentials: 'include' }), {
-    credentials: 'omit',
-  });
-  wrappedFetch(new Request(url, { credentials: 'omit' }));
-  wrappedFetch(new Request(url, { credentials: 'include' }));
-
+  await moduleFetch(moduleUrl);
+  await assetFetch(moduleUrl);
   expect(fetch).toHaveBeenCalledTimes(2);
+
+  await Promise.all(
+    Array.from({ length: 60 }, (_, index) => assetFetch(`https://asset-pressure.qiankun.org/${String(index)}.css`)),
+  );
+  await moduleFetch(moduleUrl);
+
+  expect(fetch).toHaveBeenCalledTimes(62);
 });
 
-it('should support read response body as a stream multi times', async () => {
-  const fetch = vi.fn(() => {
-    return Promise.resolve(new Response(slogan, { status: 200, statusText: 'OK' }));
-  });
-  const wrappedFetch = makeFetchCacheable(fetch);
+it.each([
+  ['assets', 50],
+  ['modules', 512],
+] as const)('bounds the %s cache at %i entries and retains recently used responses', async (cacheScope, capacity) => {
+  const fetch = vi.fn(() => Promise.resolve(new Response(slogan)));
+  const cachedFetch = makeFetchCacheable(fetch, cacheScope);
+  const urls = Array.from(
+    { length: capacity + 1 },
+    (_, index) => `https://cache-capacity.qiankun.org/${String(index)}.js`,
+  );
 
-  const url = 'https://stream.qiankun.org';
-  const response1 = await wrappedFetch(url);
-  const bodyStream1 = response1.body!;
-  expect(bodyStream1.locked).toBe(false);
-  const reader = bodyStream1.getReader();
-  const { done, value } = await reader.read();
-  expect(done).toBe(false);
-  expect(value).toStrictEqual(new TextEncoder().encode('Hello Qiankun 3.0'));
-  expect(bodyStream1.locked).toBe(true);
+  await Promise.all(urls.slice(0, capacity).map((url) => cachedFetch(url)));
+  await cachedFetch(urls[0]);
+  await cachedFetch(urls[capacity]);
+  await cachedFetch(urls[0]);
+  expect(fetch).toHaveBeenCalledTimes(capacity + 1);
 
-  const response2 = await wrappedFetch(url);
-  const bodyStream2 = response2.body!;
-  expect(bodyStream2.locked).toBe(false);
-});
-
-it('should clear cache while respond error with invalid status code', async () => {
-  const fetch = vi.fn(() => {
-    return Promise.resolve(new Response(slogan, { status: 400 }));
-  });
-  const wrappedFetch = makeFetchCacheable(fetch);
-  const url = 'https://errorStatusCode.qiankun.org';
-
-  const response1 = await wrappedFetch(url);
-  const result1 = await response1.text();
-  expect(result1).toBe(slogan);
-
-  const response2 = await wrappedFetch(url);
-  const result2 = await response2.text();
-  expect(result2).toBe(slogan);
-
-  expect(fetch).toHaveBeenCalledTimes(2);
-});
-
-it('should clear cache while respond error', async () => {
-  const fetch = vi.fn(() => {
-    return Promise.reject(new Error('error'));
-  });
-  const wrappedFetch = makeFetchCacheable(fetch);
-
-  const url = 'https://error.qiankun.org';
-  await expect(wrappedFetch(url)).rejects.toThrow('error');
-  await expect(wrappedFetch(url)).rejects.toThrow('error');
-
-  expect(fetch).toHaveBeenCalledTimes(2);
+  await cachedFetch(urls[1]);
+  expect(fetch).toHaveBeenCalledTimes(capacity + 2);
 });

--- a/packages/shared/src/fetch-utils/makeFetchCacheable.ts
+++ b/packages/shared/src/fetch-utils/makeFetchCacheable.ts
@@ -33,12 +33,23 @@ const getCacheKey = (input: Parameters<Fetch>[0], init?: Parameters<Fetch>[1]): 
   return JSON.stringify([getCanonicalRequestUrl(input), getEffectiveCredentials(input, init)]);
 };
 
-const getGlobalCache = once(() => {
+const getAssetCache = once(() => {
   return new LRUCache<string, Promise<Response>>(50);
 });
 
-export const makeFetchCacheable: (fetch: Fetch) => Fetch = (fetch) => {
-  const lruCache = getGlobalCache();
+// Keep module source responses separate from HTML, classic scripts, and styles:
+// a typical Vite development graph already exceeds the asset cache's 50 entries.
+// Both caches belong to this runtime copy, so new app instances can reuse source
+// responses without retaining another instance's rewritten modules or globals.
+const getModuleCache = once(() => {
+  return new LRUCache<string, Promise<Response>>(512);
+});
+
+export const makeFetchCacheable: (fetch: Fetch, cacheScope?: 'assets' | 'modules') => Fetch = (
+  fetch,
+  cacheScope = 'assets',
+) => {
+  const lruCache = cacheScope === 'modules' ? getModuleCache() : getAssetCache();
 
   const cachedFetch: Fetch = (input, init) => {
     const fetchInput = input;


### PR DESCRIPTION
约 270 个模块的 ESM 应用会挤满原来与入口、Classic 脚本和样式共用的 50 条 LRU，导致新实例重新下载模块，也挤出入口和样式响应。本次将模块源码分流到独立的 512 条 LRU，其他资源保留原容量。

模块缓存按 URL 与实际生效的 credentials 分区，存活实例之间共享原始响应；改写产物、命名空间和隔离膜仍按实例独立。`unload` 会使该应用用过的入口、样式和模块源码条目失效，再次加载时重新请求（由 #3204 实现）；未完成的下载只在没有其他所有者使用时取消。实例自己的模块图和 blob 仍由原生命周期释放。新增可选 moduleFetch 接入点，保留未配置时已有 fetch 的优先级和重试行为。中英文实现文档及 RFC Q4/§11 已同步。

验证：

- ESLint、Prettier 检查通过；shared 205、sandbox 74、qiankun 34 项单测通过。
- 真实 loadApp → Sandbox → Compartment → Engine 集成对照：同一 270 模块图由两个存活实例先后加载，共享 50 条缓存时为 544 次请求，修复后为 272 次；断言完成后再 unload 两个实例。
- 包构建、E2E fixtures 构建及文档构建通过；Chromium 的 esm-sandbox 与 standalone-sandbox 共 11 项通过。
- Firefox 同组 11 项仍为已知预期失败；本 PR 只解决模块缓存，兼容执行基座的设计评估另行处理。
- 基线和候选的完整 benchmark:smoke 均通过（各 3 trials × 100 samples/cell，A/A 门禁启用）。候选沙箱相对无隔离开销 +0.21%，95% CI −1.99% 至 +5.64%。
- 干净基线与候选的 RFC 配对回归门禁全部通过（100 对样本，回归预算 +5%、95% CI 宽度小于 10pp）：membrane get −1.14%，set +0.83%，ESM rewrite 0.00%，加载链 −0.47%（95% CI −1.72% 至 +0.45%）。这些冷加载指标用于验证回归，模块缓存收益以请求数对照为准。

512 是条目数上限而非字节上限；更大的工作集仍可能淘汰。本次未加入模块图 prefetch。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
