### PR TITLE
feat: export the shared QiankunError from qiankun

### DIFF
--- a/packages/qiankun/src/__tests__/error.test.ts
+++ b/packages/qiankun/src/__tests__/error.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { QiankunError } from 'qiankun';
+import { createSandbox } from '@qiankunjs/sandbox';
+import { QiankunError as SharedQiankunError } from '@qiankunjs/shared';
+
+describe('public QiankunError export', () => {
+  it('exports the constructor shared by the runtime packages', () => {
+    const error = new QiankunError('micro-app failed');
+
+    expect(QiankunError).toBe(SharedQiankunError);
+    expect(error).toBeInstanceOf(QiankunError);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe('[qiankun]: micro-app failed');
+  });
+
+  it('identifies errors raised by the sandbox through the top-level export', () => {
+    expect(() => createSandbox('missing-container', { styleIsolation: true })).toThrow(QiankunError);
+  });
+});

--- a/packages/qiankun/src/core/__tests__/loadApp.test.ts
+++ b/packages/qiankun/src/core/__tests__/loadApp.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment happy-dom
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { QiankunError } from 'qiankun';
 import type { LoaderOpts } from '@qiankunjs/loader';
 import { isNativePassthroughNode, nativeGlobal } from '@qiankunjs/sandbox';
 import { createSandbox as createRealSandbox } from '../../../../sandbox/src/core/sandbox';
@@ -120,7 +121,9 @@ describe('loadApp sandbox cleanup', () => {
   it('aborts its sandbox when entry exports fail lifecycle validation', async () => {
     mocks.loadEntry.mockResolvedValue({});
 
-    await expect(loadApp(createApp())).rejects.toThrowError('You need to export lifecycle functions');
+    const loading = loadApp(createApp());
+    await expect(loading).rejects.toBeInstanceOf(QiankunError);
+    await expect(loading).rejects.toThrowError('You need to export lifecycle functions');
     expect(mocks.dispose).toHaveBeenCalledOnce();
   });
 

--- a/packages/qiankun/src/error.ts
+++ b/packages/qiankun/src/error.ts
@@ -1,5 +1,1 @@
-export class QiankunError extends Error {
-  constructor(message: string) {
-    super(`[qiankun]: ${message}`);
-  }
-}
+export { QiankunError } from '@qiankunjs/shared';

--- a/packages/qiankun/src/index.ts
+++ b/packages/qiankun/src/index.ts
@@ -4,6 +4,7 @@ export * from './apis/isRuntimeCompatible';
 export * from './apis/prefetch';
 export * from './apis/effects';
 export * from './apis/errorHandler';
+export { QiankunError } from './error';
 export type * from './types';
 export { moduleSourceInstanceKeyPlaceholder, precompileModuleSource } from '@qiankunjs/sandbox';
 export { navigateToUrl } from '@qiankunjs/single-spa';


### PR DESCRIPTION
从 qiankun 顶层导出 QiankunError，并将 qiankun 内部的重复类改为再导出 shared 中的同一构造函数。调用方可以通过 import { QiankunError } from 'qiankun' 和 instanceof 识别框架错误，覆盖 qiankun 与底层沙箱，而无需依赖 ESM/CJS 产物的内部路径。关联 #2842。

新增顶层导入与跨包构造函数身份测试，并在实际生命周期校验失败路径断言 instanceof；保留既有错误文案检查。

验证：pnpm run eslint、pnpm run prettier:check、qiankun 单测 35 项、sandbox 单测 72 项、pnpm run build:packages、e2e fixtures 构建、Chromium error-handling 共 4 项全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
