### PR TITLE
chore: remove obsolete v2 sandbox fallbacks

### DIFF
--- a/docs/internals/js-sandbox.md
+++ b/docs/internals/js-sandbox.md
@@ -122,7 +122,7 @@ The sandbox follows single-spa's mount / unmount:
 - On **unmount**, each patcher's `free()` runs first (collecting the rebuilds for next time), then `sandbox.inactive()` **locks** the membrane. While locked, global writes from the app are ignored (with a warning in dev).
 
 ::: info No snapshot diffing
-Some sandbox approaches snapshot every property on `window` at mount and diff it back at unmount. qiankun v3 does **not** do this. Isolation comes from never touching the real `window` in the first place, so there's nothing to diff back. A `SnapshotSandbox` type does exist in the enum, but it has no implementation — `createSandbox` always constructs a `StandardSandbox`, in both the `Proxy`-present and `Proxy`-absent branches. In practice the v3 sandbox **requires** `Proxy`; there's no fallback path.
+Some sandbox approaches snapshot every property on `window` at mount and restore it on unmount by comparing differences. qiankun v3 stores global writes in an app-local object from the start, so there is no need to restore the real `window`. `createSandbox` always constructs a `StandardSandbox` and provides no legacy fallback. See [Browser support](/guide/browser-support) for runtime requirements.
 :::
 
 ## Boundaries and escape hatches

--- a/docs/zh-CN/internals/js-sandbox.md
+++ b/docs/zh-CN/internals/js-sandbox.md
@@ -122,7 +122,7 @@ const globalVariableWhiteList = ['System', '__cjsWrapper', /* + dev-only */];
 - **卸载时**，先调用各补丁模块的 `free()` 并保存下次挂载所需的重建函数，再由 `sandbox.inactive()` 锁定隔离膜。锁定期间，应用发起的全局写入会被忽略，开发环境中还会输出警告。
 
 ::: info v3 不使用快照差异比较
-部分沙箱会在挂载时记录 `window` 属性快照，并在卸载时通过差异比较恢复。qiankun v3 不采用此方式：全局写入从一开始就保存在应用本地对象中，因此无需恢复真实 `window`。代码中虽然存在 `SnapshotSandbox` 枚举值，但并未提供对应实现；`createSandbox` 始终创建 `StandardSandbox`。qiankun v3 要求浏览器支持 `Proxy`，不提供旧版降级实现。
+部分沙箱会在挂载时记录 `window` 属性快照，并在卸载时通过差异比较恢复。qiankun v3 不采用此方式：全局写入从一开始就保存在应用本地对象中，因此无需恢复真实 `window`。`createSandbox` 始终创建 `StandardSandbox`，不提供旧版降级实现。运行环境要求见[浏览器支持](/zh-CN/guide/browser-support)。
 :::
 
 ## 隔离边界

