### PR TITLE
refactor: narrow the public qiankun API surface

### DIFF
--- a/docs/rfcs/insertion-point-ownership.md
+++ b/docs/rfcs/insertion-point-ownership.md
@@ -191,7 +191,7 @@ const config = elementConfigs.get(ownerNode) ?? resolveConfigByPosition(ownerNod
 
 容器占用闸门(见 `container-occupancy-gate.md`)把共享容器的 DOM 写入全序化之后,本 RFC 拆出的两个标记按最小感知原则进一步收敛,盖章点与形态均有变化:
 
-- **效果位 `nativePassthroughNode`**:从 `@qiankunjs/shared` 移入 sandbox 包内部(`core/nativePassthrough.ts`,不再对外导出)。盖章点从 loadEntry 闭包移至 sandbox 自己的 pipeline transformer(`controller.nodeTransformer`,与 dynamicAppend 所用裸变体构成双闭包,以调用点身份区分,无调用方传参)。loader 对该标记零感知。仍为 `Symbol.for` 注册符号:unmount 链中途失败(SKIP_BECAUSE_BROKEN)会留下残留实例 patch,跨副本互认在该角落仍然必要。
+- **效果位 `nativePassthroughNode`**:从 `@qiankunjs/shared` 移入 sandbox 包内部(`core/nativePassthrough.ts`,相关辅助函数以 `@internal` 导出供 qiankun 包使用,不属于公开契约)。盖章点从 loadEntry 闭包移至 sandbox 自己的 pipeline transformer(`controller.nodeTransformer`,与 dynamicAppend 所用裸变体构成双闭包,以调用点身份区分,无调用方传参)。loader 对该标记零感知。仍为 `Symbol.for` 注册符号:unmount 链中途失败(SKIP_BECAUSE_BROKEN)会留下残留实例 patch,跨副本互认在该角落仍然必要。
 - **出处位 `loaderStreamedNode`**:**整体退役**。其唯一消费点(mount 时的 head 供给裁决)改由编排层显式声明——`createSandbox` 新增 `provisionContainerHead` 选项(默认 `true`,standalone 自建;qiankun 的 loadApp 传 `false`,head 由 entry HTML 经流式管线生成)。「容器是否由 loader 喂养」本就是编排者的静态知识,不必刻在 DOM 上再全树扫描回来。
 
 本 RFC 正文中关于「出处位保留、由 loadEntry 闭包盖两个章」的表述以本后记为准。

--- a/packages/qiankun/src/index.ts
+++ b/packages/qiankun/src/index.ts
@@ -6,5 +6,5 @@ export * from './apis/effects';
 export * from './apis/errorHandler';
 export { QiankunError, type QiankunErrorCode } from './error';
 export type * from './types';
-export { moduleSourceInstanceKeyPlaceholder, precompileModuleSource } from '@qiankunjs/sandbox';
+export { precompileModuleSource } from '@qiankunjs/sandbox';
 export { navigateToUrl } from '@qiankunjs/single-spa';

--- a/packages/sandbox/src/core/nativePassthrough.ts
+++ b/packages/sandbox/src/core/nativePassthrough.ts
@@ -16,10 +16,12 @@
  */
 export const nativePassthroughNode = Symbol.for('qiankun.nativePassthroughNode');
 
+/** @internal */
 export function markNodeForNativePassthrough(node: Node): void {
   (node as unknown as Record<symbol, unknown>)[nativePassthroughNode] = true;
 }
 
+/** @internal */
 export function isNativePassthroughNode(node: Node): boolean {
   return !!(node as unknown as Record<symbol, unknown>)[nativePassthroughNode];
 }

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,6 +1,7 @@
 export * from './core/sandbox';
 export * from './core/compartment';
 export * from './consts';
+// For qiankun's internal use only; not part of the public API contract.
 export { isNativePassthroughNode, markNodeForNativePassthrough } from './core/nativePassthrough';
 export { esmDestructurableGlobals } from './core/esm-globals';
 export { moduleSourceInstanceKeyPlaceholder, precompileModuleSource } from '@qiankunjs/shared';


### PR DESCRIPTION
收敛包入口的公开 API：从 qiankun 顶层移除 moduleSourceInstanceKeyPlaceholder 再导出，保留 precompileModuleSource；sandbox 的内部导出链保持可用。

isNativePassthroughNode 和 markNodeForNativePassthrough 仍供 qiankun 跨包调用，在函数 JSDoc 标记 @internal，并在 sandbox 入口及 insertion-point-ownership RFC 后记明确其不属于公开契约。未开启 stripInternal，两个函数仍出现在运行时及声明产物中。已核对 docs 没有将 placeholder 作为公开 API 介绍，双语插件指南仅导入 precompileModuleSource。

验证：pnpm run eslint、pnpm run prettier:check、qiankun 单测 36 项、sandbox 单测 72 项、pnpm run build:packages、e2e fixtures 构建、Chromium nested-sandbox/standalone-sandbox、pnpm run docs:build 通过；核对生成声明中的 @internal 以及 qiankun/sandbox 的导出边界。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