--- a/packages/qiankun/src/apis/registerMicroApps.ts
+++ b/packages/qiankun/src/apis/registerMicroApps.ts
@@ -46,15 +46,6 @@ export function registerMicroApps<T extends ObjectType>(apps: Array<RegistrableA
 
 export function start(opts: StartOpts = {}) {
   if (!started) {
-    // frameworkConfiguration = { prefetch: true, singular: true, sandbox: true, ...opts };
-    // const { prefetch, urlRerouteOnly = defaultUrlRerouteOnly, ...importEntryOpts } = frameworkConfiguration;
-
-    // if (prefetch) {
-    //   doPrefetchStrategy(microApps, prefetch, importEntryOpts);
-    // }
-
-    // frameworkConfiguration = autoDowngradeForLowVersionBrowser(frameworkConfiguration);
-
     startSingleSpa(opts);
     started = true;
 

--- a/packages/sandbox/AGENTS.md
+++ b/packages/sandbox/AGENTS.md
@@ -29,7 +29,7 @@ sandbox/
 | Proxy logic | `core/membrane/index.ts` | Write → local target; Read → local → configured globals → host window |
 | Compartment facade | `core/compartment/index.ts` | Owns the membrane, module facade, and CSP-safe blob classic evaluation |
 | Plugin protocol | `patchers/types.ts` | Public `IsolationPlugin`, context, `Free`, and `Rebuild` contracts |
-| Built-in plugins | `patchers/index.ts` | Data-driven Standard/Snapshot presets; user plugins append after these |
+| Built-in plugins | `patchers/index.ts` | Standard preset; user plugins append after these |
 | DOM interception | `patchers/dynamicAppend/forStandardSandbox.ts` | Redirects dynamic script/style/link to app container |
 | Side-effect cleanup | `patchers/*.ts` | Each patcher returns a `free()` called on unmount |
 | ESM globals contract | `core/esm-globals.ts` | Consumed by `shared/esm-sandbox` engine, passed as `globalsBaseSet` |

--- a/packages/sandbox/src/core/sandbox/index.ts
+++ b/packages/sandbox/src/core/sandbox/index.ts
@@ -195,14 +195,7 @@ export function createSandbox(appName: string, opts: CreateSandboxOptions = {}):
     },
   };
 
-  let sandbox: Sandbox;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (window.Proxy) {
-    sandbox = new StandardSandbox(appName, globals, incubatorContext, standardSandboxOptions);
-  } else {
-    // TODO snapshot sandbox
-    sandbox = new StandardSandbox(appName, globals, incubatorContext, standardSandboxOptions);
-  }
+  const sandbox = new StandardSandbox(appName, globals, incubatorContext, standardSandboxOptions);
 
   const classicScriptTransformer = (source: string, sourceURL?: string) =>
     sandbox.transformClassicScript(source, sourceURL);

--- a/packages/sandbox/src/core/sandbox/types.ts
+++ b/packages/sandbox/src/core/sandbox/types.ts
@@ -7,7 +7,6 @@ import type { Compartment } from '../compartment';
 
 export enum SandboxType {
   Standard = 'Standard',
-  Snapshot = 'Snapshot',
 }
 
 export interface Sandbox extends Compartment {

--- a/packages/sandbox/src/patchers/dynamicAppend/forStandardSandbox.ts
+++ b/packages/sandbox/src/patchers/dynamicAppend/forStandardSandbox.ts
@@ -380,32 +380,6 @@ function patchDOMPrototypeFns(): Unpatch {
 
   state.refCount += 1;
 
-  // TODO https://github.com/umijs/qiankun/pull/2415 Not support yet as getCurrentRunningApp api is not reliable
-  // patch parentNode getter to avoid document === html.parentNode
-  // https://github.com/umijs/qiankun/issues/2408#issuecomment-1446229105
-  // const parentNodeDescriptor = Object.getOwnPropertyDescriptor(Node.prototype, 'parentNode');
-  // if (parentNodeDescriptor) {
-  //   const { get: parentNodeGetter, configurable } = parentNodeDescriptor;
-  //   if (parentNodeGetter && configurable) {
-  //     const patchedParentNodeDescriptor = {
-  //       ...parentNodeDescriptor,
-  //       get(this: Node) {
-  //         const parentNode = parentNodeGetter.call(this) as HTMLElement;
-  //         if (parentNode instanceof Document) {
-  //           const proxy = getCurrentRunningApp()?.window;
-  //           if (proxy) {
-  //             return proxy.document;
-  //           }
-  //         }
-  //
-  //         return parentNode;
-  //       },
-  //     };
-  //     Object.defineProperty(Node.prototype, 'parentNode', patchedParentNodeDescriptor);
-  //
-  //   }
-  // }
-
   let released = false;
   return () => {
     if (released) return;
@@ -423,10 +397,6 @@ function patchDOMPrototypeFns(): Unpatch {
     if (sharedState.domPrototypePatch === state) {
       delete sharedState.domPrototypePatch;
     }
-
-    // if (parentNodeDescriptor) {
-    //   Object.defineProperty(Node.prototype, 'parentNode', parentNodeDescriptor);
-    // }
   };
 }
 

--- a/packages/sandbox/src/patchers/index.ts
+++ b/packages/sandbox/src/patchers/index.ts
@@ -52,11 +52,9 @@ const baseIsolationPlugins = [intervalPlugin, windowListenerPlugin, historyListe
 
 /**
  * Built-in presets retain the historical patch order. User plugins are appended by the container.
- * Snapshot remains a fallback preset and deliberately omits the standard DOM interception plugin.
  */
 export const defaultIsolationPlugins = {
   [SandboxType.Standard]: [...baseIsolationPlugins, dynamicAppendPlugin],
-  [SandboxType.Snapshot]: baseIsolationPlugins,
 } satisfies Record<SandboxType, readonly IsolationPlugin[]>;
 
 export function getDefaultIsolationPlugins(


### PR DESCRIPTION
清理 v2 遗留的未启用逻辑，使代码和当前 v3 沙箱实现一致：移除 start() 中废弃的 prefetch/singular/浏览器降级注释、createSandbox 的 Proxy 假分支、Snapshot 枚举和空预设，以及依赖已退役 getCurrentRunningApp 的 parentNode 补丁草案。同步中英文沙箱文档及包内说明。

已核对 #3066 对应提交 0d58a12f：v3 隔离膜的白名单读写路径均使用 typeof p === 'string'，没有 v2 的同类匹配缺陷，因此没有新增修复逻辑。删除 #2415 的死注释不代表实现了其原本针对的 parentNode/document 身份兼容行为。

验证：pnpm run eslint、pnpm run prettier:check、qiankun 单测 33 项、sandbox 单测 72 项、pnpm run build:packages、e2e fixtures 构建、Chromium router-mode/sandbox-js/nested-sandbox 共 16 项、pnpm run docs:build 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
